### PR TITLE
Add missing Toggle Button sample

### DIFF
--- a/app/ids-toggle-button/example.html
+++ b/app/ids-toggle-button/example.html
@@ -1,0 +1,11 @@
+<ids-layout-grid>
+  <ids-label font-size="12" type="h1">Toggle Buttons</ids-label>
+</ids-layout-grid>
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-toggle-button id="test-toggle-button" icon-on="star-filled" icon-off="star-outlined" text-off="Toggle Button (Off)" text-on="Toggle Button (On)">
+      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <span slot="text"></span>
+    </ids-toggle-button>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,10 +143,10 @@ module.exports = {
       title: 'IDS Button Component (disabled state)'
     }),
     new HTMLWebpackPlugin({
-      template: './app/ids-button/index.html',
+      template: './app/ids-toggle-button/index.html',
       inject: 'body',
       filename: 'ids-toggle-button/index.html',
-      chunks: ['ids-button/ids-button', 'ids-toggle-button/ids-toggle-button'],
+      chunks: ['ids-toggle-button/ids-toggle-button'],
       title: 'IDS Toggle Button Component'
     }),
     new HTMLWebpackPlugin({


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Not sure how but my Toggle Button sample was missing and incorrectly tagged with Webpack.  This PR just adds it back in and makes the page accessible by itself.

**Related github/jira issue (required)**:
related to #12
Related to infor-design/enterprise#4390

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4300 - underneath the icon buttons there should be a working Toggle button
- Open http://localhost:4300/ids-toggle-button - same example and the toggle button should work

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
