### PR TITLE
4390 - Minor IdsButton improvements

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,8 +17,11 @@
       "custom-properties",
       "declarations"
     ],
-    "order/properties-alphabetical-order": true,
     "max-nesting-depth": 3,
+    "no-descending-specificity": [true, {
+      "ignore": [ "selectors-within-list" ]
+    }],
+    "order/properties-alphabetical-order": true,
     "selector-pseudo-class-no-unknown": [true, {
       "ignorePseudoClasses": ["root", "host", "unresolved"]
     }],

--- a/app/ids-button/example.html
+++ b/app/ids-button/example.html
@@ -1,3 +1,4 @@
 {{> button.html }}
 {{> disabled-button.html }}
 {{> icon-button.html }}
+{{> icon-button-align-right.html }}

--- a/app/ids-button/icon-button-align-right.html
+++ b/app/ids-button/icon-button-align-right.html
@@ -1,0 +1,32 @@
+<ids-layout-grid>
+    <ids-text font-size="12" type="h1">Text + Icon Buttons</ids-text>
+</ids-layout-grid>
+<ids-layout-grid cols="4" gap="md">
+    <ids-layout-grid-cell>
+        <ids-button id="test-icon-end-button-default" icon-align="end">
+            <span slot="text">Default Button</span>
+            <ids-icon slot="icon" icon="settings"></ids-icon>
+        </ids-button>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+        <ids-button id="test-icon-end-button-primary" icon-align="end" type="primary">
+            <span slot="text">Primary Button</span>
+            <ids-icon slot="icon" icon="settings"></ids-icon>
+        </ids-button>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+        <ids-button id="test-icon-end-button-secondary" icon-align="end" type="secondary">
+            <span slot="text">Secondary Button</span>
+            <ids-icon slot="icon" icon="settings"></ids-icon>
+        </ids-button>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+        <ids-button id="test-icon-end-button-tertiary" icon-align="end" type="tertiary">
+            <span slot="text">Tertiary Button</span>
+            <ids-icon slot="icon" icon="settings"></ids-icon>
+        </ids-button>
+    </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/app/ids-button/icon-button.html
+++ b/app/ids-button/icon-button.html
@@ -1,37 +1,4 @@
 <ids-layout-grid>
-  <ids-text font-size="12" type="h1">Icon + Text Buttons</ids-text>
-</ids-layout-grid>
-<ids-layout-grid cols="4" gap="md">
-  <ids-layout-grid-cell>
-    <ids-button id="test-icon-button-default">
-      <ids-icon slot="icon" icon="settings"></ids-icon>
-      <span slot="text">Default Button</span>
-    </ids-button>
-  </ids-layout-grid-cell>
-
-  <ids-layout-grid-cell>
-    <ids-button id="test-icon-button-primary" type="primary">
-      <ids-icon slot="icon" icon="settings"></ids-icon>
-      <span slot="text">Primary Button</span>
-    </ids-button>
-  </ids-layout-grid-cell>
-
-  <ids-layout-grid-cell>
-    <ids-button id="test-icon-button-secondary" type="secondary">
-      <ids-icon slot="icon" icon="settings"></ids-icon>
-      <span slot="text">Secondary Button</span>
-    </ids-button>
-  </ids-layout-grid-cell>
-
-  <ids-layout-grid-cell>
-    <ids-button id="test-icon-button-tertiary" type="tertiary">
-      <ids-icon slot="icon" icon="settings"></ids-icon>
-      <span slot="text">Tertiary Button</span>
-    </ids-button>
-  </ids-layout-grid-cell>
-</ids-layout-grid>
-
-<ids-layout-grid>
   <ids-text font-size="12" type="h1">Icon Only Buttons</ids-text>
 </ids-layout-grid>
 <ids-layout-grid cols="4" gap="md">
@@ -60,6 +27,39 @@
     <ids-button id="test-icon-only-button-tertiary" type="tertiary">
       <span class="audible">Tertiary Button</span>
       <ids-icon slot="icon" icon="settings"></ids-icon>
+    </ids-button>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-text font-size="12" type="h1">Icon + Text Buttons</ids-text>
+</ids-layout-grid>
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-button id="test-icon-button-default">
+      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <span slot="text">Default Button</span>
+    </ids-button>
+  </ids-layout-grid-cell>
+
+  <ids-layout-grid-cell>
+    <ids-button id="test-icon-button-primary" type="primary">
+      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <span slot="text">Primary Button</span>
+    </ids-button>
+  </ids-layout-grid-cell>
+
+  <ids-layout-grid-cell>
+    <ids-button id="test-icon-button-secondary" type="secondary">
+      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <span slot="text">Secondary Button</span>
+    </ids-button>
+  </ids-layout-grid-cell>
+
+  <ids-layout-grid-cell>
+    <ids-button id="test-icon-button-tertiary" type="tertiary">
+      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <span slot="text">Tertiary Button</span>
     </ids-button>
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/app/ids-button/standalone-css.html
+++ b/app/ids-button/standalone-css.html
@@ -34,22 +34,22 @@
 </div>
 <div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
     <div class="ids-layout-grid-cell">
-        <button id="test-button-default" class="ids-button" disabled>
+        <button id="test-disabled-button-default" class="ids-button" disabled>
             <span>Default Button</span>
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-primary" class="ids-button btn-primary" disabled>
+        <button id="test-disabled-button-primary" class="ids-button btn-primary" disabled>
             <span>Primary Button</span>
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-secondary" class="ids-button btn-secondary" disabled>
+        <button id="test-disabled-button-secondary" class="ids-button btn-secondary" disabled>
             <span>Secondary Button</span>
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-tertiary" class="ids-button btn-tertiary" disabled>
+        <button id="test-disabled-button-tertiary" class="ids-button btn-tertiary" disabled>
             <span>Tertiary Button</span>
         </button>
     </div>

--- a/app/ids-button/standalone-css.html
+++ b/app/ids-button/standalone-css.html
@@ -1,0 +1,182 @@
+<link rel="stylesheet" href="ids-button.css" />
+<link rel="stylesheet" href="../ids-icon/ids-icon.css" />
+<link rel="stylesheet" href="../ids-layout-grid/ids-layout-grid.css" />
+<link rel="stylesheet" href="../ids-text/ids-text.css" />
+
+<div class="ids-layout-grid">
+    <h1 class="ids-text ids-text-12">Standalone CSS Buttons</h1>
+</div>
+<div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-default" class="ids-button">
+            <span>Default Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-primary" class="ids-button btn-primary">
+            <span>Primary Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-secondary" class="ids-button btn-secondary">
+            <span>Secondary Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-tertiary" class="ids-button btn-tertiary">
+            <span>Tertiary Button</span>
+        </button>
+    </div>
+</div>
+
+<div class="ids-layout-grid">
+    <h1 class="ids-text ids-text-12">Standalone CSS Disabled Buttons</h1>
+</div>
+<div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-default" class="ids-button" disabled>
+            <span>Default Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-primary" class="ids-button btn-primary" disabled>
+            <span>Primary Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-secondary" class="ids-button btn-secondary" disabled>
+            <span>Secondary Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-tertiary" class="ids-button btn-tertiary" disabled>
+            <span>Tertiary Button</span>
+        </button>
+    </div>
+</div>
+
+<div class="ids-layout-grid">
+    <h1 class="ids-text ids-text-12">Standalone CSS Icon Only Buttons</h1>
+</div>
+<div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-default" class="ids-icon-button">
+            <span class="audible">Default Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-primary" class="ids-icon-button btn-primary">
+            <span class="audible">Primary Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-secondary" class="ids-icon-button btn-secondary">
+            <span class="audible">Secondary Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-tertiary" class="ids-icon-button btn-tertiary">
+            <span class="audible">Tertiary Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+</div>
+
+<div class="ids-layout-grid">
+    <h1 class="ids-text ids-text-12">Standalone CSS Icon + Text Button</h1>
+</div>
+<div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-default" class="ids-button">
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+            <span>Default Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-primary" class="ids-button btn-primary">
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+            <span>Primary Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-secondary" class="ids-button btn-secondary">
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+            <span>Secondary Button</span>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-tertiary" class="ids-button btn-tertiary">
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+            <span>Tertiary Button</span>
+        </button>
+    </div>
+</div>
+
+<div class="ids-layout-grid">
+    <h1 class="ids-text ids-text-12">Standalone CSS Text + Icon Button</h1>
+</div>
+<div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-default" class="ids-button">
+            <span>Default Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
+                height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path
+                    d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z"
+                    stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-primary" class="ids-button btn-primary">
+            <span>Primary Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
+                height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path
+                    d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z"
+                    stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-secondary" class="ids-button btn-secondary">
+            <span>Secondary Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
+                height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path
+                    d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z"
+                    stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+    <div class="ids-layout-grid-cell">
+        <button id="test-button-tertiary" class="ids-button btn-tertiary">
+            <span>Tertiary Button</span>
+            <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
+                height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                <path
+                    d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z"
+                    stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+            </svg>
+        </button>
+    </div>
+</div>

--- a/app/ids-button/standalone-css.html
+++ b/app/ids-button/standalone-css.html
@@ -60,7 +60,7 @@
 </div>
 <div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
     <div class="ids-layout-grid-cell">
-        <button id="test-button-default" class="ids-icon-button">
+        <button id="test-icon-button-default" class="ids-icon-button">
             <span class="audible">Default Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
@@ -68,7 +68,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-primary" class="ids-icon-button btn-primary">
+        <button id="test-icon-button-primary" class="ids-icon-button btn-primary">
             <span class="audible">Primary Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
@@ -76,7 +76,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-secondary" class="ids-icon-button btn-secondary">
+        <button id="test-icon-button-secondary" class="ids-icon-button btn-secondary">
             <span class="audible">Secondary Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
@@ -84,7 +84,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-tertiary" class="ids-icon-button btn-tertiary">
+        <button id="test-icon-button-tertiary" class="ids-icon-button btn-tertiary">
             <span class="audible">Tertiary Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
@@ -98,7 +98,7 @@
 </div>
 <div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
     <div class="ids-layout-grid-cell">
-        <button id="test-button-default" class="ids-button">
+        <button id="test-icon-text-button-default" class="ids-button">
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
             </svg>
@@ -106,7 +106,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-primary" class="ids-button btn-primary">
+        <button id="test-icon-text-button-primary" class="ids-button btn-primary">
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
             </svg>
@@ -114,7 +114,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-secondary" class="ids-button btn-secondary">
+        <button id="test-icon-text-button-secondary" class="ids-button btn-secondary">
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
             </svg>
@@ -122,7 +122,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-tertiary" class="ids-button btn-tertiary">
+        <button id="test-icon-text-button-tertiary" class="ids-button btn-tertiary">
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                 <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
             </svg>
@@ -136,7 +136,7 @@
 </div>
 <div class="ids-layout-grid ids-layout-grid ids-layout-grid-cols-4 ids-layout-grid-gap-md">
     <div class="ids-layout-grid-cell">
-        <button id="test-button-default" class="ids-button">
+        <button id="test-text-icon-button-default" class="ids-button">
             <span>Default Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
                 height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
@@ -147,7 +147,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-primary" class="ids-button btn-primary">
+        <button id="test-text-icon-button-primary" class="ids-button btn-primary">
             <span>Primary Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
                 height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
@@ -158,7 +158,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-secondary" class="ids-button btn-secondary">
+        <button id="test-text-icon-button-secondary" class="ids-button btn-secondary">
             <span>Secondary Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
                 height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
@@ -169,7 +169,7 @@
         </button>
     </div>
     <div class="ids-layout-grid-cell">
-        <button id="test-button-tertiary" class="ids-button btn-tertiary">
+        <button id="test-text-icon-button-tertiary" class="ids-button btn-tertiary">
             <span>Tertiary Button</span>
             <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
                 height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">

--- a/app/ids-expandable-area/example.html
+++ b/app/ids-expandable-area/example.html
@@ -75,8 +75,8 @@
         text-off="Employee"
         text-on="Employee"
       >
-        <span slot="text"></span>
         <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span slot="text"></span>
       </ids-toggle-button>
       <ids-text slot="pane" font-size="14">
         Ubiquitous out-of-the-box, scalable; communities disintermediate beta-test, enable utilize markets dynamic

--- a/app/ids-toggle-button/icon-align-right.html
+++ b/app/ids-toggle-button/icon-align-right.html
@@ -1,0 +1,12 @@
+<ids-layout-grid>
+    <ids-text font-size="12" type="h1">Toggle Buttons</ids-text>
+</ids-layout-grid>
+<ids-layout-grid cols="4" gap="md">
+    <ids-layout-grid-cell>
+        <ids-toggle-button id="test-toggle-button" icon-align="end" icon-on="heart-filled" icon-off="heart-outlined"
+            text-off="Favorite (Off)" text-on="Favorite (On)">
+            <ids-icon slot="icon" icon="settings"></ids-icon>
+            <span slot="text"></span>
+        </ids-toggle-button>
+    </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/doc/CHECKLIST.md
+++ b/doc/CHECKLIST.md
@@ -135,12 +135,12 @@ Standalone Css not applicable use SVG files or PNG files. Could also still use a
 
 **Button** (ids-button)
  - [x] Docs
- - [ ] 100% Test Coverage
+ - [x] 100% Test Coverage
  - [x] Feature Parity with 4.x
  - [x] Upgrade Docs in Changelog
- - [ ] Typings
+ - [x] Typings
  - [ ] NG / Vue / React Example
- - [ ] Standalone Css
+ - [x] Standalone Css
  - [ ] Works in Page with 4.x
 
 **Calendar** (ids-calendar)

--- a/src/ids-base/ids-constants.js
+++ b/src/ids-base/ids-constants.js
@@ -31,6 +31,7 @@ export const props = {
   GROUP_DISABLED: 'group-disabled',
   HORIZONTAL: 'horizontal',
   ICON: 'icon',
+  ID: 'id',
   INDETERMINATE: 'indeterminate',
   KEEP_OPEN: 'keep-open',
   LABEL: 'label',

--- a/src/ids-base/ids-constants.js
+++ b/src/ids-base/ids-constants.js
@@ -31,6 +31,7 @@ export const props = {
   GROUP_DISABLED: 'group-disabled',
   HORIZONTAL: 'horizontal',
   ICON: 'icon',
+  ICON_ALIGN: 'icon-align',
   ID: 'id',
   INDETERMINATE: 'indeterminate',
   KEEP_OPEN: 'keep-open',

--- a/src/ids-button/README.md
+++ b/src/ids-button/README.md
@@ -60,6 +60,7 @@ Standard button states include:
 - Hover
 - Focus
 - Active (pressed)
+- Disabled
 
 IDS button types include:
 
@@ -67,6 +68,24 @@ IDS button types include:
 - `primary`
 - `secondary`
 - `tertiary`
+
+An IDS Button that contains an icon has the icon aligned left of the button text by default.  To switch the alignment, it's possible to set the `icon-align` attribute.
+
+```html
+<ids-button id="my-button" type="primary" icon-align="end">
+  <ids-icon slot="icon" icon="settings"></ids-icon>
+  <span slot="text">My Button</span>
+</ids-button>
+```
+
+The attribute has the following effects:
+
+| prop value | LTR (default) Icon Location | RTL Icon Location |
+| :--------- | :-------------------------- | :---------------- |
+| 'start'    | icon to the left of text | icon to the right of text |
+| 'end'      | icon to the right of text | icon to the left of text |
+
+In the absence of the property, icons will align to `start` by default.
 
 ## Keyboard Guidelines
 

--- a/src/ids-button/ids-button-base.scss
+++ b/src/ids-button/ids-button-base.scss
@@ -179,4 +179,13 @@
       @include text-slate-30();
     }
   }
+
+  // ====================================================
+  // Alignment changes
+
+  &.align-icon-end {
+    ids-icon[slot] {
+      align-self: flex-end;
+    }
+  }
 }

--- a/src/ids-button/ids-button-base.scss
+++ b/src/ids-button/ids-button-base.scss
@@ -42,6 +42,7 @@
   @include border-solid();
   @include font-normal();
   @include font-sans();
+  @include inline-flex();
   @include px-28();
   @include rounded-default();
   @include text-16();
@@ -98,6 +99,20 @@
 
   &:not([disabled]) {
     @include cursor-pointer();
+  }
+
+  // ====================================================
+  // Standard element types inside the button
+  span {
+    vertical-align: bottom;
+
+    &.audible {
+      @include audible();
+    }
+  }
+
+  .ids-icon {
+    vertical-align: middle;
   }
 
   // ====================================================

--- a/src/ids-button/ids-button.d.ts
+++ b/src/ids-button/ids-button.d.ts
@@ -1,6 +1,5 @@
 // Ids is a JavaScript project, but we define TypeScript declarations so we can
 // confirm our code is type safe, and to support TypeScript users.
-
 export class IdsButton extends HTMLElement {
   /* Contains space-delimeted CSS classes (or an array of CSS classes) that will be passed to the Shadow Root button */
   cssClass?: Array<string> | string | null;

--- a/src/ids-button/ids-button.d.ts
+++ b/src/ids-button/ids-button.d.ts
@@ -1,6 +1,8 @@
 // Ids is a JavaScript project, but we define TypeScript declarations so we can
 // confirm our code is type safe, and to support TypeScript users.
-export class IdsButton extends HTMLElement {
+import { IdsElement } from '../ids-base/ids-element';
+
+export class IdsButton extends IdsElement {
   /* Contains space-delimeted CSS classes (or an array of CSS classes) that will be passed to the Shadow Root button */
   cssClass?: Array<string> | string | null;
   /* A string representing an icon to display inside the button.  This icon will become the content of the Shadow Root button's `icon` slot when set. */

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -5,12 +5,11 @@ import {
   scss
 } from '../ids-base/ids-element';
 
+import { IdsDomUtilsMixin as domUtils } from '../ids-base/ids-dom-utils-mixin';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsRenderLoopMixin, IdsRenderLoopItem } from '../ids-render-loop/ids-render-loop-mixin';
-
-// @ts-ignore
-import { IdsStringUtilsMixin as stringUtils } from '../ids-base/ids-string-utils-mixin';
 import { props } from '../ids-base/ids-constants';
+
 // @ts-ignore
 import styles from './ids-button.scss';
 
@@ -27,7 +26,7 @@ const BUTTON_TYPES = [
 const BUTTON_DEFAULTS = {
   cssClass: [],
   disabled: false,
-  tabindex: true,
+  tabIndex: true,
   type: BUTTON_TYPES[0]
 };
 
@@ -67,7 +66,17 @@ class IdsButton extends IdsElement {
    */
   attributeChangedCallback(name, oldValue, newValue) {
     if (this.shouldUpdate) {
-      IdsElement.prototype.attributeChangedCallback.apply(this, [name, oldValue, newValue]);
+      switch (name) {
+        // Convert "tabindex" to "tabIndex"
+        case 'tabindex':
+          if (oldValue !== newValue) {
+            this.tabIndex = Number(newValue);
+          }
+          break;
+        default:
+          IdsElement.prototype.attributeChangedCallback.apply(this, [name, oldValue, newValue]);
+          break;
+      }
     }
   }
 
@@ -128,7 +137,7 @@ class IdsButton extends IdsElement {
     let protoClasses = '';
     let disabled = '';
     let icon = '';
-    let tabindex = 'tabindex="0"';
+    let tabIndex = 'tabindex="0"';
     let text = '';
     let type = '';
     if (this.state?.cssClass) {
@@ -137,8 +146,8 @@ class IdsButton extends IdsElement {
     if (this.state?.disabled) {
       disabled = ` disabled="true"`;
     }
-    if (this.state?.tabindex) {
-      tabindex = `tabindex="${this.state.tabindex}"`;
+    if (this.state?.tabIndex) {
+      tabIndex = `tabindex="${this.state.tabIndex}"`;
     }
     if (this.state?.icon) {
       icon = `<ids-icon slot="icon" icon="${this.state.icon}"></ids-icon>`;
@@ -154,7 +163,7 @@ class IdsButton extends IdsElement {
       protoClasses = `${this.protoClasses.join(' ')}`;
     }
 
-    return `<button class="${protoClasses}${type}${cssClass}" ${tabindex}${disabled}>
+    return `<button class="${protoClasses}${type}${cssClass}" ${tabIndex}${disabled}>
       <slot name="icon">${icon}</slot>
       <slot name="text">${text}</slot>
       <slot>${icon}${text}</slot>
@@ -256,7 +265,7 @@ class IdsButton extends IdsElement {
     this.removeAttribute(props.DISABLED);
     this.shouldUpdate = true;
 
-    const trueVal = stringUtils.stringToBool(val);
+    const trueVal = domUtils.isTrueBooleanAttribute(val);
     this.state.disabled = trueVal;
 
     /* istanbul ignore next */
@@ -270,30 +279,31 @@ class IdsButton extends IdsElement {
   }
 
   /**
-   * Passes a tabindex attribute from the custom element to the button
-   * @param {number} val the tabindex value
+   * Passes a tabIndex attribute from the custom element to the button
+   * @param {number} val the tabIndex value
    * @returns {void}
    */
-  set tabindex(val) {
+  set tabIndex(val) {
+    // Remove the webcomponent tabIndex
     this.shouldUpdate = false;
     this.removeAttribute(props.TABINDEX);
     this.shouldUpdate = true;
 
-    const trueVal = parseInt(val.toString(), 10);
+    const trueVal = Number(val);
     if (Number.isNaN(trueVal) || trueVal < -1) {
-      this.state.tabindex = 0;
-      this.button.removeAttribute(props.TABINDEX);
+      this.state.tabIndex = 0;
+      this.button.setAttribute(props.TABINDEX, '0');
       return;
     }
-    this.state.tabindex = trueVal;
-    this.button.setAttribute(props.TABINDEX, trueVal.toString());
+    this.state.tabIndex = trueVal;
+    this.button.setAttribute(props.TABINDEX, `${trueVal}`);
   }
 
   /**
-   * @returns {number} the current tabindex number for the button
+   * @returns {number} the current tabIndex number for the button
    */
-  get tabindex() {
-    return this.state.tabindex;
+  get tabIndex() {
+    return this.state.tabIndex;
   }
 
   /**

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -69,9 +69,7 @@ class IdsButton extends IdsElement {
       switch (name) {
         // Convert "tabindex" to "tabIndex"
         case 'tabindex':
-          if (oldValue !== newValue) {
-            this.tabIndex = Number(newValue);
-          }
+          this.tabIndex = Number(newValue);
           break;
         default:
           IdsElement.prototype.attributeChangedCallback.apply(this, [name, oldValue, newValue]);

--- a/src/ids-button/ids-button.scss
+++ b/src/ids-button/ids-button.scss
@@ -44,6 +44,20 @@
     @include pl-4();
   }
 
+  .ids-icon {
+    @include inline-flex();
+
+    place-self: center;
+    vertical-align: middle;
+  }
+
+  // Padding rules for standalone CSS buttons (match the rules/style above)
+  .ids-icon:last-child,
+  span + span,
+  span:last-child {
+    @include pl-4();
+  }
+
   // Technically not valid
   ::slotted(ids-icon:only-child) {
     @include block();
@@ -63,11 +77,15 @@
   @include py-8();
   @include rounded-round();
 
-  ::slotted(ids-icon) {
+  .ids-icon {
     @include block();
     @include pl-0();
 
     font-size: 0;
+  }
+
+  span.audible {
+    @include audible();
   }
 
   .ripple-effect {

--- a/test/ids-button/ids-button-e2e-test.js
+++ b/test/ids-button/ids-button-e2e-test.js
@@ -25,4 +25,11 @@ describe('Ids Button e2e Tests', () => {
     await page.goto(url, { waitUntil: 'load' });
     await percySnapshot(page, 'ids-button');
   });
+
+  it('should not have visual regressions (percy) on standalone CSS', async () => {
+    page = await browser.newPage();
+    await page.setBypassCSP(true);
+    await page.goto('http://localhost:4444/ids-button/standalone-css', { waitUntil: 'load' });
+    await percySnapshot(page, 'ids-button-css');
+  });
 });

--- a/test/ids-button/ids-button-func-test.js
+++ b/test/ids-button/ids-button-func-test.js
@@ -43,6 +43,17 @@ describe('IdsButton Component', () => {
     expect(elem.outerHTML).toMatchSnapshot();
   });
 
+  it('renders icons on the opposite side correctly', () => {
+    const elem = new IdsButton();
+    elem.id = 'test-button';
+    elem.icon = 'settings';
+    elem.iconAlign = 'end';
+    elem.text = 'Settings';
+    document.body.appendChild(elem);
+    elem.template();
+    expect(elem.outerHTML).toMatchSnapshot();
+  });
+
   it('exposes its inner button component', () => {
     expect(btn.button).toBeDefined();
     expect(btn.button instanceof HTMLElement).toBeTruthy();
@@ -198,6 +209,23 @@ describe('IdsButton Component', () => {
     expect(btn.querySelector('ids-icon')).toBe(null);
   });
 
+  it('can align its icon differently', () => {
+    btn.icon = 'settings';
+    btn.iconAlign = 'end';
+
+    expect(btn.button.classList.contains('align-icon-end')).toBeTruthy();
+
+    btn.iconAlign = 'start';
+
+    expect(btn.button.classList.contains('align-icon-start')).toBeTruthy();
+
+    // Can't set a bad one
+    btn.iconAlign = 'fish';
+
+    expect(btn.button.classList.contains('align-icon-start')).toBeTruthy();
+    expect(btn.button.classList.contains('align-icon-fish')).toBeFalsy();
+  });
+
   it('can be an "icon-only" button', () => {
     btn.icon = 'settings';
     btn.text = '';
@@ -216,6 +244,7 @@ describe('IdsButton Component', () => {
     btn.tabIndex = -1;
     btn.type = 'secondary';
     btn.cssClass = ['awesome'];
+    btn.iconAlign = 'end';
 
     expect(btn.text).toEqual('New');
   });

--- a/test/ids-button/ids-button-func-test.js
+++ b/test/ids-button/ids-button-func-test.js
@@ -65,48 +65,48 @@ describe('IdsButton Component', () => {
   });
 
   it('can be focusable or not', () => {
-    btn.tabindex = -1;
+    btn.tabIndex = -1;
 
     expect(btn.hasAttribute('tabindex')).toBeFalsy();
-    expect(btn.tabindex).toEqual(-1);
+    expect(btn.tabIndex).toEqual(-1);
     expect(btn.button.getAttribute('tabindex')).toEqual('-1');
-    expect(btn.state.tabindex).toEqual(-1);
+    expect(btn.state.tabIndex).toEqual(-1);
 
-    btn.tabindex = 0;
+    btn.tabIndex = 0;
 
     expect(btn.hasAttribute('tabindex')).toBeFalsy();
-    expect(btn.tabindex).toEqual(0);
+    expect(btn.tabIndex).toEqual(0);
     expect(btn.button.getAttribute('tabindex')).toEqual('0');
-    expect(btn.state.tabindex).toEqual(0);
+    expect(btn.state.tabIndex).toEqual(0);
 
-    btn.setAttribute('tabindex', '-1');
+    btn.setAttribute('tabIndex', '-1');
 
     expect(btn.hasAttribute('focusable')).toBeFalsy();
-    expect(btn.tabindex).toEqual(-1);
+    expect(btn.tabIndex).toEqual(-1);
     expect(btn.button.getAttribute('tabindex')).toEqual('-1');
-    expect(btn.state.tabindex).toEqual(-1);
+    expect(btn.state.tabIndex).toEqual(-1);
 
-    btn.setAttribute('tabindex', '0');
+    btn.setAttribute('tabIndex', '0');
 
     expect(btn.hasAttribute('tabindex')).toBeFalsy();
-    expect(btn.tabindex).toEqual(0);
+    expect(btn.tabIndex).toEqual(0);
     expect(btn.button.getAttribute('tabindex')).toEqual('0');
-    expect(btn.state.tabindex).toEqual(0);
+    expect(btn.state.tabIndex).toEqual(0);
 
     // Handles incorrect values
-    btn.tabindex = 'fish';
+    btn.tabIndex = 'fish';
 
     expect(btn.hasAttribute('tabindex')).toBeFalsy();
-    expect(btn.tabindex).toEqual(0);
-    expect(btn.button.hasAttribute('tabindex')).toBeFalsy();
-    expect(btn.state.tabindex).toEqual(0);
+    expect(btn.tabIndex).toEqual(0);
+    expect(btn.button.getAttribute('tabindex')).toEqual('0');
+    expect(btn.state.tabIndex).toEqual(0);
 
-    btn.tabindex = -2;
+    btn.tabIndex = -2;
 
     expect(btn.hasAttribute('tabindex')).toBeFalsy();
-    expect(btn.tabindex).toEqual(0);
-    expect(btn.button.hasAttribute('tabindex')).toBeFalsy();
-    expect(btn.state.tabindex).toEqual(0);
+    expect(btn.tabIndex).toEqual(0);
+    expect(btn.button.getAttribute('tabindex')).toEqual('0');
+    expect(btn.state.tabIndex).toEqual(0);
   });
 
   it('can add extra CSS classes to the button', () => {
@@ -213,7 +213,7 @@ describe('IdsButton Component', () => {
     btn.text = 'New';
     btn.icon = 'check';
     btn.disabled = true;
-    btn.tabindex = -1;
+    btn.tabIndex = -1;
     btn.type = 'secondary';
     btn.cssClass = ['awesome'];
 

--- a/test/ids-button/ids-button-func-test.js
+++ b/test/ids-button/ids-button-func-test.js
@@ -79,14 +79,14 @@ describe('IdsButton Component', () => {
     expect(btn.button.getAttribute('tabindex')).toEqual('0');
     expect(btn.state.tabIndex).toEqual(0);
 
-    btn.setAttribute('tabIndex', '-1');
+    btn.setAttribute('tabindex', '-1');
 
     expect(btn.hasAttribute('focusable')).toBeFalsy();
     expect(btn.tabIndex).toEqual(-1);
     expect(btn.button.getAttribute('tabindex')).toEqual('-1');
     expect(btn.state.tabIndex).toEqual(-1);
 
-    btn.setAttribute('tabIndex', '0');
+    btn.setAttribute('tabindex', '0');
 
     expect(btn.hasAttribute('tabindex')).toBeFalsy();
     expect(btn.tabIndex).toEqual(0);

--- a/test/ids-button/ids-button-func-test.js.snap
+++ b/test/ids-button/ids-button-func-test.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IdsButton Component renders correctly 1`] = `"<ids-button css-class=\\"test-class\\" icon=\\"add\\"><span>test</span><ids-icon slot=\\"icon\\" icon=\\"add\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;
+
+exports[`IdsButton Component renders icons on the opposite side correctly 1`] = `"<ids-button id=\\"test-button\\" icon=\\"settings\\"><span>Settings</span><ids-icon slot=\\"icon\\" icon=\\"settings\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR changes a couple minor things in IdsButton:
- Replaced the `setTimeout` in the ripple effect method to use IdsRenderLoop instead
- Code cleanup for property names (all now point to prop names in `src/ids-base/ids-constants.js`)
- Standardized `tabIndex` to be camelCase like the Button base prop, and linked it to `domUtils.isTrueBooleanAttribute()` for null/empty check.  Added this in menu to handle boolean attributes and it does [per the guidelines here](https://github.com/infor-design/enterprise-wc/blob/master/doc/COMPONENTS.md#boolean-attributes)
- Adds an `iconAlign` property/attribute that can be used to swap the location of a button's icon from `start` to `end` (left/right).  Adds supporting examples, tests, and docs for this feature.

**Related github/jira issue (required)**:
- Related to infor-design/enterprise#4390
- Follows Up: #12 

**Steps necessary to review your pull request (required)**:
- All tests should pass.
- Open http://localhost:4300/ids-button, pick a button, and try setting `tabIndex`, `type`, `disabled`, and `id` props.  Everything should work the same.
- Click/Key "Enter" on the button and ensure it still ripples
- Smoke test any components that extend `IdsButton` to make sure it all still works.
- Try the Toggle Button sample as well: http://localhost:4300/ids-toggle-button/icon-align-right
- Test Standalone CSS: http://localhost:4300/ids-button/standalone-css

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
