### PR TITLE
Add Event Namespacing, Remove mixin-based IdsEventMixin

### DIFF
--- a/src/ids-base/README.md
+++ b/src/ids-base/README.md
@@ -62,10 +62,24 @@ The Event mixin needs to record its state in a map for each component so it cant
   // Handle Clicking the x for dismissible
   const closeIcon = this.querySelector('ids-icon[icon="close"]');
   this.eventHandlers.addEventListener('click', closeIcon, () => this.dismiss());
+```
 
 - Handles consistency on the data sent (element, event data, id, idx, custom ect)
 - Before events events can be vetoed
-- All events should have past tense for example activated, beforeactivated, afteractived not activate, beforeactivate, afteractivate
+- All events should have past tense for example `activated`, `beforeactivated`, `afteractived` and not `activate`, `beforeactivate`, `afteractivate`
+
+It's also possible to use Namespaces with the Ids Event Handler's methods, similar to the 4.x version's support for jQuery Event Namespacing.  When assigning an event name, usage of a period (.) will cause any text after the period to be considered the "namespace".  When removing assigned event listeners using the namespace, only handlers that match the event type AND namespace will be removed:
+
+```js
+this.eventHandlers.addEventListener('click', closeIcon, () => this.dismiss());
+this.eventHandlers.addEventListener('click.doop', closeIcon, () => this.otherDismissCheck());
+console.log(this.eventHandlers.handledEvents());
+// both `click` and `click.doop` exist.
+
+this.eventHandlers.removeEventListener('click.doop', closeIcon);
+console.log(this.eventHandlers.handledEvents());
+// `click.doop` is not there, but `click` remains.
+```
 
 ## Ids Mixins
 

--- a/src/ids-base/ids-events-mixin.js
+++ b/src/ids-base/ids-events-mixin.js
@@ -12,7 +12,7 @@ class IdsEventsMixin {
    * @param {object} options Additional event settings (passive, once, passive ect)
    */
   addEventListener(eventName, target, callback, options) {
-    target.addEventListener(eventName, callback, options);
+    target.addEventListener(eventName.split('.')[0], callback, options);
     this.handledEvents.set(eventName, { target, callback, options });
   }
 
@@ -24,7 +24,7 @@ class IdsEventsMixin {
    */
   removeEventListener(eventName, target, options) {
     const handler = this.handledEvents.get(eventName);
-    target.removeEventListener(eventName, handler.callback, options || handler.options);
+    target.removeEventListener(eventName.split('.')[0], handler.callback, options || handler.options);
     this.handledEvents.delete(eventName);
   }
 
@@ -35,7 +35,7 @@ class IdsEventsMixin {
    * @param {object} [options] The custom data to send
    */
   dispatchEvent(eventName, target, options = {}) {
-    const event = new CustomEvent(eventName, options);
+    const event = new CustomEvent(eventName.split('.')[0], options);
     target.dispatchEvent(event);
   }
 

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -1,7 +1,6 @@
 import {
   IdsElement,
   customElement,
-  mixin,
   scss
 } from '../ids-base/ids-element';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
@@ -42,7 +41,6 @@ const BUTTON_PROPS = [
  */
 @customElement('ids-button')
 @scss(styles)
-@mixin(IdsEventsMixin)
 class IdsButton extends IdsElement {
   constructor() {
     super();

--- a/src/ids-input/ids-input.js
+++ b/src/ids-input/ids-input.js
@@ -61,7 +61,6 @@ const TEXT_ALIGN = {
 @mixin(IdsClearableMixin)
 @mixin(IdsDirtyTrackerMixin)
 @mixin(IdsDomUtilsMixin)
-@mixin(IdsEventsMixin)
 @mixin(IdsStringUtilsMixin)
 @mixin(IdsValidationMixin)
 class IdsInput extends IdsElement {

--- a/src/ids-popup/ids-popup.js
+++ b/src/ids-popup/ids-popup.js
@@ -71,7 +71,6 @@ function formatAlignAttribute(alignX, alignY, edge) {
  */
 @customElement('ids-popup')
 @scss(styles)
-@mixin(IdsEventsMixin)
 @mixin(IdsRenderLoopMixin)
 @mixin(IdsResizeMixin)
 class IdsPopup extends IdsElement {

--- a/src/ids-radio/ids-radio-group.js
+++ b/src/ids-radio/ids-radio-group.js
@@ -18,7 +18,6 @@ import IdsText from '../ids-text/ids-text';
  */
 @customElement('ids-radio-group')
 @scss(styles)
-@mixin(IdsEventsMixin)
 @mixin(IdsStringUtilsMixin)
 @mixin(IdsDirtyTrackerMixin)
 @mixin(IdsValidationMixin)

--- a/src/ids-radio/ids-radio.js
+++ b/src/ids-radio/ids-radio.js
@@ -20,7 +20,6 @@ import IdsRadioGroup from './ids-radio-group';
 @customElement('ids-radio')
 @scss(styles)
 @mixin(IdsDomUtilsMixin)
-@mixin(IdsEventsMixin)
 @mixin(IdsHideFocusMixin)
 @mixin(IdsStringUtilsMixin)
 class IdsRadio extends IdsElement {

--- a/src/ids-switch/ids-switch.js
+++ b/src/ids-switch/ids-switch.js
@@ -17,7 +17,6 @@ import IdsText from '../ids-text/ids-text';
  */
 @customElement('ids-switch')
 @scss(styles)
-@mixin(IdsEventsMixin)
 @mixin(IdsHideFocusMixin)
 @mixin(IdsStringUtilsMixin)
 class IdsSwitch extends IdsElement {

--- a/src/ids-toggle-button/ids-toggle-button.js
+++ b/src/ids-toggle-button/ids-toggle-button.js
@@ -1,6 +1,5 @@
 import {
   customElement,
-  mixin,
   scss
 } from '../ids-base/ids-element';
 import { IdsButton, BUTTON_PROPS, BUTTON_TYPES } from '../ids-button/ids-button';
@@ -19,7 +18,6 @@ const DEFAULT_ICON_ON = 'star-filled';
  */
 @customElement('ids-toggle-button')
 @scss(styles)
-@mixin(IdsEventsMixin)
 class IdsToggleButton extends IdsButton {
   constructor() {
     super();

--- a/src/ids-virtual-scroll/ids-virtual-scroll.js
+++ b/src/ids-virtual-scroll/ids-virtual-scroll.js
@@ -15,7 +15,6 @@ import styles from './ids-virtual-scroll.scss';
  */
 @customElement('ids-virtual-scroll')
 @scss(styles)
-@mixin(IdsEventsMixin)
 @mixin(IdsRenderLoopMixin)
 class IdsVirtualScroll extends IdsElement {
   constructor() {

--- a/test/ids-base/ids-events-mixin-func-test.js
+++ b/test/ids-base/ids-events-mixin-func-test.js
@@ -23,4 +23,22 @@ describe('IdsEventsMixin Tests', () => {
     elem.events.dispatchEvent('customtest', elem);
     expect(mockHandler.mock.calls.length).toBe(1);
   });
+
+  it('can attach and remove events with a namespace', () => {
+    const mockHandlerNormal = jest.fn();
+    const mockHandlerNS = jest.fn();
+
+    elem.events.addEventListener('click', elem, mockHandlerNormal);
+    elem.events.addEventListener('click.doop', elem, mockHandlerNS);
+    elem.events.dispatchEvent('click', elem);
+
+    expect(mockHandlerNormal.mock.calls.length).toBe(1);
+    expect(mockHandlerNS.mock.calls.length).toBe(1);
+
+    elem.events.removeEventListener('click.doop', elem);
+    elem.events.dispatchEvent('click', elem);
+
+    expect(mockHandlerNormal.mock.calls.length).toBe(2);
+    expect(mockHandlerNS.mock.calls.length).toBe(1);
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR changes a couple items related to event handling:
- Adds support for Event Namespacing in a similar fashion to jQuery events, and as specified [here](https://stackoverflow.com/a/44426162/4024149), along with some supporting documentation.
- Per the change in #29, removed any existing `@mixin` statements for invoking the IdsEventsMixin.  Most components were already changed to use `new` but this was lingering around, so I removed it to prevent any confusion. 

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
Ensure the new test for namespacing passes

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
