### PR TITLE
Change Events mixin `dispatchEvent` to expose all custom event options

### DIFF
--- a/src/ids-base/ids-clearable-mixin.js
+++ b/src/ids-base/ids-clearable-mixin.js
@@ -69,7 +69,7 @@ const IdsClearableMixin = {
       this.input.dispatchEvent(new Event('change'));
       this.input.focus();
       this.checkContents();
-      this.eventHandlers.dispatchEvent('cleared', this, { elem: this, value: this.value });
+      this.eventHandlers.dispatchEvent('cleared', this, { detail: { elem: this, value: this.value } });
     }
   },
 
@@ -87,7 +87,7 @@ const IdsClearableMixin = {
       } else {
         xButton.classList.remove('is-empty');
       }
-      this.eventHandlers.dispatchEvent('contents-checked', this, { elem: this, value: this.value });
+      this.eventHandlers.dispatchEvent('contents-checked', this, { detail: { elem: this, value: this.value } });
     }
   },
 

--- a/src/ids-base/ids-events-mixin.js
+++ b/src/ids-base/ids-events-mixin.js
@@ -34,10 +34,10 @@ IdsEventsMixin.eventHandlers = {
    * Create and trigger a custom event
    * @param {string} eventName The event id with optional namespace
    * @param {HTMLElement} target The DOM element to register
-   * @param {object} options The custom data to send
+   * @param {object} [options] The custom data to send
    */
-  dispatchEvent(eventName, target, options) {
-    const event = new CustomEvent(eventName, { detail: options });
+  dispatchEvent(eventName, target, options = {}) {
+    const event = new CustomEvent(eventName, options);
     target.dispatchEvent(event);
   },
 

--- a/src/ids-base/ids-validation-mixin.js
+++ b/src/ids-base/ids-validation-mixin.js
@@ -76,7 +76,7 @@ const IdsValidationMixin = {
           this.removeMessage(thisRule.rule);
         }
       });
-      this.eventHandlers.dispatchEvent('validated', this, { elem: this, value: this.value, isValid });
+      this.eventHandlers.dispatchEvent('validated', this, { detail: { elem: this, value: this.value, isValid } });
     }
   },
 

--- a/src/ids-checkbox/ids-checkbox.js
+++ b/src/ids-checkbox/ids-checkbox.js
@@ -154,10 +154,12 @@ class IdsCheckbox extends IdsElement {
              * @param  {string} value The updated input element value
              */
             this.eventHandlers.dispatchEvent(`trigger${e.type}`, this, {
-              elem: this,
-              nativeEvent: e,
-              value: this.value,
-              checked: this.input.checked
+              detail: {
+                elem: this,
+                nativeEvent: e,
+                value: this.value,
+                checked: this.input.checked
+              }
             });
           });
         }

--- a/src/ids-input/ids-input.js
+++ b/src/ids-input/ids-input.js
@@ -255,7 +255,13 @@ class IdsInput extends IdsElement {
              * @param  {object} elem Actual event
              * @param  {string} value The updated input element value
              */
-            this.eventHandlers.dispatchEvent(`trigger${e.type}`, this, { elem: this, nativeEvent: e, value: this.value });
+            this.eventHandlers.dispatchEvent(`trigger${e.type}`, this, {
+              detail: {
+                elem: this,
+                nativeEvent: e,
+                value: this.value
+              }
+            });
           });
         }
       });

--- a/src/ids-switch/ids-switch.js
+++ b/src/ids-switch/ids-switch.js
@@ -140,10 +140,12 @@ class IdsSwitch extends IdsElement {
              * @param  {string} value The updated input element value
              */
             this.eventHandlers.dispatchEvent(`trigger${e.type}`, this, {
-              elem: this,
-              nativeEvent: e,
-              value: this.value,
-              checked: this.input.checked
+              detail: {
+                elem: this,
+                nativeEvent: e,
+                value: this.value,
+                checked: this.input.checked
+              }
             });
           });
         }

--- a/src/ids-tag/ids-tag.js
+++ b/src/ids-tag/ids-tag.js
@@ -207,15 +207,15 @@ class IdsTag extends IdsElement {
     const response = (veto) => {
       canDismiss = !!veto;
     };
-    this.eventHandlers.dispatchEvent('beforetagremoved', this, { elem: this, response });
+    this.eventHandlers.dispatchEvent('beforetagremoved', this, { detail: { elem: this, response } });
 
     if (!canDismiss) {
       return;
     }
 
-    this.eventHandlers.dispatchEvent('tagremoved', this, { elem: this });
+    this.eventHandlers.dispatchEvent('tagremoved', this, { detail: { elem: this } });
     this.remove();
-    this.eventHandlers.dispatchEvent('aftertagremoved', this, { elem: this });
+    this.eventHandlers.dispatchEvent('aftertagremoved', this, { detail: { elem: this } });
   }
 }
 

--- a/src/ids-trigger-field/ids-trigger-field.js
+++ b/src/ids-trigger-field/ids-trigger-field.js
@@ -143,13 +143,13 @@ class IdsTriggerField extends IdsElement {
     const response = (veto) => {
       canTrigger = !!veto;
     };
-    this.eventHandlers.dispatchEvent('beforetriggerclicked', this, { elem: this, response });
+    this.eventHandlers.dispatchEvent('beforetriggerclicked', this, { detail: { elem: this, response } });
 
     if (!canTrigger) {
       return;
     }
 
-    this.eventHandlers.dispatchEvent('triggerclicked', this, { elem: this });
+    this.eventHandlers.dispatchEvent('triggerclicked', this, { detail: { elem: this } });
   }
 
   /**

--- a/test/ids-render-loop/ids-render-loop-func-test.js
+++ b/test/ids-render-loop/ids-render-loop-func-test.js
@@ -120,7 +120,7 @@ describe('Ids RenderLoop', () => {
         loop.start();
 
         expect(loop.resumeTime).toBeDefined();
-        expect(loop.totalStoppedTime).toBeGreaterThan(timeoutLength);
+        expect(loop.totalStoppedTime).toBeGreaterThan((timeoutLength - 1));
         done();
       }, timeoutLength);
     }, 10);
@@ -263,7 +263,7 @@ describe('Ids RenderLoop', () => {
         setTimeout(() => {
           item.resume();
 
-          expect(item.totalStoppedTime).toBeGreaterThan(timeoutLength);
+          expect(item.totalStoppedTime).toBeGreaterThan((timeoutLength - 1));
           done();
         }, timeoutLength);
       }, 10);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR changes the `dispatchEvent()` pass-through method in `IdsEventsMixin` to expose the entire options object that is passed to the `CustomEvent` constructor.  Previously, it was only possible to set the contents of the `detail` property inside this object, but we determined that we will need more fine-grain control of other properties, like `bubbles`, for some event types (As an example, I need it for telling [Popupmenus](infor-design/enterprise#4628) to close by clicking on lower-level items).

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
I changed the implementation but not the event listeners, so as long as all tests pass, this should be ok.  As a manual smoke test, open http://localhost:4300 against this branch and test any components that use internal custom events (Trigger button, Tag) and ensure they work properly.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
