### PR TITLE
4458 - Add dirty tracker, validation and update input, labels

### DIFF
--- a/app/ids-input/example.html
+++ b/app/ids-input/example.html
@@ -1,0 +1,46 @@
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-label font-size="12" type="h2">Ids Input</ids-label>
+
+    <ids-input type="text" label="First Name" name="first-name" placeholder="Normal text Field"></ids-input>
+
+    <ids-input type="text" label="Last Name" name="last-name" validate="required"></ids-input>
+
+    <ids-input type="text" label="Email Address" name="email-address" placeholder="Company@address.com" validate="email required"></ids-input>
+
+    <ids-input type="text" label="Disabled" disabled="true" value="Field not editable" name="department"></ids-input>
+
+    <ids-input type="text" label="Readonly" readonly="true" value="02006" name="department-code"></ids-input>
+
+    <ids-input type="text" label="Dirty Tracking" dirty-tracker="true" placeholder="Dirty Tracking" name="department-code-dirty-tracker"></ids-input>
+
+  </ids-layout-grid-cell>
+
+  <!-- Sizes -->
+  <ids-layout-grid-cell>
+    <ids-label font-size="12" type="h2">Ids Input - Sizes</ids-label>
+
+    <!-- sizes: [xs, sm, mm, md, lg, full] -->
+    <ids-input size="xs" label="Xtra Small"></ids-input>
+    <ids-input size="sm" label="Small"></ids-input>
+    <ids-input size="mm" label="Small - Medium"></ids-input>
+    <ids-input size="md" label="Medium"></ids-input>
+
+  </ids-layout-grid-cell>
+
+  <!-- Enable, Disable, Readonly -->
+  <ids-layout-grid-cell>
+    <ids-label font-size="12" type="h2">Input - Enable/ Disable/ Readonly</ids-label>
+    <ids-input id="input-toggle-state" label="Text Field" value="Some text"></ids-input>
+
+    <ids-button id="btn-input-enable" type="secondary">
+      <span slot="text">Enable</span>
+    </ids-button>
+    <ids-button id="btn-input-disable" type="secondary">
+      <span slot="text">Disable</span>
+    </ids-button>
+    <ids-button id="btn-input-readonly" type="secondary">
+      <span slot="text">Readonly</span>
+    </ids-button>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/app/ids-input/index.html
+++ b/app/ids-input/index.html
@@ -1,0 +1,3 @@
+{{> ../layouts/head.html }}
+{{> example.html }}
+{{> ../layouts/footer.html }}

--- a/app/ids-input/index.js
+++ b/app/ids-input/index.js
@@ -1,1 +1,31 @@
 import IdsInput from '../../src/ids-input/ids-input';
+
+// Supporting components
+import IdsButton from '../../src/ids-button/ids-button';
+import IdsIcon from '../../src/ids-icon/ids-icon';
+import IdsLabel from '../../src/ids-label/ids-label';
+import IdsLayoutGrid from '../../src/ids-layout-grid/ids-layout-grid';
+import IdsValidationMessage from '../../src/ids-validation-message/ids-validation-message';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btnEnable = document.querySelector('#btn-input-enable');
+  const btnDisable = document.querySelector('#btn-input-disable');
+  const btnReadonly = document.querySelector('#btn-input-readonly');
+  const input = document.querySelector('#input-toggle-state') || {};
+
+  // Enable
+  btnEnable?.addEventListener('click', () => {
+    input.disabled = false;
+    input.readonly = false;
+  });
+
+  // Disable
+  btnDisable?.addEventListener('click', () => {
+    input.disabled = true;
+  });
+
+  // Readonly
+  btnReadonly?.addEventListener('click', () => {
+    input.readonly = true;
+  });
+});

--- a/app/ids-trigger-field/example.html
+++ b/app/ids-trigger-field/example.html
@@ -5,7 +5,7 @@
 <ids-layout-grid auto="true" gap="md">
   <ids-layout-grid-cell>
     <ids-trigger-field tabbable="false">
-      <ids-input placeholder="Enter Date"></ids-input>
+      <ids-input placeholder="Enter Date" size="full"></ids-input>
       <ids-trigger-button>
         <ids-icon slot="icon" icon="schedule"><ids-icon>
       </ids-trigger-button>
@@ -14,7 +14,7 @@
 
   <ids-layout-grid-cell>
     <ids-trigger-field>
-      <ids-input type="text"></ids-input>
+      <ids-input type="text" size="full"></ids-input>
       <ids-trigger-button>
         <ids-icon slot="icon" icon="clock"><ids-icon>
       </ids-trigger-button>
@@ -23,7 +23,7 @@
 
   <ids-layout-grid-cell>
     <ids-trigger-field disable-native-events="true">
-      <ids-input type="text" placeholder="Enter Date"></ids-input>
+      <ids-input type="text" placeholder="Enter Date" size="full"></ids-input>
       <ids-trigger-button>
         <ids-icon slot="icon" icon="schedule"><ids-icon>
       </ids-trigger-button>

--- a/app/ids-validation-message/example.html
+++ b/app/ids-validation-message/example.html
@@ -1,0 +1,25 @@
+<ids-layout-grid>
+  <ids-label font-size="12" type="h2">Ids Validation Message</ids-label>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true" gap="md">
+  <ids-layout-grid-cell>
+
+    <ids-validation-message type="error">
+      <span class="audible">Error </span>Something is wrong do not continue
+    </ids-validation-message>
+
+    <ids-validation-message type="alert">
+      <span class="audible">Alert </span>Warning the value may be incorrect
+    </ids-validation-message>
+
+    <ids-validation-message type="success">
+      <span class="audible">Success </span>This value is correct
+    </ids-validation-message>
+
+    <ids-validation-message type="info">
+      <span class="audible">Info </span>Random information about this field
+    </ids-validation-message>
+
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/app/ids-validation-message/index.html
+++ b/app/ids-validation-message/index.html
@@ -1,0 +1,3 @@
+{{> ../layouts/head.html }}
+{{> example.html }}
+{{> ../layouts/footer.html }}

--- a/app/ids-validation-message/index.js
+++ b/app/ids-validation-message/index.js
@@ -1,0 +1,6 @@
+import IdsValidationMessage from '../../src/ids-validation-message/ids-validation-message';
+
+// Supporting components
+import IdsIcon from '../../src/ids-icon/ids-icon';
+import IdsLabel from '../../src/ids-label/ids-label';
+import IdsLayoutGrid from '../../src/ids-layout-grid/ids-layout-grid';

--- a/app/index.html
+++ b/app/index.html
@@ -1,4 +1,6 @@
 {{> layouts/head.html title=htmlWebpackPlugin.options.title }}
+{{> ids-input/example.html }}
+{{> ids-validation-message/example.html }}
 {{> ids-button/example.html }}
 {{> ids-toggle-button/example.html }}
 {{> ids-tag/example.html }}

--- a/app/index.js
+++ b/app/index.js
@@ -10,9 +10,11 @@ import IdsLayoutGridCell from '../src/ids-layout-grid/ids-layout-grid-cell';
 import IdsInput from '../src/ids-input/ids-input';
 import IdsTriggerField from '../src/ids-trigger-field/ids-trigger-field';
 import IdsTriggerButton from '../src/ids-trigger-button/ids-trigger-button';
+import IdsValidationMessage from '../src/ids-validation-message/ids-validation-message';
 
 // Import Example Code
 import './ids-button/index.js'; // eslint-disable-line
 import './ids-icon/index.js'; //eslint-disable-line
+import './ids-input/index.js'; //eslint-disable-line
 import './ids-popup/index.js'; //eslint-disable-line
 import './ids-trigger-field/index.js'; //eslint-disable-line

--- a/src/ids-base/ids-constants.js
+++ b/src/ids-base/ids-constants.js
@@ -23,7 +23,18 @@ export const props = {
   CSS_CLASS: 'css-class',
   DISABLED: 'disabled',
   FOCUSABLE: 'focusable',
-  TEXT: 'text'
+  TEXT: 'text',
+  SIZE: 'size',
+  FONT_SIZE: 'font-size',
+  REQUIRED: 'required',
+  AUDIBLE: 'audible',
+  VALIDATE: 'validate',
+  VALUE: 'value',
+  LABEL: 'label',
+  LABEL_FONT_SIZE: 'label-font-size',
+  DIRTY_TRACKER: 'dirty-tracker',
+  READONLY: 'readonly',
+  NAME: 'name'
 };
 
 export const prefix = {

--- a/src/ids-base/ids-dirty-tracker-mixin.js
+++ b/src/ids-base/ids-dirty-tracker-mixin.js
@@ -1,0 +1,122 @@
+/**
+ * Track changes on inputs elements and show a dirty indicator.
+ */
+const IdsDirtyTrackerMixin = {
+  /**
+   * Handle dirty tracker values
+   * @returns {void}
+   */
+  handleDirtyTracker() {
+    if (this.dirtyTracker) {
+      if (this.input) {
+        const val = this.input.value;
+        this.dirty = { original: val !== null ? val : '' };
+        this.dirtyTrackerEvents();
+      }
+    }
+  },
+
+  /**
+   * Check if dirty tracker icon exists if not add it
+   * @private
+   * @returns {void}
+   */
+  appendDirtyTrackerIcon() {
+    let icon = this.shadowRoot.querySelector('.icon-dirty');
+    if (!icon) {
+      icon = document.createElement('ids-icon');
+      icon.setAttribute('icon', 'dirty');
+      icon.setAttribute('size', 'small');
+      icon.className = 'icon-dirty';
+      this.input?.parentNode?.insertBefore(icon, this.input);
+    }
+  },
+
+  /**
+   * Remove if dirty tracker icon exists
+   * @private
+   * @returns {void}
+   */
+  removeDirtyTrackerIcon() {
+    const icon = this.shadowRoot.querySelector('.icon-dirty');
+    if (icon) {
+      icon.remove();
+    }
+  },
+
+  /**
+   * Check if dirty tracker msg exists if not add it
+   * @private
+   * @returns {void}
+   */
+  appendDirtyTrackerMsg() {
+    let msg = this.label?.querySelector('.msg-dirty');
+    if (!msg) {
+      msg = document.createElement('ids-label');
+      msg.setAttribute('audible', true);
+      msg.className = 'msg-dirty';
+      msg.innerHTML = ', Modified';
+      this.label?.appendChild(msg);
+    }
+  },
+
+  /**
+   * Remove if dirty tracker msg exists
+   * @private
+   * @returns {void}
+   */
+  removeDirtyTrackerMsg() {
+    const msg = this.label?.querySelector('.msg-dirty');
+    if (msg) {
+      msg.remove();
+    }
+  },
+
+  /**
+   * Set dirtyTracker
+   * @private
+   * @param {string} val The current element value
+   * @returns {void}
+   */
+  setDirtyTracker(val) {
+    if (typeof val === 'undefined') {
+      this.handleDirtyTracker();
+      return;
+    }
+
+    this.isDirty = this.dirty?.original !== val;
+    if (this.isDirty) {
+      this.appendDirtyTrackerIcon();
+      this.appendDirtyTrackerMsg();
+    } else {
+      this.removeDirtyTrackerIcon();
+      this.removeDirtyTrackerMsg();
+    }
+  },
+
+  /**
+   * Handle dirty tracker events
+   * @private
+   * @param {string} option If 'remove', will remove attached events
+   * @returns {void}
+   */
+  dirtyTrackerEvents(option) {
+    const action = option === 'remove' ? 'removeEventListener' : 'addEventListener';
+    if (this.input) {
+      this.eventHandlers[action]('change', this.input, () => {
+        this.setDirtyTracker(this.input.value);
+      });
+    }
+  },
+
+  /**
+   * Destroy dirty tracker
+   * @returns {void}
+   */
+  destroyDirtyTracker() {
+    this.dirtyTrackerEvents('remove');
+    this.removeDirtyTrackerIcon();
+  }
+};
+
+export { IdsDirtyTrackerMixin };

--- a/src/ids-base/ids-dirty-tracker-mixin.scss
+++ b/src/ids-base/ids-dirty-tracker-mixin.scss
@@ -1,0 +1,7 @@
+@import './ids-base';
+
+.icon-dirty {
+  @include absolute();
+  @include m-4();
+  @include text-alert-caution();
+}

--- a/src/ids-base/ids-validation-mixin.js
+++ b/src/ids-base/ids-validation-mixin.js
@@ -1,0 +1,172 @@
+/**
+ * The validation rules.
+ */
+const IdsValidationMixin = {
+  useRules: new Map(),
+
+  /**
+   * Handle the validation rules
+   * @returns {void}
+   */
+  handleValidation() {
+    if (this.label && this.input && typeof this.validate === 'string') {
+      const getRule = (id) => ({ id, rule: this.rules[id] });
+      let isRulesAdded = false;
+      this.validate.split(' ').forEach((strRule) => {
+        if (strRule === 'required') {
+          this.label.classList.add('required');
+          this.input.setAttribute('aria-required', true);
+        }
+        const useRules = this.useRules.get(this.input);
+        if (useRules) {
+          let found = false;
+          useRules.forEach((rule) => {
+            if (rule.id === strRule) {
+              found = true;
+            }
+          });
+          if (!found) {
+            const mergeRule = [...useRules, getRule(strRule)];
+            this.useRules.set(this.input, mergeRule);
+            isRulesAdded = true;
+          }
+        } else {
+          this.useRules.set(this.input, [getRule(strRule)]);
+          isRulesAdded = true;
+        }
+      });
+      if (isRulesAdded) {
+        this.validationEvents();
+      }
+    } else {
+      this.destroyValidation();
+    }
+  },
+
+  /**
+   * Check the validation and set to add/remove errors
+   * @private
+   * @returns {void}
+   */
+  checkValidation() {
+    if (this.input) {
+      const useRules = this.useRules.get(this.input);
+      useRules?.forEach((thisRule) => {
+        if (!thisRule.rule.check(this.input)) {
+          this.addError(thisRule.rule);
+        } else {
+          this.removeError(thisRule.rule);
+        }
+      });
+    }
+  },
+
+  /**
+   * Add the error for given rule
+   * @private
+   * @param {object} rule The rule to add error
+   * @returns {void}
+   */
+  addError(rule) {
+    const { id, type, message } = rule;
+    let errorEl = this.shadowRoot.querySelector(`[validation-id="${id}"]`);
+
+    if (!errorEl) {
+      const audible = type.replace(/^./, type[0].toUpperCase());
+      errorEl = document.createElement('ids-validation-message');
+      errorEl.setAttribute('type', type);
+      errorEl.setAttribute('validation-id', id);
+      errorEl.innerHTML = `<span class="audible">${audible} </span>${message}`;
+      this.shadowRoot.appendChild(errorEl);
+    }
+  },
+
+  /**
+   * Remove the error for given rule
+   * @private
+   * @param {object} rule The rule to add error
+   * @returns {void}
+   */
+  removeError(rule) {
+    const { id } = rule;
+    const errorElem = this.shadowRoot.querySelector(`[validation-id="${id}"]`);
+    const errorLen = [].slice.call(this.querySelectorAll(`ids-validation-message`)).length;
+
+    errorElem?.remove();
+    if (!errorLen) {
+      this.input?.removeAttribute('validation-status');
+    }
+  },
+
+  /**
+   * Handle validation events
+   * @private
+   * @param {string} option If 'remove', will remove attached events
+   * @returns {void}
+   */
+  validationEvents(option) {
+    const action = option === 'remove' ? 'removeEventListener' : 'addEventListener';
+    if (this.input) {
+      this.eventHandlers[action]('blur', this.input, () => {
+        this.checkValidation();
+      });
+    }
+  },
+
+  /**
+   * Destroy validation
+   * @returns {void}
+   */
+  destroyValidation() {
+    if (this.input) {
+      const useRules = this.useRules.get(this.input);
+      if (useRules) {
+        useRules.forEach((thisRule) => {
+          if (thisRule.id === 'required') {
+            const label = this.querySelector('ids-label');
+            label?.removeAttribute('required');
+          }
+        });
+        this.validationEvents('remove');
+        this.useRules.delete(this.input);
+      }
+    }
+  },
+
+  /**
+   * Set all validation rules
+   * @private
+   */
+  rules: {
+    /**
+     * Required validation rule
+     * @private
+     */
+    required: {
+      check: (input) => {
+        const val = input.value;
+        return !((val === null) || (typeof val === 'string' && val === '') || (typeof val === 'number' && isNaN(val))) // eslint-disable-line
+      },
+      message: 'Required',
+      type: 'error',
+      id: 'required'
+    },
+
+    /**
+     * Email validation rule
+     * @private
+     */
+    email: {
+      check: (input) => {
+        const val = input.value;
+        const regex = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,16}(?:\.[a-z]{2})?)$/i;
+        return (val.length) ? regex.test(val) : true;
+      },
+      message: 'Email address not valid',
+      type: 'error',
+      id: 'email'
+    }
+  }
+};
+
+export { IdsValidationMixin };

--- a/src/ids-icon/ids-icon.js
+++ b/src/ids-icon/ids-icon.js
@@ -1,5 +1,6 @@
 import pathData from 'ids-identity/dist/theme-uplift/icons/standard/path-data.json';
 import { IdsElement, scss, customElement } from '../ids-base/ids-element';
+import { props } from '../ids-base/ids-constants';
 import styles from './ids-icon.scss';
 
 // Setting Defaults
@@ -25,7 +26,7 @@ class IdsIcon extends IdsElement {
    * @returns {Array} The properties in an array
    */
   static get properties() {
-    return ['icon', 'size'];
+    return [props.ICON, props.SIZE];
   }
 
   /**
@@ -34,7 +35,7 @@ class IdsIcon extends IdsElement {
    * @returns {string} The template
    */
   template() {
-    const size = sizes[this.size];
+    const size = sizes[this.size] || sizes.normal;
     return `<svg xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="${size}" width="${size}" viewBox="0 0 18 18" focusable="false" aria-hidden="true" role="presentation">
       ${this.iconData()}
     </svg>`;
@@ -52,14 +53,14 @@ class IdsIcon extends IdsElement {
    * Return the icon name
    * @returns {string} the path data
    */
-  get icon() { return this.getAttribute('icon'); }
+  get icon() { return this.getAttribute(props.ICON); }
 
   set icon(value) {
     if (value) {
-      this.setAttribute('icon', value);
+      this.setAttribute(props.ICON, value);
       this.shadowRoot.querySelector('svg').innerHTML = this.iconData();
     } else {
-      this.removeAttribute('icon');
+      this.removeAttribute(props.ICON);
       this.shadowRoot.querySelector('svg')?.remove();
     }
   }
@@ -68,15 +69,16 @@ class IdsIcon extends IdsElement {
    * Return the size. May be large, normal/medium or small
    * @returns {string} the path data
    */
-  get size() { return this.getAttribute('size') || 'normal'; }
+  get size() { return this.getAttribute(props.SIZE) || 'normal'; }
 
   set size(value) {
     if (value) {
-      this.setAttribute('size', value);
-      this.shadowRoot.querySelector('svg').setAttribute('height', sizes[this.size]);
-      this.shadowRoot.querySelector('svg').setAttribute('width', sizes[this.size]);
+      const size = sizes[this.size] || sizes.normal;
+      this.setAttribute(props.SIZE, value);
+      this.shadowRoot.querySelector('svg').setAttribute('height', size);
+      this.shadowRoot.querySelector('svg').setAttribute('width', size);
     } else {
-      this.removeAttribute('size');
+      this.removeAttribute(props.SIZE);
     }
   }
 }

--- a/src/ids-input/TODO.md
+++ b/src/ids-input/TODO.md
@@ -1,0 +1,23 @@
+# TODO - ids-input
+
+## Basic Checks
+- [x] Fix errors in the console
+- [x] Use `ids-input` instead `ids-field`
+- [x] The labels are not working (can't click them to focus the field). Tried adding a for and id and this didn't work. So what we should try to add the label in with input.
+
+```html
+<label for="x" />
+<input id="x" />
+```
+- [x] Can we add more complete input styles from current uplift?
+- [ ] Add tests functional and e2e
+- [ ] Add docs and a typings file(s)
+
+## Dirty Tracker
+
+- [x] Remove property `useTrackdirty`
+- [x] Maybe `ids-dirty-tracker` sounds better than `trackdirty`
+
+## Labels
+
+- [ ] Rename `ids-label` to `ids-text`

--- a/src/ids-input/ids-input.d.ts
+++ b/src/ids-input/ids-input.d.ts
@@ -2,9 +2,18 @@
 // confirm our code is type safe, and to support TypeScript users.
 
 interface nativeElement extends HTMLElement {
+  dirtyTracker: boolean;
+  disabled: boolean;
+  label: string;
+  labelFontSize: 10 | 12 | 14 | 16 | 20 | 24 | 28 | 32 | 40 | 48 | 60 | 72 | 'xs' | 'sm ' | 'lg' | 'xl' | string | number;
+  name: string
+  placeholder: string
+  size: 'xs' | 'sm ' | 'mm' | 'md' | 'lg' | 'full' | string;
+  readonly: boolean;
   type: 'text' | 'password' | 'email' | 'number' | string;
+  validate: 'required' | 'email' | string;
+  value: string | number;
   tabbable: boolean;
-  placeholder: string;
 }
 
 export class IdsInput extends HTMLElement {

--- a/src/ids-input/ids-input.js
+++ b/src/ids-input/ids-input.js
@@ -6,16 +6,32 @@ import {
 } from '../ids-base/ids-element';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsStringUtilsMixin } from '../ids-base/ids-string-utils-mixin';
+import { IdsDirtyTrackerMixin } from '../ids-base/ids-dirty-tracker-mixin';
+import { IdsValidationMixin } from '../ids-base/ids-validation-mixin';
 import { props } from '../ids-base/ids-constants';
 import styles from './ids-input.scss';
 
-// Setting Defaults
-const types = {
+// Input id
+const ID = 'ids-input-id';
+
+// Types
+const TYPES = {
   default: 'text',
   text: 'text',
   password: 'password',
   number: 'number',
   email: 'email'
+};
+
+// Setting defaults sizes
+const SIZES = {
+  default: 'md',
+  xs: 'xs',
+  sm: 'sm',
+  mm: 'mm',
+  md: 'md',
+  lg: 'lg',
+  full: 'full'
 };
 
 /**
@@ -25,6 +41,8 @@ const types = {
 @scss(styles)
 @mixin(IdsEventsMixin)
 @mixin(IdsStringUtilsMixin)
+@mixin(IdsDirtyTrackerMixin)
+@mixin(IdsValidationMixin)
 class IdsInput extends IdsElement {
   /**
    * Call the constructor and then initialize
@@ -38,7 +56,32 @@ class IdsInput extends IdsElement {
    * @returns {Array} The properties in an array
    */
   static get properties() {
-    return [props.TYPE, props.PLACEHOLDER];
+    return [
+      props.DIRTY_TRACKER,
+      props.DISABLED,
+      props.LABEL,
+      props.LABEL_FONT_SIZE,
+      props.NAME,
+      props.PLACEHOLDER,
+      props.SIZE,
+      props.READONLY,
+      props.TYPE,
+      props.VALIDATE,
+      props.VALUE
+    ];
+  }
+
+  /**
+   * Custom Element `connectedCallBack` implementation
+   * @private
+   * @returns {void}
+   */
+  connectedCallBack() {
+    this.input = this.shadowRoot.querySelector(`#${ID}`);
+    this.label = this.shadowRoot.querySelector(`[for="${ID}"]`);
+
+    this.handleDirtyTracker();
+    this.handleValidation();
   }
 
   /**
@@ -46,39 +89,211 @@ class IdsInput extends IdsElement {
    * @returns {string} The template
    */
   template() {
+    // Input
+    const placeholder = this.placeholder ? ` placeholder="${this.placeholder}"` : '';
+    const value = this.value !== null ? ` value="${this.value}"` : '';
+    const fieldName = this.fieldName !== null ? ` name="${this.fieldName}"` : '';
+    const type = ` type="${this.type || TYPES.default}"`;
+    const inputClass = ` class="ids-input-field ${this.size}"`;
+    let inputState = this.stringToBool(this.readonly) ? ' readonly' : '';
+    inputState = this.stringToBool(this.disabled) ? ' disabled' : inputState;
+
+    // Label
+    const labelFontSize = this.labelFontSize ? ` font-size="${this.labelFontSize}"` : '';
+    const labelClass = ` class="ids-input-label${inputState}"`;
+
     return `
-      <input class="ids-input-field" type="${types.default}" ${this.placeholder ? `placeholder="${this.placeholder}"` : ''}/>
+      <label for="${ID}"${labelClass}>
+        <ids-label${labelFontSize}>${this.labelText}</ids-label>
+      </label>
+      <input id="${ID}"${fieldName}${type}${inputClass}${value}${placeholder}${inputState} />
     `;
   }
 
   /**
-   * Set the type of input
-   * @param {boolean} value [text, password, number, email]
+   * Set input state for disabled or readonly
+   * @private
+   * @param {string} prop The property
+   * @returns {void}
    */
-  set type(value) {
-    if (value) {
-      this.setAttribute(props.TYPE, value);
-      return;
+  setInputState(prop) {
+    if (prop === props.READONLY || prop === props.DISABLED) {
+      const options = {
+        prop1: prop,
+        prop2: prop !== props.READONLY ? props.READONLY : props.DISABLED,
+        val: this.stringToBool(this[prop])
+      };
+      if (options.val) {
+        this.input?.removeAttribute(options.prop2);
+        this.label?.classList.remove(options.prop2);
+
+        this.input?.setAttribute(options.prop1, true);
+        this.label?.classList.add(options.prop1);
+      } else {
+        this.input?.removeAttribute(options.prop1);
+        this.label?.classList.remove(options.prop1);
+      }
     }
-    this.setAttribute(props.TYPE, types.default);
   }
 
-  get type() { return this.getAttribute(props.TYPE); }
+  /**
+   * Set `dirty-tracker` attribute
+   * @param {boolean} value If true will set `dirty-tracker` attribute
+   */
+  set dirtyTracker(value) {
+    if (value) {
+      const val = this.stringToBool(value);
+      this.setAttribute(props.DIRTY_TRACKER, val);
+      return;
+    }
+    this.removeAttribute(props.DIRTY_TRACKER);
+  }
+
+  get dirtyTracker() { return this.getAttribute(props.DIRTY_TRACKER); }
 
   /**
-   * Set the placeholder of input
-   * @param {string} value of the placeholder property
+   * Set `disabled` attribute
+   * @param {boolean} value If true will set `disabled` attribute
+   */
+  set disabled(value) {
+    if (value) {
+      const val = this.stringToBool(value);
+      this.setAttribute(props.DISABLED, val);
+    } else {
+      this.removeAttribute(props.DISABLED);
+    }
+    this.setInputState(props.DISABLED);
+  }
+
+  get disabled() { return this.getAttribute(props.DISABLED); }
+
+  /**
+   * Set the field `name` of input
+   * @param {string} value of the field `name` property
+   */
+  set fieldName(value) {
+    if (value) {
+      this.setAttribute(props.NAME, value);
+      return;
+    }
+    this.removeAttribute(props.NAME);
+  }
+
+  get fieldName() { return this.getAttribute(props.NAME); }
+
+  /**
+   * Set the `label-font-size` of input label
+   * @param {string} value of the `label-font-size` property
+   */
+  set labelFontSize(value) {
+    if (value) {
+      this.setAttribute(props.LABEL_FONT_SIZE, value);
+      return;
+    }
+    this.removeAttribute(props.LABEL_FONT_SIZE);
+  }
+
+  get labelFontSize() { return this.getAttribute(props.LABEL_FONT_SIZE); }
+
+  /**
+   * Set the `label` text of input label
+   * @param {string} value of the `label` text property
+   */
+  set labelText(value) {
+    if (value) {
+      this.setAttribute(props.LABEL, value);
+      return;
+    }
+    this.removeAttribute(props.LABEL);
+  }
+
+  get labelText() { return this.getAttribute(props.LABEL) || ''; }
+
+  /**
+   * Set the `placeholder` of input
+   * @param {string} value of the `placeholder` property
    */
   set placeholder(value) {
     if (value) {
       this.setAttribute(props.PLACEHOLDER, value);
       return;
     }
-
     this.removeAttribute(props.PLACEHOLDER);
   }
 
   get placeholder() { return this.getAttribute(props.PLACEHOLDER); }
+
+  /**
+   * Set the `readonly` of input
+   * @param {boolean} value If true will set `readonly` attribute
+   */
+  set readonly(value) {
+    if (value) {
+      const val = this.stringToBool(value);
+      this.setAttribute(props.READONLY, val);
+    } else {
+      this.removeAttribute(props.READONLY);
+    }
+    this.setInputState(props.READONLY);
+  }
+
+  get readonly() { return this.getAttribute(props.READONLY); }
+
+  /**
+   * Set the size of input
+   * @param {string} value [xs, sm, mm, md, lg, full]
+   */
+  set size(value) {
+    if (SIZES[value]) {
+      this.setAttribute(props.SIZE, SIZES[value]);
+      return;
+    }
+    this.setAttribute(props.SIZE, SIZES.default);
+  }
+
+  get size() { return this.getAttribute(props.SIZE) || SIZES.default; }
+
+  /**
+   * Set the type of input
+   * @param {string} value [text, password, number, email]
+   */
+  set type(value) {
+    if (TYPES[value]) {
+      this.setAttribute(props.TYPE, TYPES[value]);
+      return;
+    }
+    this.setAttribute(props.TYPE, TYPES.default);
+  }
+
+  get type() { return this.getAttribute(props.TYPE); }
+
+  /**
+   * Set `validate` attribute
+   * @param {string} value The `validate` attribute
+   */
+  set validate(value) {
+    if (value) {
+      this.setAttribute(props.VALIDATE, value);
+      return;
+    }
+    this.removeAttribute(props.VALIDATE);
+  }
+
+  get validate() { return this.getAttribute(props.VALIDATE); }
+
+  /**
+   * Set the `value` attribute of input
+   * @param {string} val the value property
+   */
+  set value(val) {
+    if (val) {
+      this.setAttribute(props.VALUE, val);
+      return;
+    }
+    this.removeAttribute(props.VALUE);
+  }
+
+  get value() { return this.getAttribute(props.VALUE); }
 }
 
 export default IdsInput;

--- a/src/ids-input/ids-input.scss
+++ b/src/ids-input/ids-input.scss
@@ -1,8 +1,126 @@
 @import '../ids-base/ids-base';
+@import '../ids-base/ids-dirty-tracker-mixin';
+
+// Field Sizes
+$input-size-xs: 75px;
+$input-size-sm: 150px;
+$input-size-mm: 225px;
+$input-size-md: 300px;
+$input-size-lg: 400px;
+$input-size-full: 100%;
+
+// Set default size
+$input-size-default: $input-size-md;
+
+:host {
+  @include block();
+  @include mb-16();
+}
+
+.ids-input-label {
+  @include text-slate-60();
+
+  align-items: baseline;
+  display: flex;
+
+  &.required {
+    margin-top: -4px;
+
+    &::after {
+      @include relative();
+      @include font-sans();
+      @include mx-2();
+      @include text-20();
+      @include text-alert-danger();
+
+      content: '*';
+      top: 1px;
+    }
+
+    &.disabled::after {
+      @include text-ruby-30();
+    }
+  }
+
+  &.disabled {
+    @include text-slate-30();
+  }
+}
 
 .ids-input-field {
+  @include antialiased();
+  @include bg-white();
   @include box-border();
-  @include px-8();
-  @include py-8();
-  @include w-full();
+  @include border-1();
+  @include border-slate-40();
+  @include border-solid();
+  @include mb-4();
+  @include p-8();
+  @include rounded-default();
+  @include text-14();
+  @include text-black();
+
+  -webkit-appearance: none;
+  border-collapse: separate;
+  border-radius: 2px;
+  display: inline-block;
+  height: 38px;
+  max-width: 100%;
+  resize: none;
+  text-align: left;
+  width: $input-size-default;
+
+  &:hover {
+    @include border-slate-90();
+  }
+
+  &:focus {
+    @include border-azure-60();
+    @include shadow();
+
+    outline: none;
+    outline-color: transparent;
+  }
+
+  &[disabled] {
+    @include border-slate-30();
+    @include text-slate-30();
+  }
+
+  &[readonly] {
+    @include bg-slate-20();
+    @include border-1();
+    @include border-solid();
+    @include border-slate-40();
+    @include rounded-default();
+    @include text-black();
+
+    padding-bottom: 9px;
+    padding-top: 9px;
+  }
+
+  // input sizes: [xs, sm, mm, md, lg, full]
+  &.xs {
+    width: $input-size-xs;
+  }
+
+  &.sm {
+    width: $input-size-sm;
+  }
+
+  &.mm {
+    width: $input-size-mm;
+  }
+
+  &.md {
+    width: $input-size-md;
+  }
+
+  &.lg {
+    width: $input-size-lg;
+  }
+
+  &.full {
+    width: $input-size-full;
+  }
 }

--- a/src/ids-label/ids-label.js
+++ b/src/ids-label/ids-label.js
@@ -3,6 +3,7 @@ import {
   customElement,
   scss
 } from '../ids-base/ids-element';
+import { props } from '../ids-base/ids-constants';
 import styles from './ids-label.scss';
 
 /**
@@ -20,7 +21,7 @@ class IdsLabel extends IdsElement {
    * @returns {Array} The properties in an array
    */
   static get properties() {
-    return ['font-size', 'type'];
+    return [props.TYPE, props.FONT_SIZE, props.AUDIBLE];
   }
 
   /**
@@ -29,7 +30,12 @@ class IdsLabel extends IdsElement {
    */
   template() {
     const tag = this.type || 'span';
-    return `<${tag} class="ids-label${this.fontSize ? ` ids-text-${this.fontSize}` : ''}"><slot></slot></${tag}>`;
+    let classList = 'ids-label';
+    classList += this.audible ? ' audible' : '';
+    classList += this.fontSize ? ` ids-text-${this.fontSize}` : '';
+    classList = ` class="${classList}"`;
+
+    return `<${tag}${classList}><slot></slot></${tag}>`;
   }
 
   /**
@@ -49,17 +55,17 @@ class IdsLabel extends IdsElement {
    */
   set fontSize(value) {
     if (value) {
-      this.setAttribute('font-size', value);
+      this.setAttribute(props.FONT_SIZE, value);
       this.container.classList.add(`ids-text-${value}`);
       return;
     }
 
-    this.removeAttribute('font-size');
+    this.removeAttribute(props.FONT_SIZE);
     this.container.className = '';
     this.container.classList.add('ids-label');
   }
 
-  get fontSize() { return this.getAttribute('font-size'); }
+  get fontSize() { return this.getAttribute(props.FONT_SIZE); }
 
   /**
    * Set the type of object it is (h1-h6, label, span (default))
@@ -67,16 +73,32 @@ class IdsLabel extends IdsElement {
    */
   set type(value) {
     if (value) {
-      this.setAttribute('type', value);
+      this.setAttribute(props.TYPE, value);
       this.rerender();
       return;
     }
 
-    this.removeAttribute('type');
+    this.removeAttribute(props.TYPE);
     this.rerender();
   }
 
-  get type() { return this.getAttribute('type'); }
+  get type() { return this.getAttribute(props.TYPE); }
+
+  /**
+   * Set `audible` attribute
+   * @param {string} value The `audible` attribute
+   */
+  set audible(value) {
+    if (value) {
+      this.setAttribute(props.AUDIBLE, value);
+      this.rerender();
+      return;
+    }
+    this.removeAttribute(props.AUDIBLE);
+    this.rerender();
+  }
+
+  get audible() { return this.getAttribute(props.AUDIBLE); }
 }
 
 export default IdsLabel;

--- a/src/ids-label/ids-label.scss
+++ b/src/ids-label/ids-label.scss
@@ -1,11 +1,32 @@
 /* Ids Label Css */
 @import '../ids-base/ids-base';
 
+@mixin audible {
+  @include absolute();
+  @include m-0();
+  @include min-h-0();
+  @include p-0();
+
+  clip: rect(0, 0, 0, 0);
+  height: 0;
+  line-height: 0;
+  overflow: hidden;
+  width: 1px;
+}
+
 .ids-label {
   @include antialiased();
   @include font-sans();
   @include block();
   @include mb-8();
+
+  &.audible {
+    @include audible();
+  }
+}
+
+::slotted(.audible) {
+  @include audible();
 }
 
 /* Ids Typography System */

--- a/src/ids-validation-message/ids-validation-message.js
+++ b/src/ids-validation-message/ids-validation-message.js
@@ -1,0 +1,116 @@
+import {
+  IdsElement,
+  customElement,
+  scss
+} from '../ids-base/ids-element';
+import { props } from '../ids-base/ids-constants';
+import styles from './ids-validation-message.scss';
+
+const icons = {
+  alert: 'alert-solid',
+  error: 'error-solid',
+  info: 'info-solid',
+  success: 'success-solid',
+};
+
+/**
+ * IDS Field Components
+ */
+@customElement('ids-validation-message')
+@scss(styles)
+class IdsValidationMessage extends IdsElement {
+  /**
+   * Call the constructor and then initialize
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * Custom Element `connectedCallBack` implementation
+   * @private
+   * @returns {void}
+   */
+  connectedCallBack() {
+    this.refresh();
+  }
+
+  attributeChangedCallback() {
+    this.refresh();
+  }
+
+  /**
+   * Return the properties we handle as getters/setters
+   * @returns {Array} The properties in an array
+   */
+  static get properties() {
+    return [props.TYPE];
+  }
+
+  /**
+   * Create the Template for the contents
+   * @returns {string} The template
+   */
+  template() {
+    const iconName = icons[this.type];
+    const icon = iconName ? `<ids-icon icon="${iconName}" class="ids-icon"></ids-icon>` : '';
+    return `<div class="ids-validation-message">${icon}<ids-label class="message-text"><slot></slot></ids-label></div>`;
+  }
+
+  /**
+   * Set `type` attribute
+   * @param {string} value The `type` attribute
+   */
+  set type(value) {
+    if (value) {
+      this.setAttribute(props.TYPE, value);
+      return;
+    }
+    this.removeAttribute(props.TYPE);
+  }
+
+  get type() { return this.getAttribute(props.TYPE); }
+
+  /**
+   * Refresh to reset
+   * @private
+   * @returns {void}
+   */
+  refresh() {
+    this.rootEl = this.shadowRoot.querySelector('.ids-validation-message');
+    if (this.rootEl) {
+      const icon = icons[this.type];
+      if (icon && this.type) {
+        this.appendIcon(icon);
+      }
+    }
+  }
+
+  /**
+   * Check if an icon exists if not add it
+   * @private
+   * @param {string} iconName The icon name to check
+   * @returns {void}
+   */
+  appendIcon(iconName) {
+    const icon = this.rootEl?.querySelector(`[icon="${iconName}"]`);
+    if (!icon) {
+      this.rootEl?.insertAdjacentHTML('afterbegin', `<ids-icon icon="${iconName}" class="ids-icon"></ids-icon>`);
+    }
+  }
+
+  /**
+   * Check if an icon exists, if found remove it.
+   * @private
+   * @param {string} iconName The icon name to check
+   * @returns {void}
+   */
+  removeIcon(iconName) {
+    const icon = this.rootEl?.querySelector(`[icon="${iconName}"]`);
+    if (icon) {
+      icon.remove();
+    }
+  }
+}
+
+export default IdsValidationMessage;

--- a/src/ids-validation-message/ids-validation-message.scss
+++ b/src/ids-validation-message/ids-validation-message.scss
@@ -1,0 +1,29 @@
+@import '../ids-base/ids-base';
+
+.ids-validation-message {
+  @include antialiased();
+  @include font-sans();
+
+  display: flex;
+
+  .ids-icon {
+    @include mb-4();
+    @include mr-4();
+  }
+}
+
+:host([type='alert']) {
+  @include text-alert-warning();
+}
+
+:host([type='error']) {
+  @include text-alert-danger();
+}
+
+:host([type='info']) {
+  @include text-alert-info();
+}
+
+:host([type='success']) {
+  @include text-alert-success();
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
     index: ['./app/index.js'],
     'ids-button/ids-button': ['./app/ids-button/index.js'],
     'ids-icon/ids-icon': ['./app/ids-icon/index.js'],
+    'ids-input/ids-input': ['./app/ids-input/index.js'],
     'ids-label/ids-label': ['./app/ids-label/index.js'],
     'ids-layout-grid/ids-layout-grid': ['./app/ids-layout-grid/index.js'],
     'ids-popup/ids-popup': ['./app/ids-popup/index.js'],
@@ -22,6 +23,7 @@ module.exports = {
     'ids-popup/test-target-in-grid': ['./app/ids-popup/test-target-in-grid.js'],
     'ids-tag/ids-tag': ['./app/ids-tag/index.js'],
     'ids-toggle-button/ids-toggle-button': ['./app/ids-toggle-button/index.js'],
+    'ids-validation-message/ids-validation-message': ['./app/ids-validation-message/index.js']
   },
   devtool: 'cheap-source-map', // try source-map for prod
   mode: 'development',
@@ -171,6 +173,13 @@ module.exports = {
       chunks: ['ids-icon/ids-icon', 'ids-label/ids-label', 'ids-layout-grid/ids-layout-grid']
     }),
     new HTMLWebpackPlugin({
+      template: './app/ids-input/index.html',
+      inject: 'body',
+      filename: 'ids-input/index.html',
+      title: 'IDS Input Component',
+      chunks: ['ids-input/ids-input']
+    }),
+    new HTMLWebpackPlugin({
       template: './app/ids-label/index.html',
       inject: 'body',
       filename: 'ids-label/index.html',
@@ -238,6 +247,13 @@ module.exports = {
       filename: 'ids-popup/test-target-in-grid',
       chunks: ['ids-popup/test-target-in-grid'],
       title: 'Popup Test - Align Target inside a Layout Grid'
+    }),
+    new HTMLWebpackPlugin({
+      template: './app/ids-validation-message/index.html',
+      inject: 'body',
+      filename: 'ids-validation-message/index.html',
+      title: 'IDS Validation Message',
+      chunks: ['ids-validation-message/ids-validation-message']
     }),
     // Show Style Lint Errors in the console and fail
     new StylelintPlugin({}),


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
- ids-input: basic input field component
- ids-validation-message: wrapper for validation messages
- ids-dirty-tracker-mixin: to keep track user changes
- ids-validation-mixin: to check/set validation on form fields

Update some feature as:
ids-input: add attributes state, validation and dispatch basic events
ids-label: add basic uplift styles, sizes, validation, enable, disable, readonly

**Related github/jira issue (required)**:
Fixes infor-design/enterprise#4458

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to:
- http://localhost:4300
- http://localhost:4300/ids-input
- http://localhost:4300/ids-validation-message
- See the styles for validation message (icons, color and audible text for each type)
- See input uplift styles
- See disabled, readonly inputs
- See required label with red `*` star
- See input sizes
- Test dirty tracker
- Test validation for required and email (will do future validation updates)
- Test to change state (enable, disable, readonly)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
