### PR TITLE
4815 - Improve tabbable option

### DIFF
--- a/app/ids-trigger-field/index.js
+++ b/app/ids-trigger-field/index.js
@@ -1,6 +1,1 @@
 import IdsTriggerField from '../../src/ids-trigger-field/ids-trigger-field';
-
-// Supporting components
-import IdsButton from '../../src/ids-button/ids-button';
-import IdsInput from '../../src/ids-input/ids-input';
-import IdsTriggerButton from '../../src/ids-trigger-button/ids-trigger-button';

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -25,6 +25,7 @@
   - Markup has changed to a custom element `<ids-input></ids-input>`
   - If using events, events are now plain JS events.
   - Can now be imported as a single JS file and used with encapsulated styles
+  - If using a clearable X on the input the x is now tabbable by default for accessibility
 - `[Loader]` The Busy Indicator component has been changed to a web component and renamed to ids-loader.
   - If using properties/settings these are now attributes: dismissible, color
   - Markup has changed to a custom element `<ids-loader></ids-loader>`
@@ -40,7 +41,7 @@
   - If using properties/settings, these are now attributes: x, y, align, alignX, alignY, alignEdge, alignTarget, animated, visible.
   - Popup is now driven by its own HTMLElement rather than a being a behavior applied to any element: `<ids-popup x="0" y="0" align="top, left">My Popup</ids-popup>`
   - Can now be imported as a single JS file and used with encapsulated styles
-- `[Popup Menu]` The Popup Menu is now a web component called ids-popup-menu.  
+- `[Popup Menu]` The Popup Menu is now a web component called ids-popup-menu.
   - Markup has been changed to a custom element `<ids-popup-menu></ids-popup-menu>`.
   - Events triggered by the Popup Menu are now plain JS (for example `selected`/`deselected`)
   - Selection of items is now divided up by Menu Groups `<ids-menu-group></ids-menu-group>`.  Multiple menu groups in each Popup Menu are supported, and selection in one group will not affect selection in other groups.

--- a/src/ids-base/ids-clearable-mixin.scss
+++ b/src/ids-base/ids-clearable-mixin.scss
@@ -2,8 +2,8 @@
 
 .ids-input-field {
   ~ .btn-clear {
-    margin-left: -28px;
-    margin-top: 10px;
+    margin-left: 1px;
+    margin-top: -24px;
     position: absolute;
 
     &.is-empty {
@@ -12,6 +12,8 @@
 
     [slot='icon'] {
       @include text-slate-60();
+
+      margin-left: -1px;
     }
 
     &:hover [slot='icon'] {

--- a/src/ids-base/ids-validation-mixin.js
+++ b/src/ids-base/ids-validation-mixin.js
@@ -12,10 +12,10 @@ const IdsValidationMixin = {
 
   // Icons
   VALIDATION_ICONS: {
-    alert: 'alert-solid',
-    error: 'error-solid',
-    info: 'info-solid',
-    success: 'success-solid',
+    alert: 'alert',
+    error: 'error',
+    info: 'info',
+    success: 'success',
   },
 
   /**

--- a/src/ids-trigger-button/ids-trigger-button.js
+++ b/src/ids-trigger-button/ids-trigger-button.js
@@ -5,6 +5,7 @@ import {
 
 // @ts-ignore
 import { IdsButton, BUTTON_PROPS } from '../ids-button/ids-button';
+import { IdsStringUtilsMixin as stringUtils } from '../ids-base/ids-string-utils-mixin';
 import { props } from '../ids-base/ids-constants';
 // @ts-ignore
 import styles from './ids-trigger-button.scss';
@@ -27,8 +28,22 @@ class IdsTriggerButton extends IdsButton {
    * @returns {Array} The properties in an array
    */
   static get properties() {
-    return BUTTON_PROPS.concat([props.DISABLE_EVENTS]);
+    return BUTTON_PROPS.concat([props.DISABLE_EVENTS, props.tabbable]);
   }
+
+  /**
+   * Set if the trigger field is tabbable
+   * @param {boolean|string} value True of false depending if the trigger field is tabbable
+   */
+  set tabbable(value) {
+    const isTabbable = stringUtils.stringToBool(value);
+    /** @type {any} */
+    const button = this.shadowRoot.querySelector('button');
+    this.setAttribute(props.TABBABLE, value.toString());
+    button.tabIndex = !isTabbable ? '-1' : '0';
+  }
+
+  get tabbable() { return this.getAttribute(props.TABBABLE) || true; }
 }
 
 export default IdsTriggerButton;

--- a/src/ids-trigger-button/ids-trigger-button.scss
+++ b/src/ids-trigger-button/ids-trigger-button.scss
@@ -2,14 +2,21 @@
 
 .ids-icon-button {
   @include bg-transparent();
-  @include border-0();
+  @include border-1();
+  @include border-transparent();
   @include cursor-pointer();
+  @include rounded-round();
   @include text-slate-60();
 
-  height: 20px;
+  height: 28px;
+  margin-left: -32px;
+  margin-top: 29px;
+  width: 28px;
 
   &:focus {
-    outline: none;
+    @include border-azure-70();
+    @include outline-none();
+    @include shadow();
   }
 
   &:hover {
@@ -19,5 +26,10 @@
   &[disabled] {
     @include cursor-default();
     @include text-slate-30();
+  }
+
+  ::slotted(ids-icon) {
+    margin-left: -2px;
+    margin-top: 3px;
   }
 }

--- a/src/ids-trigger-field/ids-trigger-field.js
+++ b/src/ids-trigger-field/ids-trigger-field.js
@@ -70,7 +70,7 @@ class IdsTriggerField extends IdsElement {
     button.tabbable = isTabbable;
   }
 
-  get tabbable() { return this.getAttribute(props.TABBABLE) || true; }
+  get tabbable() { return this.getAttribute(props.TABBABLE); }
 
   /**
    * Set the appearance of the trigger field

--- a/src/ids-trigger-field/ids-trigger-field.js
+++ b/src/ids-trigger-field/ids-trigger-field.js
@@ -12,6 +12,11 @@ import { IdsDomUtilsMixin } from '../ids-base/ids-dom-utils-mixin';
 // @ts-ignore
 import styles from './ids-trigger-field.scss';
 
+// Supporting components
+import IdsButton from '../ids-button/ids-button';
+import IdsInput from '../ids-input/ids-input';
+import IdsTriggerButton from '../ids-trigger-button/ids-trigger-button';
+
 /**
  * IDS Trigger Field Components
  */
@@ -59,10 +64,10 @@ class IdsTriggerField extends IdsElement {
     /** @type {any} */
     const button = this.querySelector('ids-trigger-button');
     this.setAttribute(props.TABBABLE, value.toString());
-    button.tabindex = !isTabbable ? '-1' : '0';
+    button.tabbable = isTabbable;
   }
 
-  get tabbable() { return this.getAttribute(props.TABBABLE); }
+  get tabbable() { return this.getAttribute(props.TABBABLE) || true; }
 
   /**
    * Set the appearance of the trigger field

--- a/src/ids-trigger-field/ids-trigger-field.js
+++ b/src/ids-trigger-field/ids-trigger-field.js
@@ -13,8 +13,11 @@ import { IdsDomUtilsMixin } from '../ids-base/ids-dom-utils-mixin';
 import styles from './ids-trigger-field.scss';
 
 // Supporting components
-import IdsButton from '../ids-button/ids-button';
+// @ts-ignore
+import { IdsButton } from '../ids-button/ids-button';
+// @ts-ignore
 import IdsInput from '../ids-input/ids-input';
+// @ts-ignore
 import IdsTriggerButton from '../ids-trigger-button/ids-trigger-button';
 
 /**

--- a/src/ids-trigger-field/ids-trigger-field.scss
+++ b/src/ids-trigger-field/ids-trigger-field.scss
@@ -13,8 +13,3 @@
 ::slotted(ids-input[size='full']) {
   width: 100%;
 }
-
-::slotted(ids-trigger-button) {
-  margin-left: -36px;
-  margin-top: 33px;
-}

--- a/test/ids-trigger-button/ids-trigger-button-test.js
+++ b/test/ids-trigger-button/ids-trigger-button-test.js
@@ -28,4 +28,21 @@ describe('IdsTriggerButton Component', () => {
   it('renders correctly', () => {
     expect(triggerButton.outerHTML).toMatchSnapshot();
   });
+
+  it('defaults tabbable to true', () => {
+    triggerButton.removeAttribute('tabbable');
+    expect(triggerButton.tabbable).toEqual(true);
+  });
+
+  it('supports tabbable', () => {
+    triggerButton.tabbable = true;
+
+    expect(triggerButton.shadowRoot.querySelector('button').getAttribute('tabindex')).toEqual('0');
+    expect(triggerButton.tabbable).toEqual('true');
+
+    triggerButton.tabbable = false;
+
+    expect(triggerButton.shadowRoot.querySelector('button').getAttribute('tabindex')).toEqual('-1');
+    expect(triggerButton.tabbable).toEqual('false');
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Looked over the tabbable options on clear an trigger fields. Also changed the validation icon to the newer icons as was intended but we never did it. It also looks better (i think anyways)

**Related github/jira issue (required)**:
Adds some work on #4815 to WC

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-input
- go to the clearable example and type something and then tab
- go to http://localhost:4300/ids-trigger-field
- tab through the fields - the first trigger is NOT tabbable the rest are so you should hit the trigger button on the last two fields

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
