### PR TITLE
Implement Ids Toolbar / Enable usage of Ids Menu Button in shadow root

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,8 @@ module.exports = {
     quotes: ['error', 'single', { allowTemplateLiterals: true }],
     // Allow Arrow functions to be on the next line or below
     'no-useless-constructor': ['off', { }],
+    // Allow assignment of properties from items in `forEach` loops
+    'no-param-reassign': ['error', { props: false }],
     // Allow hasOwnProperty
     'no-prototype-builtins': ['off', { }],
     // Allow functions with no this in them

--- a/app/ids-toolbar/centered.html
+++ b/app/ids-toolbar/centered.html
@@ -1,0 +1,45 @@
+{{> ../layouts/head.html }}
+
+<ids-layout-grid>
+  <ids-text font-size="12" type="h1">Toolbar (Centered)</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-column auto="true">
+
+    <ids-toolbar>
+      <ids-toolbar-section>
+        <ids-button icon="menu" role="button">
+          <span slot="text" class="audible">Application Menu Trigger</span>
+        </ids-button>
+      </ids-toolbar-section>
+
+      <ids-toolbar-section type="buttonset" align="center">
+        <ids-button id="button-1" role="button">
+          <span class="audible" slot="text">About Infor</span>
+          <ids-icon slot="icon" icon="logo"></ids-icon>
+        </ids-button>
+      </ids-toolbar-section>
+
+      <ids-toolbar-more-actions>
+        <ids-menu-group>
+          <ids-menu-item value="1">Option One</ids-menu-item>
+          <ids-menu-item value="2">Option Two</ids-menu-item>
+          <ids-menu-item value="3">Option Three</ids-menu-item>
+          <ids-menu-item>More Options
+            <ids-popup-menu>
+              <ids-menu-group>
+                <ids-menu-item value="4">Option Four</ids-menu-item>
+                <ids-menu-item value="5">Option Five</ids-menu-item>
+                <ids-menu-item value="6">Option Six</ids-menu-item>
+              </ids-menu-group>
+            </ids-popup-menu>
+          </ids-menu-item>
+        </ids-menu-group>
+      </ids-toolbar-more-actions>
+    </ids-toolbar>
+
+  </ids-layout-grid-column>
+</ids-layout-grid>
+
+{{> ../layouts/footer.html }}

--- a/app/ids-toolbar/disabled.html
+++ b/app/ids-toolbar/disabled.html
@@ -1,11 +1,13 @@
+{{> ../layouts/head.html }}
+
 <ids-layout-grid>
-  <ids-text font-size="12" type="h1">Toolbar</ids-text>
+  <ids-text font-size="12" type="h1">Toolbar (Disabled)</ids-text>
 </ids-layout-grid>
 
 <ids-layout-grid>
   <ids-layout-grid-column auto="true">
 
-    <ids-toolbar>
+    <ids-toolbar disabled="true">
       <ids-toolbar-section>
         <ids-button icon="menu" role="button">
           <span slot="text" class="audible">Application Menu Trigger</span>
@@ -71,3 +73,5 @@
 
   </ids-layout-grid-column>
 </ids-layout-grid>
+
+{{> ../layouts/footer.html }}

--- a/app/ids-toolbar/example.html
+++ b/app/ids-toolbar/example.html
@@ -1,0 +1,15 @@
+<ids-toolbar>
+  <ids-toolbar-section>
+    <ids-button id="button-1">
+      <span slot="text">Button 1</span>
+    </ids-button>
+    <ids-button id="button-2">
+      <span slot="text">Button 2</span>
+    </ids-button>
+  </ids-toolbar-section>
+  <ids-toolbar-section align="right">
+    <ids-button id="button-3">
+      <span slot="text">Button 3</span>
+    </ids-button>
+  </ids-toolbar-section>
+</ids-toolbar>

--- a/app/ids-toolbar/example.html
+++ b/app/ids-toolbar/example.html
@@ -1,5 +1,11 @@
 <ids-toolbar>
   <ids-toolbar-section>
+    <ids-button icon="menu"></ids-button>
+  </ids-toolbar-section>
+  <ids-toolbar-section type="fluid">
+    <ids-text type="h3">My Toolbar</ids-text>
+  </ids-toolbar-section>
+  <ids-toolbar-section>
     <ids-button id="button-1">
       <span slot="text">Button 1</span>
     </ids-button>

--- a/app/ids-toolbar/example.html
+++ b/app/ids-toolbar/example.html
@@ -50,7 +50,22 @@
         </ids-button>
       </ids-toolbar-section>
 
-      <ids-toolbar-more-actions></ids-toolbar-more-actions>
+      <ids-toolbar-more-actions>
+        <ids-menu-group>
+          <ids-menu-item value="1">Option One</ids-menu-item>
+          <ids-menu-item value="2">Option Two</ids-menu-item>
+          <ids-menu-item value="3">Option Three</ids-menu-item>
+          <ids-menu-item>More Options
+            <ids-popup-menu>
+              <ids-menu-group>
+                <ids-menu-item value="4">Option Four</ids-menu-item>
+                <ids-menu-item value="5">Option Five</ids-menu-item>
+                <ids-menu-item value="6">Option Six</ids-menu-item>
+              </ids-menu-group>
+            </ids-popup-menu>
+          </ids-menu-item>
+        </ids-menu-group>
+      </ids-toolbar-more-actions>
     </ids-toolbar>
 
   </ids-layout-grid-column>

--- a/app/ids-toolbar/example.html
+++ b/app/ids-toolbar/example.html
@@ -7,24 +7,35 @@
 
     <ids-toolbar>
       <ids-toolbar-section>
-        <ids-button icon="menu"></ids-button>
+        <ids-button icon="menu" role="button">
+          <span slot="text" class="audible">Application Menu Trigger</span>
+        </ids-button>
       </ids-toolbar-section>
       <ids-toolbar-section type="title">
         <ids-text type="h3">My Toolbar</ids-text>
       </ids-toolbar-section>
       <ids-toolbar-section type="buttonset" align="end">
-        <ids-button id="button-1">
-          <span slot="text">Button 1</span>
+        <ids-button id="button-1" role="button">
+          <span slot="text">Text</span>
         </ids-button>
 
-        <ids-menu-button id="button-2" menu="button-2-menu" dropdown-icon>
-          <span slot="text">Button 2</span>
+        <ids-menu-button role="button" id="button-2" menu="button-2-menu" dropdown-icon>
+          <span slot="text">Menu</span>
         </ids-menu-button>
         <ids-popup-menu id="button-2-menu" target="#button-2">
           <ids-menu-group>
             <ids-menu-item value="1">Item One</ids-menu-item>
             <ids-menu-item value="2">Item Two</ids-menu-item>
             <ids-menu-item value="3">Item Three</ids-menu-item>
+            <ids-menu-item>More Items
+              <ids-popup-menu>
+                <ids-menu-group>
+                  <ids-menu-item value="4">Item Four</ids-menu-item>
+                  <ids-menu-item value="4">Item Five</ids-menu-item>
+                  <ids-menu-item value="4">Item Six</ids-menu-item>
+                </ids-menu-group>
+              </ids-popup-menu>
+            </ids-menu-item>
           </ids-menu-group>
         </ids-popup-menu>
 

--- a/app/ids-toolbar/example.html
+++ b/app/ids-toolbar/example.html
@@ -2,20 +2,35 @@
   <ids-toolbar-section>
     <ids-button icon="menu"></ids-button>
   </ids-toolbar-section>
-  <ids-toolbar-section type="fluid">
+  <ids-toolbar-section type="title">
     <ids-text type="h3">My Toolbar</ids-text>
   </ids-toolbar-section>
-  <ids-toolbar-section>
+  <ids-toolbar-section type="buttonset">
     <ids-button id="button-1">
       <span slot="text">Button 1</span>
     </ids-button>
     <ids-button id="button-2">
       <span slot="text">Button 2</span>
     </ids-button>
-  </ids-toolbar-section>
-  <ids-toolbar-section align="right">
     <ids-button id="button-3">
       <span slot="text">Button 3</span>
     </ids-button>
   </ids-toolbar-section>
+  <ids-toolbar-more-actions></ids-toolbar-more-actions>
+
+  <!--
+  <ids-toolbar-section>
+    <ids-menu-button id="icon-button" menu="icon-menu">
+      <ids-icon slot="icon" icon="more"></ids-icon>
+      <span class="audible">More Actions Button</span>
+    </ids-menu-button>
+    <ids-popup-menu id="icon-menu" target="icon-button" trigger="click">
+      <ids-menu-group>
+        <ids-menu-item>Option One</ids-menu-item>
+        <ids-menu-item>Option Two</ids-menu-item>
+        <ids-menu-item>Option Three</ids-menu-item>
+      </ids-menu-group>
+    </ids-popup-menu>
+  </ids-toolbar-section>
+  -->
 </ids-toolbar>

--- a/app/ids-toolbar/example.html
+++ b/app/ids-toolbar/example.html
@@ -5,32 +5,32 @@
   <ids-toolbar-section type="title">
     <ids-text type="h3">My Toolbar</ids-text>
   </ids-toolbar-section>
-  <ids-toolbar-section type="buttonset">
+  <ids-toolbar-section type="buttonset" align="end">
     <ids-button id="button-1">
       <span slot="text">Button 1</span>
     </ids-button>
-    <ids-button id="button-2">
-      <span slot="text">Button 2</span>
-    </ids-button>
-    <ids-button id="button-3">
-      <span slot="text">Button 3</span>
-    </ids-button>
-  </ids-toolbar-section>
-  <ids-toolbar-more-actions></ids-toolbar-more-actions>
 
-  <!--
-  <ids-toolbar-section>
-    <ids-menu-button id="icon-button" menu="icon-menu">
-      <ids-icon slot="icon" icon="more"></ids-icon>
-      <span class="audible">More Actions Button</span>
+    <ids-menu-button id="button-2" menu="button-2-menu" dropdown-icon>
+      <span slot="text">Button 2</span>
     </ids-menu-button>
-    <ids-popup-menu id="icon-menu" target="icon-button" trigger="click">
+    <ids-popup-menu id="button-2-menu" target="#button-2">
       <ids-menu-group>
-        <ids-menu-item>Option One</ids-menu-item>
-        <ids-menu-item>Option Two</ids-menu-item>
-        <ids-menu-item>Option Three</ids-menu-item>
+        <ids-menu-item value="1">Item One</ids-menu-item>
+        <ids-menu-item value="2">Item Two</ids-menu-item>
+        <ids-menu-item value="3">Item Three</ids-menu-item>
       </ids-menu-group>
     </ids-popup-menu>
+
+    <ids-button id="button-3" disabled>
+      <span slot="text" class="audible">Settings</span>
+      <ids-icon slot="icon" icon="settings"></ids-icon>
+    </ids-button>
+
+    <ids-button id="button-4">
+      <span slot="text" class="audible">Trash</span>
+      <ids-icon slot="icon" icon="delete"></ids-icon>
+    </ids-button>
   </ids-toolbar-section>
-  -->
+
+  <ids-toolbar-more-actions></ids-toolbar-more-actions>
 </ids-toolbar>

--- a/app/ids-toolbar/example.html
+++ b/app/ids-toolbar/example.html
@@ -1,36 +1,46 @@
-<ids-toolbar>
-  <ids-toolbar-section>
-    <ids-button icon="menu"></ids-button>
-  </ids-toolbar-section>
-  <ids-toolbar-section type="title">
-    <ids-text type="h3">My Toolbar</ids-text>
-  </ids-toolbar-section>
-  <ids-toolbar-section type="buttonset" align="end">
-    <ids-button id="button-1">
-      <span slot="text">Button 1</span>
-    </ids-button>
+<ids-layout-grid>
+  <ids-text font-size="12" type="h1">Toolbar</ids-text>
+</ids-layout-grid>
 
-    <ids-menu-button id="button-2" menu="button-2-menu" dropdown-icon>
-      <span slot="text">Button 2</span>
-    </ids-menu-button>
-    <ids-popup-menu id="button-2-menu" target="#button-2">
-      <ids-menu-group>
-        <ids-menu-item value="1">Item One</ids-menu-item>
-        <ids-menu-item value="2">Item Two</ids-menu-item>
-        <ids-menu-item value="3">Item Three</ids-menu-item>
-      </ids-menu-group>
-    </ids-popup-menu>
+<ids-layout-grid>
+  <ids-layout-grid-column auto="true">
 
-    <ids-button id="button-3" disabled>
-      <span slot="text" class="audible">Settings</span>
-      <ids-icon slot="icon" icon="settings"></ids-icon>
-    </ids-button>
+    <ids-toolbar>
+      <ids-toolbar-section>
+        <ids-button icon="menu"></ids-button>
+      </ids-toolbar-section>
+      <ids-toolbar-section type="title">
+        <ids-text type="h3">My Toolbar</ids-text>
+      </ids-toolbar-section>
+      <ids-toolbar-section type="buttonset" align="end">
+        <ids-button id="button-1">
+          <span slot="text">Button 1</span>
+        </ids-button>
 
-    <ids-button id="button-4">
-      <span slot="text" class="audible">Trash</span>
-      <ids-icon slot="icon" icon="delete"></ids-icon>
-    </ids-button>
-  </ids-toolbar-section>
+        <ids-menu-button id="button-2" menu="button-2-menu" dropdown-icon>
+          <span slot="text">Button 2</span>
+        </ids-menu-button>
+        <ids-popup-menu id="button-2-menu" target="#button-2">
+          <ids-menu-group>
+            <ids-menu-item value="1">Item One</ids-menu-item>
+            <ids-menu-item value="2">Item Two</ids-menu-item>
+            <ids-menu-item value="3">Item Three</ids-menu-item>
+          </ids-menu-group>
+        </ids-popup-menu>
 
-  <ids-toolbar-more-actions></ids-toolbar-more-actions>
-</ids-toolbar>
+        <ids-button id="button-3" disabled>
+          <span slot="text" class="audible">Settings</span>
+          <ids-icon slot="icon" icon="settings"></ids-icon>
+        </ids-button>
+
+        <ids-button id="button-4">
+          <span slot="text" class="audible">Trash</span>
+          <ids-icon slot="icon" icon="delete"></ids-icon>
+        </ids-button>
+      </ids-toolbar-section>
+
+      <ids-toolbar-more-actions></ids-toolbar-more-actions>
+    </ids-toolbar>
+
+  </ids-layout-grid-column>
+</ids-layout-grid>

--- a/app/ids-toolbar/example.js
+++ b/app/ids-toolbar/example.js
@@ -1,0 +1,11 @@
+// Supporting components
+import IdsButton from '../../src/ids-button/ids-button';
+import IdsInput from '../../src/ids-input/ids-input';
+import IdsMenuButton from '../../src/ids-menu-button/ids-menu-button';
+import IdsPopupMenu, {
+  IdsMenuGroup,
+  IdsMenuItem,
+  IdsMenuHeader,
+  IdsSeparator
+} from '../../src/ids-popup-menu/ids-popup-menu';
+import IdsText from '../../src/ids-text/ids-text';

--- a/app/ids-toolbar/index.html
+++ b/app/ids-toolbar/index.html
@@ -1,0 +1,3 @@
+{{> ../layouts/head.html }}
+{{> example.html }}
+{{> ../layouts/footer.html }}

--- a/app/ids-toolbar/index.js
+++ b/app/ids-toolbar/index.js
@@ -1,10 +1,12 @@
 import IdsToolbar, {
-  IdsToolbarSection
+  IdsToolbarSection,
+  IdsToolbarMoreActions
 } from '../../src/ids-toolbar/ids-toolbar';
 
 // Supporting components
 import IdsButton from '../../src/ids-button/ids-button';
 import IdsInput from '../../src/ids-input/ids-input';
+import IdsMenuButton from '../../src/ids-menu-button/ids-menu-button';
 import IdsPopupMenu, {
   IdsMenuGroup,
   IdsMenuItem,

--- a/app/ids-toolbar/index.js
+++ b/app/ids-toolbar/index.js
@@ -2,15 +2,3 @@ import IdsToolbar, {
   IdsToolbarSection,
   IdsToolbarMoreActions
 } from '../../src/ids-toolbar/ids-toolbar';
-
-// Supporting components
-import IdsButton from '../../src/ids-button/ids-button';
-import IdsInput from '../../src/ids-input/ids-input';
-import IdsMenuButton from '../../src/ids-menu-button/ids-menu-button';
-import IdsPopupMenu, {
-  IdsMenuGroup,
-  IdsMenuItem,
-  IdsMenuHeader,
-  IdsSeparator
-} from '../../src/ids-popup-menu/ids-popup-menu';
-import IdsText from '../../src/ids-text/ids-text';

--- a/app/ids-toolbar/index.js
+++ b/app/ids-toolbar/index.js
@@ -11,3 +11,4 @@ import IdsPopupMenu, {
   IdsMenuHeader,
   IdsSeparator
 } from '../../src/ids-popup-menu/ids-popup-menu';
+import IdsText from '../../src/ids-text/ids-text';

--- a/app/ids-toolbar/index.js
+++ b/app/ids-toolbar/index.js
@@ -1,0 +1,13 @@
+import IdsToolbar, {
+  IdsToolbarSection
+} from '../../src/ids-toolbar/ids-toolbar';
+
+// Supporting components
+import IdsButton from '../../src/ids-button/ids-button';
+import IdsInput from '../../src/ids-input/ids-input';
+import IdsPopupMenu, {
+  IdsMenuGroup,
+  IdsMenuItem,
+  IdsMenuHeader,
+  IdsSeparator
+} from '../../src/ids-popup-menu/ids-popup-menu';

--- a/app/ids-toolbar/no-eyebrow.html
+++ b/app/ids-toolbar/no-eyebrow.html
@@ -1,5 +1,7 @@
+{{> ../layouts/head.html }}
+
 <ids-layout-grid>
-  <ids-text font-size="12" type="h1">Toolbar</ids-text>
+  <ids-text font-size="12" type="h1">Toolbar (with no Title Eyebrow)</ids-text>
 </ids-layout-grid>
 
 <ids-layout-grid>
@@ -13,7 +15,6 @@
       </ids-toolbar-section>
       <ids-toolbar-section type="title">
         <ids-text font-size="20">My Toolbar</ids-text>
-        <ids-text font-size="14">With some extra information below</ids-text>
       </ids-toolbar-section>
       <ids-toolbar-section type="buttonset" align="end">
         <ids-button id="button-1" role="button">
@@ -71,3 +72,5 @@
 
   </ids-layout-grid-column>
 </ids-layout-grid>
+
+{{> ../layouts/footer.html }}

--- a/app/ids-toolbar/standalone-css.html
+++ b/app/ids-toolbar/standalone-css.html
@@ -1,4 +1,4 @@
-{{> ../layouts/head.html }}
+{{> ../layouts/head-visible.html }}
 
 <link rel="stylesheet" href="ids-toolbar.css" />
 <link rel="stylesheet" href="../ids-toolbar-section/ids-toolbar-section.css" />
@@ -11,42 +11,72 @@
 <link rel="stylesheet" href="../ids-separator/ids-separator.css" />
 <link rel="stylesheet" href="../ids-layout-grid/ids-layout-grid.css" />
 <link rel="stylesheet" href="../ids-text/ids-text.css" />
-<link rel="stylesheet" href="../ids-loader/ids-loader.css" />
 
 <div class="ids-layout-grid">
-  <h1 class="ids-text ids-text-12">Popup Menu Standalone CSS</h1>
+  <h1 class="ids-text ids-text-12">Toolbar Standalone CSS</h1>
 </div>
 
-<div class="ids-toolbar">
-  <div class="ids-toolbar-section">
-    <button class="ids-icon-button">
-      <span class="audible">Application Menu</span>
-      <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18"
-        focusable="false" aria-hidden="true" role="presentation">
-        <path d="M0 2.5h18m-18 12h18m-18-6h18" stroke="currentColor" fill="none" fill-rule="evenodd"
-          vector-effect="non-scaling-stroke"></path>
-      </svg>
-    </button>
-  </div>
+<div class="ids-layout-grid">
+  <div class="ids-toolbar">
+    <div class="ids-toolbar-section static">
+      <button class="ids-icon-button">
+        <span class="audible">Application Menu</span>
+        <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18"
+          focusable="false" aria-hidden="true" role="presentation">
+          <path d="M0 2.5h18m-18 12h18m-18-6h18" stroke="currentColor" fill="none" fill-rule="evenodd"
+            vector-effect="non-scaling-stroke"></path>
+        </svg>
+      </button>
+    </div>
 
-  <div class="ids-toolbar-section fluid">
-    <h3 class="ids-text ids-text-36">My Toolbar</h3>
-  </div>
+    <div class="ids-toolbar-section title">
+      <h3 class="ids-text ids-text-36">My Toolbar</h3>
+    </div>
 
-  <div class="ids-toolbar-section">
-    <button id="button-1" class="ids-button">
-      <span>Button 1</span>
-    </button>
+    <div class="ids-toolbar-section buttonset align-end">
+      <button id="button-1" class="ids-button">
+        <span>Text</span>
+      </button>
 
-    <button id="button-2" class="ids-button">
-      <span>Button 2</span>
-    </button>
-  </div>
+      <button id="button-2" class="ids-button">
+        <span>Menu</span>
+        <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+          viewBox="0 0 18 18" focusable="false" aria-hidden="true" role="presentation">
+          <path d="M4 6l5 6 5-6H4" fill="currentColor" fill-rule="evenodd" stroke="none"></path>
+        </svg>
+      </button>
 
-  <div class="ids-toolbar-section align-end">
-    <button id="button-3" class="ids-button">
-      <span>Button 3</span>
-    </button>
+      <button id="button-3" class="ids-icon-button" disabled>
+        <span class="audible">Settings</span>
+        <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+          viewBox="0 0 18 18" focusable="false" aria-hidden="true" role="presentation">
+          <path
+            d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z"
+            stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+        </svg>
+      </button>
+
+      <button id="button-4" class="ids-icon-button">
+        <span class="audible">Trash</span>
+        <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+          viewBox="0 0 18 18" focusable="false" aria-hidden="true" role="presentation">
+          <path d="M1.5 2.5l2 15H10c2.66 0 5.01-1.805 5.25-4.5L16.5 2.5h-15zM0 2.5h18m-12.5 0v-2h7v2" stroke="currentColor"
+            fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+        </svg>
+      </button>
+    </div>
+
+    <div class="ids-toolbar-section ids-toolbar-section-more more">
+      <button class="ids-icon-button">
+        <span class="audible">More Actions</span>
+        <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+          viewBox="0 0 18 18" focusable="false" aria-hidden="true" role="presentation">
+          <path
+            d="M16.5 7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM9 7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM1.5 7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z"
+            fill="currentColor" fill-rule="evenodd" stroke="none"></path>
+        </svg>
+      </button>
+    </div>
   </div>
 </div>
 

--- a/app/ids-toolbar/standalone-css.html
+++ b/app/ids-toolbar/standalone-css.html
@@ -1,0 +1,53 @@
+{{> ../layouts/head.html }}
+
+<link rel="stylesheet" href="ids-toolbar.css" />
+<link rel="stylesheet" href="../ids-toolbar-section/ids-toolbar-section.css" />
+<link rel="stylesheet" href="../ids-button/ids-button.css" />
+<link rel="stylesheet" href="../ids-popup-menu/ids-popup-menu.css" />
+<link rel="stylesheet" href="../ids-popup/ids-popup.css" />
+<link rel="stylesheet" href="../ids-menu-group/ids-menu-group.css" />
+<link rel="stylesheet" href="../ids-menu-header/ids-menu-header.css" />
+<link rel="stylesheet" href="../ids-menu-item/ids-menu-item.css" />
+<link rel="stylesheet" href="../ids-separator/ids-separator.css" />
+<link rel="stylesheet" href="../ids-layout-grid/ids-layout-grid.css" />
+<link rel="stylesheet" href="../ids-text/ids-text.css" />
+<link rel="stylesheet" href="../ids-loader/ids-loader.css" />
+
+<div class="ids-layout-grid">
+  <h1 class="ids-text ids-text-12">Popup Menu Standalone CSS</h1>
+</div>
+
+<div class="ids-toolbar">
+  <div class="ids-toolbar-section">
+    <button class="ids-icon-button">
+      <span class="audible">Application Menu</span>
+      <svg class="ids-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18"
+        focusable="false" aria-hidden="true" role="presentation">
+        <path d="M0 2.5h18m-18 12h18m-18-6h18" stroke="currentColor" fill="none" fill-rule="evenodd"
+          vector-effect="non-scaling-stroke"></path>
+      </svg>
+    </button>
+  </div>
+
+  <div class="ids-toolbar-section fluid">
+    <h3 class="ids-text ids-text-36">My Toolbar</h3>
+  </div>
+
+  <div class="ids-toolbar-section">
+    <button id="button-1" class="ids-button">
+      <span>Button 1</span>
+    </button>
+
+    <button id="button-2" class="ids-button">
+      <span>Button 2</span>
+    </button>
+  </div>
+
+  <div class="ids-toolbar-section align-end">
+    <button id="button-3" class="ids-button">
+      <span>Button 3</span>
+    </button>
+  </div>
+</div>
+
+{{> ../layouts/footer.html }}

--- a/app/ids-toolbar/standalone-css.html
+++ b/app/ids-toolbar/standalone-css.html
@@ -30,7 +30,8 @@
     </div>
 
     <div class="ids-toolbar-section title">
-      <h3 class="ids-text ids-text-36">My Toolbar</h3>
+      <span class="ids-text ids-text-20">My Toolbar</span>
+      <span class="ids-text ids-text-14">With some extra information below</span>
     </div>
 
     <div class="ids-toolbar-section buttonset align-end">

--- a/app/ids-toolbar/tabbable.html
+++ b/app/ids-toolbar/tabbable.html
@@ -1,11 +1,19 @@
+{{> ../layouts/head.html }}
+
 <ids-layout-grid>
-  <ids-text font-size="12" type="h1">Toolbar</ids-text>
+  <ids-text font-size="12" type="h1">Toolbar (Tabbable)</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-text>This Toolbar's items can be navigated with the Tab/Shift+Tab keys</ids-text>
+  </ids-layout-grid-cell>
 </ids-layout-grid>
 
 <ids-layout-grid>
   <ids-layout-grid-column auto="true">
 
-    <ids-toolbar>
+    <ids-toolbar tabbable="true">
       <ids-toolbar-section>
         <ids-button icon="menu" role="button">
           <span slot="text" class="audible">Application Menu Trigger</span>
@@ -71,3 +79,5 @@
 
   </ids-layout-grid-column>
 </ids-layout-grid>
+
+{{> ../layouts/footer.html }}

--- a/app/index.html
+++ b/app/index.html
@@ -14,6 +14,7 @@
 {{> ids-upload/example.html }}
 {{> ids-textarea/example.html }}
 {{> ids-popup/example.html }}
+{{> ids-toolbar/example.html }}
 {{> ids-layout-grid/example.html }}
 {{> ids-trigger-field/example.html }}
 {{> ids-expandable-area/example.html }}

--- a/app/index.js
+++ b/app/index.js
@@ -8,6 +8,7 @@ import IdsMenuButton from '../src/ids-menu-button/ids-menu-button';
 import IdsText from '../src/ids-text/ids-text';
 import IdsIcon from '../src/ids-icon/ids-icon';
 import IdsPopup from '../src/ids-popup/ids-popup';
+import IdsToolbar from '../src/ids-toolbar/ids-toolbar';
 import IdsTag from '../src/ids-tag/ids-tag';
 import IdsLayoutGrid from '../src/ids-layout-grid/ids-layout-grid';
 import IdsLayoutGridCell from '../src/ids-layout-grid/ids-layout-grid-cell';

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -67,6 +67,12 @@
   - If using properties/settings these are now attributes: dismissible, color
   - Markup has changed to a custom element `<ids-tag color="error">Text</ids-tag>`
   - Can now be imported as a single JS file and used with encapsulated styles
+- `[Toolbar]` The Toolbar component has been changed to a web component.
+  - Markup is now a custom element `<ids-toolbar></ids-toolbar>`
+  - There is no longer a "Toolbar Item" component, instead use standard components directly.
+  - Toolbar Sections are now codified as components `<ids-toolbar-section>`
+  - The More Actions Button is now a codified component `<ids-toolbar-more-actions>`
+  - Toolbar can be tabbable or not
 - `[Upload]` The file upload component has been changed to a web component and renamed to ids-upload.
   - Markup has changed to a custom element `<ids-upload></ids-upload>`
   - If using events, events are now plain JS events.

--- a/doc/CHECKLIST.md
+++ b/doc/CHECKLIST.md
@@ -906,13 +906,13 @@ Will make a pager type for this.
  - [ ] Works in Page with 4.x
 
 **Toolbar** (ids-toolbar)
- - [ ] Docs
- - [ ] 100% Test Coverage
+ - [x] Docs
+ - [x] 100% Test Coverage
  - [ ] Feature Parity with 4.x
- - [ ] Upgrade Docs in Changelog
- - [ ] Typings
+ - [x] Upgrade Docs in Changelog
+ - [x] Typings
  - [ ] NG / Vue / React Example
- - [ ] Standalone Css
+ - [x] Standalone Css
  - [ ] Works in Page with 4.x
 
 **Tooltip** (ids-tooltip)

--- a/src/ids-base/ids-dom-utils.d.ts
+++ b/src/ids-base/ids-dom-utils.d.ts
@@ -1,0 +1,16 @@
+declare const IdsDOMUtils: {
+  /** Returns the closest Shadow Root to the provided element, if applicable */
+  getClosestShadow(node: HTMLElement): Node | undefined;
+
+  /** Used specifically to detect the closest Shadow Root container OR `document`. */
+  getClosestContainerNode(node: HTMLElement): Node;
+
+  /**
+   * Returns the closest Root Node parent of a provided element.  If the provided element is inside
+   * a Shadow Root, that Shadow Root's host's parentNode is provided. `document` is used as a
+   * fallback. This method allows for `querySelector()` in some nested Shadow Roots to work properly
+   */
+  getClosestRootNode(node: HTMLElement): Node;
+};
+
+export default IdsDOMUtils;

--- a/src/ids-base/ids-dom-utils.js
+++ b/src/ids-base/ids-dom-utils.js
@@ -20,8 +20,8 @@ const IdsDOMUtils = {
 
   /**
    * Returns the closest Shadow Root, if the provided node is contained by one.
-   * @param {Node} node the node to check
-   * @returns {Node|undefined} the node.
+   * @param {*} node the node to check
+   * @returns {*} the node.
    */
   getClosestShadow(node) {
     /** @type {any} */
@@ -36,11 +36,20 @@ const IdsDOMUtils = {
   },
 
   /**
+   * Used specifically to detect the closest Shadow Root container OR `document`.
+   * @param {*} node the node to check
+   * @returns {Node} the parent node
+   */
+  getClosestContainerNode(node) {
+    return IdsDOMUtils.getClosestShadow(node) || document;
+  },
+
+  /**
    * Returns the closest Root Node parent of a provided element.  If the provided element is inside
-   * a Shadow Root, that Shadow Root's host's parentNode is provided. `document` is used as a fallback.
-   * This method allows for `querySelector()` in some nested Shadow Roots to work properly.
-   * @param {Node} node the node to check
-   * @returns {Node} the node.
+   * a Shadow Root, that Shadow Root's host's parentNode is provided. `document` is used as a
+   * fallback. This method allows for `querySelector()` in some nested Shadow Roots to work properly
+   * @param {*} node the node to check
+   * @returns {Node} the parent node.
    */
   getClosestRootNode(node) {
     return IdsDOMUtils.getClosestShadow(node)?.host?.parentNode || document;

--- a/src/ids-base/ids-dom-utils.js
+++ b/src/ids-base/ids-dom-utils.js
@@ -1,0 +1,50 @@
+/**
+ * Ids DOM Utils
+ */
+const IdsDOMUtils = {
+  /**
+   * Determines if a Node reference is currently contained within a Shadow Root.
+   * @param {Node} node the node to check
+   * @returns {boolean} true if the element is contained by a Shadow Root.
+   */
+  isInShadow(node) {
+    let parent = (node && node.parentNode);
+    while (parent) {
+      if (parent.toString() === '[object ShadowRoot]') {
+        return true;
+      }
+      parent = parent.parentNode;
+    }
+    return false;
+  },
+
+  /**
+   * Returns the closest Shadow Root, if the provided node is contained by one.
+   * @param {Node} node the node to check
+   * @returns {Node|undefined} the node.
+   */
+  getClosestShadow(node) {
+    /** @type {any} */
+    let parent = (node && node.parentNode);
+    while (parent) {
+      if (parent.toString() === '[object ShadowRoot]') {
+        return parent;
+      }
+      parent = parent.parentNode;
+    }
+    return undefined;
+  },
+
+  /**
+   * Returns the closest Root Node parent of a provided element.  If the provided element is inside
+   * a Shadow Root, that Shadow Root's host's parentNode is provided. `document` is used as a fallback.
+   * This method allows for `querySelector()` in some nested Shadow Roots to work properly.
+   * @param {Node} node the node to check
+   * @returns {Node} the node.
+   */
+  getClosestRootNode(node) {
+    return IdsDOMUtils.getClosestShadow(node)?.host?.parentNode || document;
+  }
+};
+
+export default IdsDOMUtils;

--- a/src/ids-base/ids-dom-utils.js
+++ b/src/ids-base/ids-dom-utils.js
@@ -3,22 +3,6 @@
  */
 const IdsDOMUtils = {
   /**
-   * Determines if a Node reference is currently contained within a Shadow Root.
-   * @param {Node} node the node to check
-   * @returns {boolean} true if the element is contained by a Shadow Root.
-   */
-  isInShadow(node) {
-    let parent = (node && node.parentNode);
-    while (parent) {
-      if (parent.toString() === '[object ShadowRoot]') {
-        return true;
-      }
-      parent = parent.parentNode;
-    }
-    return false;
-  },
-
-  /**
    * Returns the closest Shadow Root, if the provided node is contained by one.
    * @param {*} node the node to check
    * @returns {*} the node.

--- a/src/ids-base/ids-dom-utils.js
+++ b/src/ids-base/ids-dom-utils.js
@@ -4,8 +4,8 @@
 const IdsDOMUtils = {
   /**
    * Returns the closest Shadow Root, if the provided node is contained by one.
-   * @param {*} node the node to check
-   * @returns {*} the node.
+   * @param {HTMLElement} node the node to check
+   * @returns {ShadowRoot|undefined} the node.
    */
   getClosestShadow(node) {
     /** @type {any} */
@@ -21,7 +21,7 @@ const IdsDOMUtils = {
 
   /**
    * Used specifically to detect the closest Shadow Root container OR `document`.
-   * @param {*} node the node to check
+   * @param {HTMLElement} node the node to check
    * @returns {Node} the parent node
    */
   getClosestContainerNode(node) {
@@ -32,7 +32,7 @@ const IdsDOMUtils = {
    * Returns the closest Root Node parent of a provided element.  If the provided element is inside
    * a Shadow Root, that Shadow Root's host's parentNode is provided. `document` is used as a
    * fallback. This method allows for `querySelector()` in some nested Shadow Roots to work properly
-   * @param {*} node the node to check
+   * @param {HTMLElement} node the node to check
    * @returns {Node} the parent node.
    */
   getClosestRootNode(node) {

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -134,7 +134,7 @@ class IdsButton extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixin)
     const protoClasses = ['ids-button', 'ids-icon-button', 'ids-menu-button', 'ids-toggle-button'];
 
     cl.remove(...protoClasses);
-    cl.add(newProtoClass);
+    cl.add(...newProtoClass);
   }
 
   /**

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -613,6 +613,16 @@ class IdsButton extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixin)
       }
     }));
   }
+
+  /**
+   * Overrides the standard "focus" behavior to instead pass focus to the inner HTMLButton element.
+   */
+  focus() {
+    if (this.tabIndex < 0) {
+      return;
+    }
+    this.button.focus();
+  }
 }
 
 export { IdsButton, BUTTON_PROPS, BUTTON_TYPES };

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -618,9 +618,6 @@ class IdsButton extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixin)
    * Overrides the standard "focus" behavior to instead pass focus to the inner HTMLButton element.
    */
   focus() {
-    if (this.tabIndex < 0) {
-      return;
-    }
     this.button.focus();
   }
 }

--- a/src/ids-menu-button/ids-menu-button.d.ts
+++ b/src/ids-menu-button/ids-menu-button.d.ts
@@ -14,7 +14,7 @@ export default class IdsMenuButton extends IdsButton {
   menu: string | null;
 
   /** */
-  readonly menuEl?: IdsPopupMenu;
+  readonly menuEl: IdsPopupMenu;
 
   /** */
   configureMenu(): void;

--- a/src/ids-menu-button/ids-menu-button.js
+++ b/src/ids-menu-button/ids-menu-button.js
@@ -3,6 +3,7 @@ import {
   scss,
   props
 } from '../ids-base/ids-element';
+import IdsDOMUtils from '../ids-base/ids-dom-utils';
 
 // @ts-ignore
 import { IdsButton, BUTTON_PROPS } from '../ids-button/ids-button';
@@ -124,14 +125,18 @@ class IdsMenuButton extends IdsButton {
    * @returns {HTMLElement | null} element if one is present
    */
   get menuEl() {
-    return document.querySelector(`ids-popup-menu[id="${this.menu}"]`);
+    // Check for a Shadow Root parent.
+    // If none, use `document`
+    /** @type {any} */
+    const target = IdsDOMUtils.getClosestRootNode(this);
+    return target.querySelector(`ids-popup-menu[id="${this.menu}"]`);
   }
 
   /**
    * @returns {void}
    */
   configureMenu() {
-    if (!this.menuEl) {
+    if (!this.menuEl || !this.menuEl.popup) {
       return;
     }
     this.resizeMenu();

--- a/src/ids-menu-button/ids-menu-button.js
+++ b/src/ids-menu-button/ids-menu-button.js
@@ -172,7 +172,7 @@ class IdsMenuButton extends IdsButton {
    * @returns {void}
    */
   setPopupArrow() {
-    if (!this.menuEl) {
+    if (!this.menuEl || !this.menuEl.popup) {
       return;
     }
     // @ts-ignore

--- a/src/ids-menu-button/ids-menu-button.js
+++ b/src/ids-menu-button/ids-menu-button.js
@@ -122,7 +122,7 @@ class IdsMenuButton extends IdsButton {
 
   /**
    * @readonly
-   * @returns {HTMLElement | null} element if one is present
+   * @returns {IdsPopupMenu | null} element if one is present
    */
   get menuEl() {
     // Check for a Shadow Root parent.

--- a/src/ids-menu/ids-menu-item.js
+++ b/src/ids-menu/ids-menu-item.js
@@ -285,6 +285,10 @@ class IdsMenuItem extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixi
    * @returns {any} ['IdsMenu'] reference to the parent IdsMenu component, if one exists.
    */
   get menu() {
+    const toolbarParent = this.closest('ids-toolbar-more-actions');
+    if (toolbarParent) {
+      return toolbarParent.menu;
+    }
     return this.closest('ids-menu, ids-popup-menu');
   }
 

--- a/src/ids-menu/ids-menu.js
+++ b/src/ids-menu/ids-menu.js
@@ -17,6 +17,7 @@ import IdsSeparator from './ids-separator';
 
 // @ts-ignore
 import styles from './ids-menu.scss';
+import IdsDOMUtils from '../ids-base/ids-dom-utils';
 
 /**
  * @private
@@ -351,7 +352,9 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
    */
   get focused() {
     // @ts-ignore
-    return this.items.find((item) => document.activeElement.isEqualNode(item));
+    return this.items.find((item) => {
+      return IdsDOMUtils.getClosestContainerNode(this).activeElement.isEqualNode(item);
+    });
   }
 
   /**

--- a/src/ids-menu/ids-menu.js
+++ b/src/ids-menu/ids-menu.js
@@ -47,6 +47,11 @@ function isValidGroup(menuGroup, idsMenu) {
 function isUsableItem(item, idsMenu) {
   // @ts-ignore
   const isItem = item instanceof IdsMenuItem;
+  if (!isItem) {
+    return false;
+  }
+
+  // The item is only usable if it's contained by the correct IdsMenu
   const menuHasItem = idsMenu.contains(item);
 
   // In some nested cases, we need to detect the item's Shadow Root containment to accurately
@@ -54,7 +59,7 @@ function isUsableItem(item, idsMenu) {
   const closestItemRoot = IdsDOMUtils.getClosestRootNode(item.assignedSlot);
   const itemInMenuShadow = closestItemRoot?.menu?.isEqualNode(idsMenu);
 
-  return (isItem && (menuHasItem || itemInMenuShadow) && !item.disabled);
+  return (menuHasItem || itemInMenuShadow) && !item.disabled;
 }
 
 /**

--- a/src/ids-menu/ids-menu.js
+++ b/src/ids-menu/ids-menu.js
@@ -59,7 +59,7 @@ function isUsableItem(item, idsMenu) {
   const closestItemRoot = IdsDOMUtils.getClosestRootNode(item.assignedSlot);
   const itemInMenuShadow = closestItemRoot?.menu?.isEqualNode(idsMenu);
 
-  return (menuHasItem || itemInMenuShadow) && !item.disabled;
+  return (itemInMenuShadow || menuHasItem) && !item.disabled;
 }
 
 /**

--- a/src/ids-menu/ids-menu.js
+++ b/src/ids-menu/ids-menu.js
@@ -56,7 +56,9 @@ function isUsableItem(item, idsMenu) {
 
   // In some nested cases, we need to detect the item's Shadow Root containment to accurately
   // figure out if it's slotted inside the same menu.
+  // @ts-ignore
   const closestItemRoot = IdsDOMUtils.getClosestRootNode(item.assignedSlot);
+  // @ts-ignore
   const itemInMenuShadow = closestItemRoot?.menu?.isEqualNode(idsMenu);
 
   return (itemInMenuShadow || menuHasItem) && !item.disabled;
@@ -371,7 +373,9 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
   get focused() {
     // @ts-ignore
     return this.items.find((item) => {
+      // @ts-ignore
       const containerNode = IdsDOMUtils.getClosestContainerNode(this);
+      // @ts-ignore
       return containerNode?.activeElement?.isEqualNode(item);
     });
   }

--- a/src/ids-popup-menu/ids-popup-menu.js
+++ b/src/ids-popup-menu/ids-popup-menu.js
@@ -154,6 +154,7 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
         this.hide();
 
         // Since Escape cancels without selection, re-focus the button
+        /* istanbul ignore next */
         if (this.target) {
           this.target.focus();
         }

--- a/src/ids-popup-menu/ids-popup-menu.js
+++ b/src/ids-popup-menu/ids-popup-menu.js
@@ -13,6 +13,7 @@ import IdsPopup from '../ids-popup/ids-popup';
 // @ts-ignore
 import styles from './ids-popup-menu.scss';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
+import IdsDOMUtils from '../ids-base/ids-dom-utils';
 
 const POPUPMENU_PROPERTIES = [
   props.TARGET,
@@ -223,12 +224,15 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
       // @TODO
       break;
     case 'click':
+      // Configure some settings for opening
+      this.popup.align = 'bottom, left';
+      this.popup.arrow = 'bottom';
+      this.popup.y = 10;
+
       // Open/Close the menu when the trigger element is clicked
       this.onEvent('click.trigger', targetElem, (/** @type {any} */e) => {
         e.preventDefault();
         if (this.hidden) {
-          this.popup.align = 'bottom, left';
-          this.popup.y = 10;
           this.show();
         } else {
           this.hide();

--- a/src/ids-popup-menu/ids-popup-menu.js
+++ b/src/ids-popup-menu/ids-popup-menu.js
@@ -13,7 +13,6 @@ import IdsPopup from '../ids-popup/ids-popup';
 // @ts-ignore
 import styles from './ids-popup-menu.scss';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
-import IdsDOMUtils from '../ids-base/ids-dom-utils';
 
 const POPUPMENU_PROPERTIES = [
   props.TARGET,
@@ -123,7 +122,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     // Arrow Right on an item containing a submenu causes that submenu to open
     this.listen(['ArrowRight'], this, (/** @type {any} */ e) => {
       e.preventDefault();
-      // e.stopPropagation();
       const thisItem = e.target.closest('ids-menu-item');
       if (thisItem.hasSubmenu) {
         thisItem.showSubmenu();
@@ -136,7 +134,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     if (this.parentMenu) {
       this.listen(['ArrowLeft'], this, (/** @type {any} */ e) => {
         e.preventDefault();
-        // e.stopPropagation();
         this.hide();
         this.parentMenuItem.focus();
       });

--- a/src/ids-popup-menu/ids-popup-menu.js
+++ b/src/ids-popup-menu/ids-popup-menu.js
@@ -123,7 +123,7 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     // Arrow Right on an item containing a submenu causes that submenu to open
     this.listen(['ArrowRight'], this, (/** @type {any} */ e) => {
       e.preventDefault();
-      e.stopPropagation();
+      // e.stopPropagation();
       const thisItem = e.target.closest('ids-menu-item');
       if (thisItem.hasSubmenu) {
         thisItem.showSubmenu();
@@ -136,7 +136,7 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     if (this.parentMenu) {
       this.listen(['ArrowLeft'], this, (/** @type {any} */ e) => {
         e.preventDefault();
-        e.stopPropagation();
+        // e.stopPropagation();
         this.hide();
         this.parentMenuItem.focus();
       });
@@ -152,6 +152,11 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
         e.preventDefault();
         e.stopPropagation();
         this.hide();
+
+        // Since Escape cancels without selection, re-focus the button
+        if (this.target) {
+          this.target.focus();
+        }
       });
     }
   }
@@ -293,6 +298,14 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     // @ts-ignore
     this.offEvent('click.toplevel', window);
     this.hasOpenEvents = false;
+  }
+
+  /**
+   * @readonly
+   * @returns {boolean} true if the Popup Menu is currently being displayed
+   */
+  get isOpen() {
+    return this.popup.visible;
   }
 
   /**

--- a/src/ids-popup-menu/ids-popup-menu.js
+++ b/src/ids-popup-menu/ids-popup-menu.js
@@ -304,7 +304,7 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
    * @readonly
    * @returns {boolean} true if the Popup Menu is currently being displayed
    */
-  get isOpen() {
+  get visible() {
     return this.popup.visible;
   }
 

--- a/src/ids-popup/ids-popup.js
+++ b/src/ids-popup/ids-popup.js
@@ -106,7 +106,7 @@ class IdsPopup extends mix(IdsElement).with(IdsRenderLoopMixin, IdsResizeMixin, 
     this.isVisible = false;
     this.isAnimated = false;
     this.trueType = 'none';
-    // this.shouldUpdate = true;
+    this.shouldUpdate = true;
   }
 
   /**

--- a/src/ids-popup/ids-popup.js
+++ b/src/ids-popup/ids-popup.js
@@ -6,6 +6,8 @@ import {
   mix
 } from '../ids-base/ids-element';
 
+import IdsDOMUtils from '../ids-base/ids-dom-utils';
+
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsRenderLoopMixin, IdsRenderLoopItem } from '../ids-render-loop/ids-render-loop-mixin';
 
@@ -104,7 +106,7 @@ class IdsPopup extends mix(IdsElement).with(IdsRenderLoopMixin, IdsResizeMixin, 
     this.isVisible = false;
     this.isAnimated = false;
     this.trueType = 'none';
-    this.shouldUpdate = true;
+    // this.shouldUpdate = true;
   }
 
   /**
@@ -120,6 +122,8 @@ class IdsPopup extends mix(IdsElement).with(IdsRenderLoopMixin, IdsResizeMixin, 
     // @ts-ignore
     this.setupResize();
     this.handleEvents();
+
+    this.shouldUpdate = true;
     this.refresh();
   }
 
@@ -192,7 +196,9 @@ class IdsPopup extends mix(IdsElement).with(IdsRenderLoopMixin, IdsResizeMixin, 
     if (isString) {
       // @TODO Harden for security (XSS)
       // @ts-ignore
-      elem = document.querySelector(val);
+      const rootNode = IdsDOMUtils.getClosestRootNode(this);
+      // @ts-ignore
+      elem = rootNode.querySelector(val);
       if (!(elem instanceof HTMLElement)) {
         return;
       }
@@ -465,7 +471,10 @@ class IdsPopup extends mix(IdsElement).with(IdsRenderLoopMixin, IdsResizeMixin, 
     let elem;
     if (isString) {
       // @TODO Harden for security (XSS)
-      elem = document.querySelector(val);
+      // @ts-ignore
+      const rootNode = IdsDOMUtils.getClosestRootNode(this);
+      // @ts-ignore
+      elem = rootNode.querySelector(val);
       if (!(elem instanceof HTMLElement)) {
         return;
       }

--- a/src/ids-toolbar/README.md
+++ b/src/ids-toolbar/README.md
@@ -99,7 +99,8 @@ For compatibility with 4.x components Toolbars, the IDS Toolbar also supports `t
 
 ```html
 <ids-toolbar-section type="title">
-    <ids-text type="h3">My Toolbar</ids-text>
+    <ids-text font-size="20">My Toolbar</ids-text>
+    <ids-text font-size="14">With some extra information below</ids-text>
 </ids-toolbar-section>
 <ids-toolbar-section type="buttonset" align="end">
     <ids-button id="button-1" role="button">
@@ -108,6 +109,41 @@ For compatibility with 4.x components Toolbars, the IDS Toolbar also supports `t
     <ids-button id="button-2">
         <span slot="text" class="audible">Settings</span>
         <ids-icon slot="icon" icon="settings"></ids-icon>
+    </ids-button>
+</ids-toolbar-section>
+```
+
+Toolbar Title sections can have multiple text elements, if needed:
+
+```html
+<ids-toolbar-section type="title">
+    <ids-text font-size="20">My Toolbar</ids-text>
+    <ids-text font-size="14">With some extra information below</ids-text>
+</ids-toolbar-section>
+
+<!-- or... -->
+
+<ids-toolbar-section type="title">
+    <ids-text font-size="20">My Toolbar</ids-text>
+</ids-toolbar-section>
+```
+
+Toolbar Buttonset sections can contain an indeterminate number of components.  Generally these are [Buttons](../ids-button/README.md), but other component types such as Hyperlinks and some Pickers are accepted.  The Buttonset Section is styled with CSS to prevent the wrapping of these elements to multiple lines, instead cutting off actions that don't fit.  If accompanied by a More Actions button, the actions that don't fit will "spill over" into the More Actions menu:
+
+```html
+<ids-toolbar-section type="buttonset" align="end">
+    <ids-button id="button-1" role="button">
+        <span slot="text">Text</span>
+    </ids-button>
+    <ids-button id="button-2">
+        <span slot="text" class="audible">Settings</span>
+        <ids-icon slot="icon" icon="settings"></ids-icon>
+    </ids-button>
+    <ids-button id="button-3" role="button">
+        <span slot="text">Text</span>
+    </ids-button>
+    <ids-button id="button-4" role="button">
+        <span slot="text">Text</span>
     </ids-button>
 </ids-toolbar-section>
 ```

--- a/src/ids-toolbar/README.md
+++ b/src/ids-toolbar/README.md
@@ -1,0 +1,52 @@
+# Ids Toolbar Component
+
+## Description
+
+The Ids Toolbar is used for building highly-configurable Toolbars for sections of your application.  It displays [buttons](../ids-button/README.md), hyperlinks, and other components in different alignable sections, along with contextual information about a workflow or process.
+
+The Flex Toolbar can also be responsive, intelligently hiding buttons that can't be shown on-screen, and displaying them in an overflow menu.
+
+## Use Cases
+
+- Provides contextual information for a workflow or process displayed on screen
+- Provides access to contextual actions for said workflow/process
+
+## Terminology
+
+**Section** Toolbars are divided into sections.  Each of these sections has their own alignment style and "type" that determines how it fits within the Toolbar.
+**Item** Toolbar items are the actionable elements within a toolbar.  In general they correspond standard HTML Elements or other IDS Components, such as buttons, hyperlinks, checkboxes, etc.
+**More Actions** This optional element can be applied to Toolbars that contain a significant number of actions that cannot all be displayed on screen at one time.  This element contains a menu button that will display any "spilled-over" contents from the Toolbar when active, once those actions are no longer visible on the Toolbar.
+
+## Attributes and Properties
+
+### Toolbar
+
+- `items` provides access to all Toolbar items in all sections
+- `sections` provides access to all the Toolbar's sections
+- `focused` describes the currently-focused Toolbar item
+
+### Toolbar Section
+
+- `align` - Determines the alignment of the items within this section.  Defaults to `start`, which is the left side of the Toolbar in a standard Left-to-Right toolbar setup.  Can also be `center` and `end` (right).
+- `items` - provides access to all Toolbar items in this section.
+- `type` - Sets a pre-defined "type" on the toolbar section.  This defaults to `static` but can also be set to `title`, `buttonset`, and `search` to mimic those specific sections.  To create a custom section that fills available space, `fluid` is also an available type.
+
+### Toolbar More Actions
+
+- `button` provides access to the internal [Menu Button component](../ids-menu-button/README.md)
+- `menu` provides access to the internal [Popup Menu component](../ids-popup-menu/README.md)
+- `type` this component is a standalone toolbar section that always reports `more` for its type.
+
+## States and Variations
+
+## Features (With Code Examples)
+
+## Keyboard Guidelines
+
+## Responsive Guidelines
+
+## Converting from Previous Versions
+
+Ids Toolbar closely resembles the 4.x Flex Toolbar in structure and functionality.  The main differences are:
+
+-

--- a/src/ids-toolbar/README.md
+++ b/src/ids-toolbar/README.md
@@ -4,7 +4,7 @@
 
 The Ids Toolbar is used for building highly-configurable Toolbars for sections of your application.  It displays [buttons](../ids-button/README.md), hyperlinks, and other components in different alignable sections, along with contextual information about a workflow or process.
 
-The Flex Toolbar can also be responsive, intelligently hiding buttons that can't be shown on-screen, and displaying them in an overflow menu.
+The Ids Toolbar can also be responsive, intelligently hiding buttons that can't be shown on-screen, and displaying them in an overflow menu.
 
 ## Use Cases
 
@@ -21,9 +21,11 @@ The Flex Toolbar can also be responsive, intelligently hiding buttons that can't
 
 ### Toolbar
 
+- `disabled` makes the entire toolbar enabled/disabled
+- `focused` describes the currently-focused Toolbar item
 - `items` provides access to all Toolbar items in all sections
 - `sections` provides access to all the Toolbar's sections
-- `focused` describes the currently-focused Toolbar item
+- `tabbable` if true, makes it possible to navigate all Toolbar items by using the Tab/Shift+Tab keys by setting all items to a 0-or-more tabIndex property.  By default (false), only one Toolbar item at a time can have a 0-or-more tabIndex.
 
 ### Toolbar Section
 
@@ -39,14 +41,158 @@ The Flex Toolbar can also be responsive, intelligently hiding buttons that can't
 
 ## States and Variations
 
+- "disabled"
+- "tabbable"
+
+Aside from the Toolbar-level disabled state, all individual Toolbar items are responsible for management of their own state.  For more information on these components' states, see their documentation pages.
+
 ## Features (With Code Examples)
+
+Ids Toolbars are comprised of the Toolbar element, an indeterminate number of Toolbar sections, and an optional "More Actions" menu button element. Inside of the different toolbar sections, it's possible to place different Ids Components.  Below is a basic example of what an entire Ids Toolbar may look like:
+
+```html
+<ids-toolbar>
+    <ids-toolbar-section type="title">
+        <ids-text type="h3">My Toolbar</ids-text>
+    </ids-toolbar-section>
+    <ids-toolbar-section type="buttonset" align="end">
+        <ids-button id="button-1" role="button">
+            <span slot="text">Text</span>
+        </ids-button>
+        <ids-button id="button-2">
+            <span slot="text" class="audible">Settings</span>
+            <ids-icon slot="icon" icon="settings"></ids-icon>
+        </ids-button>
+    </ids-toolbar-section>
+    <ids-toolbar-more-actions>
+        <ids-menu-group>
+            <ids-menu-item value="1">Option One</ids-menu-item>
+            <ids-menu-item value="2">Option Two</ids-menu-item>
+            <ids-menu-item value="3">Option Three</ids-menu-item>
+            <ids-menu-item>More Options
+            <ids-popup-menu>
+                <ids-menu-group>
+                <ids-menu-item value="4">Option Four</ids-menu-item>
+                <ids-menu-item value="5">Option Five</ids-menu-item>
+                <ids-menu-item value="6">Option Six</ids-menu-item>
+                </ids-menu-group>
+            </ids-popup-menu>
+            </ids-menu-item>
+        </ids-menu-group>
+    </ids-toolbar-more-actions>
+</ids-toolbar>
+```
+
+### Sections
+
+Toolbar sections can be configured with different "types" that can determine their look/feel/function.  By default, the sections do not fill available space and contain no padding.  These are `static` toolbar sections:
+
+```html
+<ids-toolbar-section>
+    <ids-button icon="menu" role="button">
+        <span slot="text" class="audible">Application Menu Trigger</span>
+    </ids-button>
+</ids-toolbar-section>
+```
+
+For compatibility with 4.x components Toolbars, the IDS Toolbar also supports `title` and `buttonset` section types that act similarly.  The styling is less rigid than in previous iterations, so to make a buttonset section "right"-aligned, it's necessary to add the `align="end"` attribute:
+
+```html
+<ids-toolbar-section type="title">
+    <ids-text type="h3">My Toolbar</ids-text>
+</ids-toolbar-section>
+<ids-toolbar-section type="buttonset" align="end">
+    <ids-button id="button-1" role="button">
+        <span slot="text">Text</span>
+    </ids-button>
+    <ids-button id="button-2">
+        <span slot="text" class="audible">Settings</span>
+        <ids-icon slot="icon" icon="settings"></ids-icon>
+    </ids-button>
+</ids-toolbar-section>
+```
+
+Toolbars can also contain sections that are meant to be customized with CSS.  It's possible to create custom static sections with the `static` type, but if you want to make a custom section that fills available space, use the `fluid` type:
+
+```html
+<ids-toolbar>
+    <!-- takes up as little space as possible --->
+    <ids-toolbar-section type="static">
+        <ids-button id="button-1" role="button">
+            <span slot="text">Button 1</span>
+        </ids-button>
+    </ids-toolbar-section>
+
+    <!-- fills the rest of the toolbar space -->
+    <ids-toolbar-section type="fluid" align="end">
+        <ids-button id="button-2" role="button">
+            <span slot="text">Button 2</span>
+        </ids-button>
+    </ids-toolbar-section>
+<ids-toolbar>
+```
+
+### More Actions Button
+
+Optionally, toolbars can contain a "More Actions" Button, which is a [Menu Button]('../ids-menu-button/README.md) wrapped inside a special Toolbar Section.  This component's purpose is to provide ansulary actions that are related to your Toolbar's primary actions, but don't necessarily need to be readily available on a single click.  In responsive situations with many primary actions present, the Toolbar will collapse any actions that don't fit within its boundaries and make them available at the top of the More Actions button's menu (also referred to as the "overflow" menu).
+
+The Ids Toolbar More Actions component sits alongside the other toolbar sections, and contains a single slot that takes the same types of elements as a standard [Ids Popup Menu](../ids-popup-menu/README.md):
+
+```html
+<ids-toolbar-more-actions>
+    <ids-menu-group>
+        <ids-menu-item value="1">Option One</ids-menu-item>
+        <ids-menu-item value="2">Option Two</ids-menu-item>
+        <ids-menu-item value="3">Option Three</ids-menu-item>
+        <ids-menu-item>More Options
+        <ids-popup-menu>
+            <ids-menu-group>
+            <ids-menu-item value="4">Option Four</ids-menu-item>
+            <ids-menu-item value="5">Option Five</ids-menu-item>
+            <ids-menu-item value="6">Option Six</ids-menu-item>
+            </ids-menu-group>
+        </ids-popup-menu>
+        </ids-menu-item>
+    </ids-menu-group>
+</ids-toolbar-more-actions>
+```
+
+### API Access
+
+At the Toolbar level, it's possible to access all Items and Sections:
+
+```js
+const items = document.querySelector('ids-toolbar').items;
+const sections = document.querySelector('ids-toolbar').sections;
+```
+
+Within each section, it's possible to access the section's items:
+
+```js
+const items = document.querySelector('ids-toolbar-section').items;
+```
+
+When dealing with a More Actions button, its inner components' APIs are exposed:
+
+```js
+const moreActionsButtonEl = document.querySelector('ids-toolbar-more-actions').button;
+const moreActionsMenuEl = document.querySelector('ids-toolbar-more-actions').menu;
+```
 
 ## Keyboard Guidelines
 
+The IDS Button doesn't contain any interactions beyond a standard HTMLButtonElement:
+
+- <kbd>Enter</kbd> keys selects a toolbar action and executes the action.  On menu buttons, the menu is activated/hidden, and an action is not executed until one of its menu items is selected.
+- <kbd>Left/Right Arrow</kbd> keys navigate the available toolbar items.
+- <kbd>Tab</kbd> or <kbd>Shift</kbd>/<kbd>Tab<kbd> keys cause navigation to occur.  When `tabbable="true"`, using Tab/Shift+Tab causes navigation between Toolbar items. When `tabbable="false"`, Navigation away from the toolbar will occur to the element after/before the Toolbar respectively.
+
 ## Responsive Guidelines
+
+- Try not to provide an over-abundance of Toolbar Actions.  The Toolbar's intention is to provide contextual actions for a specific workflow. Providing too many actions can cause end-user confusion.
 
 ## Converting from Previous Versions
 
 Ids Toolbar closely resembles the 4.x Flex Toolbar in structure and functionality.  The main differences are:
 
--
+- Toolbar Sections and the More Actions Button are now standardized components.

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -13,13 +13,9 @@ import IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
  */
 @customElement('ids-toolbar-more-actions')
 @scss(styles)
-class IdsToolbarMoreActionsButton extends IdsElement {
+class IdsToolbarMoreActions extends IdsElement {
   constructor() {
     super();
-  }
-
-  static get properties() {
-    return [];
   }
 
   connectedCallback() {
@@ -88,7 +84,7 @@ class IdsToolbarMoreActionsButton extends IdsElement {
   }
 }
 
-export default IdsToolbarMoreActionsButton;
+export default IdsToolbarMoreActions;
 export {
   IdsMenuButton,
   IdsPopupMenu

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -47,7 +47,7 @@ class IdsToolbarMoreActionsButton extends IdsElement {
    * @readonly
    * @returns {IdsMenuButton} the inner menu button
    */
-  get buttonEl() {
+  get button() {
     return this.shadowRoot.querySelector('ids-menu-button');
   }
 
@@ -55,7 +55,7 @@ class IdsToolbarMoreActionsButton extends IdsElement {
    * @readonly
    * @returns {IdsPopupMenu} the inner popup menu
    */
-  get menuEl() {
+  get menu() {
     return this.shadowRoot.querySelector('ids-popup-menu');
   }
 
@@ -63,7 +63,7 @@ class IdsToolbarMoreActionsButton extends IdsElement {
    *
    */
   refresh() {
-    const popup = this.menuEl?.popup;
+    const popup = this.menu?.popup;
     if (!popup) {
       return;
     }

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -35,9 +35,18 @@ class IdsToolbarMoreActionsButton extends IdsElement {
       </ids-menu-button>
       <ids-popup-menu id="icon-menu" target="#icon-button" trigger="click">
         <ids-menu-group>
-          <ids-menu-item>Option One</ids-menu-item>
-          <ids-menu-item>Option Two</ids-menu-item>
-          <ids-menu-item>Option Three</ids-menu-item>
+          <ids-menu-item value="1">Option One</ids-menu-item>
+          <ids-menu-item value="2">Option Two</ids-menu-item>
+          <ids-menu-item value="3">Option Three</ids-menu-item>
+          <ids-menu-item>More Options
+            <ids-popup-menu>
+              <ids-menu-group>
+                <ids-menu-item value="4">Option Four</ids-menu-item>
+                <ids-menu-item value="5">Option Five</ids-menu-item>
+                <ids-menu-item value="6">Option Six</ids-menu-item>
+              </ids-menu-group>
+            </ids-popup-menu>
+          </ids-menu-item>
         </ids-menu-group>
       </ids-popup-menu>
     </div>`;
@@ -68,6 +77,14 @@ class IdsToolbarMoreActionsButton extends IdsElement {
       return;
     }
     popup.align = 'bottom, right';
+  }
+
+  /**
+   * Passes focus from the main element into the inner Ids Menu Button
+   * @returns {void}
+   */
+  focus() {
+    this.button.focus();
   }
 }
 

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -1,5 +1,4 @@
 import { IdsElement, scss, customElement } from '../ids-base/ids-element';
-import { props } from '../ids-base/ids-constants';
 
 // @ts-ignore
 import styles from './ids-toolbar-more-actions.scss';
@@ -73,7 +72,8 @@ class IdsToolbarMoreActionsButton extends IdsElement {
   }
 
   /**
-   *
+   * Refreshes the state of the More Actions button
+   * @returns {void}
    */
   refresh() {
     this.menu.popup.align = 'bottom, right';

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -1,0 +1,78 @@
+import { IdsElement, scss, customElement } from '../ids-base/ids-element';
+import { props } from '../ids-base/ids-constants';
+
+// @ts-ignore
+import styles from './ids-toolbar-more-actions.scss';
+
+// Subcomponents
+import IdsToolbarSection from './ids-toolbar-section';
+import IdsMenuButton from '../ids-menu-button/ids-menu-button';
+import IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
+
+/**
+ * IDS Toolbar Section Component
+ */
+@customElement('ids-toolbar-more-actions')
+@scss(styles)
+class IdsToolbarMoreActionsButton extends IdsElement {
+  constructor() {
+    super();
+  }
+
+  static get properties() {
+    return [];
+  }
+
+  connectedCallback() {
+    this.refresh();
+  }
+
+  template() {
+    return `<div class="ids-toolbar-section more">
+      <ids-menu-button id="icon-button" menu="icon-menu">
+        <ids-icon slot="icon" icon="more"></ids-icon>
+        <span class="audible">More Actions Button</span>
+      </ids-menu-button>
+      <ids-popup-menu id="icon-menu" target="#icon-button" trigger="click">
+        <ids-menu-group>
+          <ids-menu-item>Option One</ids-menu-item>
+          <ids-menu-item>Option Two</ids-menu-item>
+          <ids-menu-item>Option Three</ids-menu-item>
+        </ids-menu-group>
+      </ids-popup-menu>
+    </div>`;
+  }
+
+  /**
+   * @readonly
+   * @returns {IdsMenuButton} the inner menu button
+   */
+  get buttonEl() {
+    return this.shadowRoot.querySelector('ids-menu-button');
+  }
+
+  /**
+   * @readonly
+   * @returns {IdsPopupMenu} the inner popup menu
+   */
+  get menuEl() {
+    return this.shadowRoot.querySelector('ids-popup-menu');
+  }
+
+  /**
+   *
+   */
+  refresh() {
+    const popup = this.menuEl?.popup;
+    if (!popup) {
+      return;
+    }
+    popup.align = 'bottom, right';
+  }
+}
+
+export default IdsToolbarMoreActionsButton;
+export {
+  IdsMenuButton,
+  IdsPopupMenu
+};

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -24,11 +24,12 @@ class IdsToolbarMoreActionsButton extends IdsElement {
   }
 
   connectedCallback() {
+    IdsToolbarSection.prototype.connectedCallback.apply(this);
     this.refresh();
   }
 
   template() {
-    return `<div class="ids-toolbar-section more">
+    return `<div class="ids-toolbar-section ids-toolbar-more-actions more">
       <ids-menu-button id="icon-button" menu="icon-menu">
         <ids-icon slot="icon" icon="more"></ids-icon>
         <span class="audible">More Actions Button</span>
@@ -56,14 +57,26 @@ class IdsToolbarMoreActionsButton extends IdsElement {
   }
 
   /**
+   * Overrides the standard toolbar section "type" setter, which is always "more" in this case.
+   * @param {string} val the type value
+   */
+  set type(val) {
+    this.removeAttribute('type');
+  }
+
+  /**
+   * Overrides the standard toolbar section "type" getter, which always returns "more" in this case.
+   * @returns {string} representing the Toolbar Section type
+   */
+  get type() {
+    return 'more';
+  }
+
+  /**
    *
    */
   refresh() {
-    const popup = this.menu?.popup;
-    if (!popup) {
-      return;
-    }
-    popup.align = 'bottom, right';
+    this.menu.popup.align = 'bottom, right';
   }
 
   /**

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -34,20 +34,7 @@ class IdsToolbarMoreActionsButton extends IdsElement {
         <span class="audible">More Actions Button</span>
       </ids-menu-button>
       <ids-popup-menu id="icon-menu" target="#icon-button" trigger="click">
-        <ids-menu-group>
-          <ids-menu-item value="1">Option One</ids-menu-item>
-          <ids-menu-item value="2">Option Two</ids-menu-item>
-          <ids-menu-item value="3">Option Three</ids-menu-item>
-          <ids-menu-item>More Options
-            <ids-popup-menu>
-              <ids-menu-group>
-                <ids-menu-item value="4">Option Four</ids-menu-item>
-                <ids-menu-item value="5">Option Five</ids-menu-item>
-                <ids-menu-item value="6">Option Six</ids-menu-item>
-              </ids-menu-group>
-            </ids-popup-menu>
-          </ids-menu-item>
-        </ids-menu-group>
+        <slot></slot>
       </ids-popup-menu>
     </div>`;
   }

--- a/src/ids-toolbar/ids-toolbar-more-actions.scss
+++ b/src/ids-toolbar/ids-toolbar-more-actions.scss
@@ -1,0 +1,5 @@
+@import '../ids-base/ids-base.scss';
+
+:host {
+  @include flex();
+}

--- a/src/ids-toolbar/ids-toolbar-more-actions.ts
+++ b/src/ids-toolbar/ids-toolbar-more-actions.ts
@@ -1,4 +1,3 @@
-import { IdsElement } from '../ids-base/ids-element';
 import IdsToolbarSection from './ids-toolbar-section';
 
 // Subcomponents
@@ -7,8 +6,12 @@ import IdsMenuButton from '../ids-menu-button/ids-menu-button';
 
 export default class IdsToolbarMoreActions extends IdsToolbarSection {
   /** The internal Menu Button element */
-  readonly buttonEl: IdsMenuButton;
+  readonly buttonEl?: IdsMenuButton;
 
   /** The internal Popup Menu element */
-  readonly menuEl: IdsPopupMenu;
+  readonly menuEl?: IdsPopupMenu;
 }
+export {
+  IdsMenuButton,
+  IdsPopupMenu
+};

--- a/src/ids-toolbar/ids-toolbar-more-actions.ts
+++ b/src/ids-toolbar/ids-toolbar-more-actions.ts
@@ -1,0 +1,14 @@
+import { IdsElement } from '../ids-base/ids-element';
+import IdsToolbarSection from './ids-toolbar-section';
+
+// Subcomponents
+import IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
+import IdsMenuButton from '../ids-menu-button/ids-menu-button';
+
+export default class IdsToolbarMoreActions extends IdsToolbarSection {
+  /** The internal Menu Button element */
+  readonly buttonEl: IdsMenuButton;
+
+  /** The internal Popup Menu element */
+  readonly menuEl: IdsPopupMenu;
+}

--- a/src/ids-toolbar/ids-toolbar-section.d.ts
+++ b/src/ids-toolbar/ids-toolbar-section.d.ts
@@ -1,5 +1,22 @@
 import { IdsElement } from '../ids-base/ids-element';
 
-export default class IdsToolbarSection extends IdsElement {
+declare const TOOLBAR_ITEM_TAGNAMES: [
+  'ids-button',
+  'ids-checkbox',
+  'ids-input',
+  'ids-menu-button',
+  'ids-radio',
+  'ids-toolbar-more-actions'
+];
 
+export default class IdsToolbarSection extends IdsElement {
+  /** Provides a list of all available toolbar items within this section */
+  readonly items: Array<HTMLElement>;
+
+  /** Sets alignment of the contents in the section */
+  align?: string
+
+  /** Sets the "type" of section */
+  type?: 'static' | 'fluid' | 'title' | 'buttonset' | 'search' | 'more';
 }
+export { TOOLBAR_ITEM_TAGNAMES };

--- a/src/ids-toolbar/ids-toolbar-section.d.ts
+++ b/src/ids-toolbar/ids-toolbar-section.d.ts
@@ -1,0 +1,5 @@
+import { IdsElement } from '../ids-base/ids-element';
+
+export default class IdsToolbarSection extends IdsElement {
+
+}

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -4,24 +4,60 @@ import { props } from '../ids-base/ids-constants';
 import styles from './ids-toolbar.scss';
 
 const TOOLBAR_SECTION_PROPS = [
-  'align'
+  'align',
+  props.TYPE
 ];
 
-// Types of alignment that can apply to a section
+// Alignment styles that can apply to a section
 const SECTION_ALIGNS = [
-  'start',
-  'center',
-  'end'
+  'align-start',
+  'align-center',
+  'align-end'
 ];
 
-// Types of WebComponent Tagnames that are valid toolbar items
+// Section types
+const SECTION_TYPES = [
+  'static',
+  'buttonset',
+  'fluid',
+  'search',
+  'title',
+];
+
+// WebComponent Tagnames that correspond to valid toolbar items
 const TOOLBAR_ITEM_TAGNAMES = [
   'ids-button',
   'ids-checkbox',
   'ids-input',
   'ids-menu-button',
-  'ids-radio'
+  'ids-radio',
+  'ids-text'
 ];
+
+/**
+ * Checks an element's CSS classlist for an item belonging to a group,
+ * appends that item, and removes all others from the group.
+ * @private
+ * @param {string} targetClass
+ * @param {HTMLElement} targetElem
+ * @param {Array<string>} group
+ * @returns {void}
+ */
+function setCssClassFromGroup(targetClass, targetElem, group) {
+  group.forEach((item) => {
+    const cl = targetElem.classList;
+    const cssClass = `${item}`;
+    const thisClass = `${targetClass}`;
+
+    if (cssClass === thisClass) {
+      if (!cl.contains(cssClass)) {
+        cl.add(cssClass);
+      }
+    } else {
+      cl.remove(cssClass);
+    }
+  });
+}
 
 /**
  * IDS Toolbar Section Component
@@ -63,20 +99,7 @@ class IdsToolbarSection extends IdsElement {
     } else {
       this.setAttribute('align', val);
     }
-
-    SECTION_ALIGNS.forEach((align) => {
-      const cl = this.container.classList;
-      const cssClass = `align-${align}`;
-      const thisClass = `align-${val}`;
-
-      if (cssClass == thisClass) {
-        if (!cl.contains(cssClass)) {
-          cl.add(cssClass);
-        }
-      } else {
-        cl.remove(cssClass);
-      }
-    });
+    setCssClassFromGroup(`align-${val}`, this.container, SECTION_ALIGNS);
   }
 
   /**
@@ -84,6 +107,27 @@ class IdsToolbarSection extends IdsElement {
    */
   get align() {
     return this.getAttribute('align') || SECTION_ALIGNS[0];
+  }
+
+  /**
+   * @param {string} val the type of section
+   */
+  set type(val) {
+    let trueVal;
+    if (typeof val !== 'string' || val === '' || !SECTION_TYPES.includes(val)) {
+      trueVal = SECTION_TYPES[0];
+    } else {
+      trueVal = `${val}`;
+    }
+    this.setAttribute('type', trueVal);
+    setCssClassFromGroup(trueVal, this.container, SECTION_TYPES);
+  }
+
+  /**
+   *
+   */
+  get type() {
+    return this.getAttribute('type')
   }
 }
 

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -94,12 +94,13 @@ class IdsToolbarSection extends IdsElement {
    * @param {string} val the alignment type to set
    */
   set align(val) {
-    if (typeof val !== 'string' || val === '' || !SECTION_ALIGNS.includes(val)) {
+    const trueVal = `align-${val}`;
+    if (typeof val !== 'string' || val === '' || !SECTION_ALIGNS.includes(trueVal)) {
       this.removeAttribute('align');
     } else {
       this.setAttribute('align', val);
     }
-    setCssClassFromGroup(`align-${val}`, this.container, SECTION_ALIGNS);
+    setCssClassFromGroup(trueVal, this.container, SECTION_ALIGNS);
   }
 
   /**
@@ -124,10 +125,10 @@ class IdsToolbarSection extends IdsElement {
   }
 
   /**
-   *
+   * @returns {string} the type of section
    */
   get type() {
-    return this.getAttribute('type')
+    return this.getAttribute('type');
   }
 }
 

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -3,7 +3,25 @@ import { props } from '../ids-base/ids-constants';
 // @ts-ignore
 import styles from './ids-toolbar.scss';
 
-const TOOLBAR_SECTION_PROPS = [];
+const TOOLBAR_SECTION_PROPS = [
+  'align'
+];
+
+// Types of alignment that can apply to a section
+const SECTION_ALIGNS = [
+  'start',
+  'center',
+  'end'
+];
+
+// Types of WebComponent Tagnames that are valid toolbar items
+const TOOLBAR_ITEM_TAGNAMES = [
+  'ids-button',
+  'ids-checkbox',
+  'ids-input',
+  'ids-menu-button',
+  'ids-radio'
+];
 
 /**
  * IDS Toolbar Section Component
@@ -24,6 +42,52 @@ class IdsToolbarSection extends IdsElement {
       <slot></slot>
     </div>`;
   }
+
+  /**
+   * @readonly
+   * @returns {Array<any>} list of available items contained by the toolbar
+   */
+  get items() {
+    return [...this.children].filter((/** @type {any} */ e) => {
+      const elemTagName = e.tagName.toLowerCase();
+      return TOOLBAR_ITEM_TAGNAMES.includes(elemTagName);
+    });
+  }
+
+  /**
+   * @param {string} val the alignment type to set
+   */
+  set align(val) {
+    if (typeof val !== 'string' || val === '' || !SECTION_ALIGNS.includes(val)) {
+      this.removeAttribute('align');
+    } else {
+      this.setAttribute('align', val);
+    }
+
+    SECTION_ALIGNS.forEach((align) => {
+      const cl = this.container.classList;
+      const cssClass = `align-${align}`;
+      const thisClass = `align-${val}`;
+
+      if (cssClass == thisClass) {
+        if (!cl.contains(cssClass)) {
+          cl.add(cssClass);
+        }
+      } else {
+        cl.remove(cssClass);
+      }
+    });
+  }
+
+  /**
+   * @returns {string} the current alignment value
+   */
+  get align() {
+    return this.getAttribute('align') || SECTION_ALIGNS[0];
+  }
 }
 
 export default IdsToolbarSection;
+export {
+  TOOLBAR_ITEM_TAGNAMES
+};

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -35,6 +35,11 @@ const TOOLBAR_ITEM_TAGNAMES = [
   'ids-toolbar-more-actions'
 ];
 
+// WebComponent Tagnames that correspond to valid text nodes
+const TOOLBAR_TEXTNODE_TAGNAMES = [
+  'ids-text'
+];
+
 /**
  * Checks an element's CSS classlist for an item belonging to a group,
  * appends that item, and removes all others from the group.
@@ -90,10 +95,22 @@ class IdsToolbarSection extends IdsElement {
    * @returns {Array<any>} list of available items contained by the toolbar
    */
   get items() {
-    return [...this.children].filter((/** @type {any} */ e) => {
+    return [...this.children].filter((e) => {
       const elemTagName = e.tagName.toLowerCase();
       return TOOLBAR_ITEM_TAGNAMES.includes(elemTagName);
     });
+  }
+
+  /**
+   * @readonly
+   * @returns {Array<any>} list of text nodes contained by the toolbar
+   */
+  get textElems() {
+    const nodes = [...this.children].filter((e) => {
+      const elemTagName = e.tagName.toLowerCase();
+      return TOOLBAR_TEXTNODE_TAGNAMES.includes(elemTagName);
+    });
+    return nodes;
   }
 
   /**

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -1,0 +1,29 @@
+import { IdsElement, scss, customElement } from '../ids-base/ids-element';
+import { props } from '../ids-base/ids-constants';
+// @ts-ignore
+import styles from './ids-toolbar.scss';
+
+const TOOLBAR_SECTION_PROPS = [];
+
+/**
+ * IDS Toolbar Section Component
+ */
+@customElement('ids-toolbar-section')
+@scss(styles)
+class IdsToolbarSection extends IdsElement {
+  constructor() {
+    super();
+  }
+
+  static get properties() {
+    return TOOLBAR_SECTION_PROPS;
+  }
+
+  template() {
+    return `<div class="ids-toolbar-section">
+      <slot></slot>
+    </div>`;
+  }
+}
+
+export default IdsToolbarSection;

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -39,9 +39,9 @@ const TOOLBAR_ITEM_TAGNAMES = [
  * Checks an element's CSS classlist for an item belonging to a group,
  * appends that item, and removes all others from the group.
  * @private
- * @param {string} targetClass
- * @param {HTMLElement} targetElem
- * @param {Array<string>} group
+ * @param {string} targetClass the target CSS class to apply/check
+ * @param {HTMLElement} targetElem the target elem on which to apply the class
+ * @param {Array<string>} group the array of classes to scan for removal
  * @returns {void}
  */
 function setCssClassFromGroup(targetClass, targetElem, group) {

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -31,7 +31,7 @@ const TOOLBAR_ITEM_TAGNAMES = [
   'ids-input',
   'ids-menu-button',
   'ids-radio',
-  'ids-text'
+  'ids-toolbar-more-actions'
 ];
 
 /**

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -1,7 +1,7 @@
 import { IdsElement, scss, customElement } from '../ids-base/ids-element';
 import { props } from '../ids-base/ids-constants';
 // @ts-ignore
-import styles from './ids-toolbar.scss';
+import styles from './ids-toolbar-section.scss';
 
 const TOOLBAR_SECTION_PROPS = [
   'align',

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -22,6 +22,7 @@ const SECTION_TYPES = [
   'fluid',
   'search',
   'title',
+  'more'
 ];
 
 // WebComponent Tagnames that correspond to valid toolbar items
@@ -79,6 +80,11 @@ class IdsToolbarSection extends IdsElement {
     </div>`;
   }
 
+  connectedCallback() {
+    setCssClassFromGroup(`align-${this.align}`, this.container, SECTION_ALIGNS);
+    setCssClassFromGroup(this.type, this.container, SECTION_TYPES);
+  }
+
   /**
    * @readonly
    * @returns {Array<any>} list of available items contained by the toolbar
@@ -94,9 +100,10 @@ class IdsToolbarSection extends IdsElement {
    * @param {string} val the alignment type to set
    */
   set align(val) {
-    const trueVal = `align-${val}`;
+    let trueVal = `align-${val}`;
     if (typeof val !== 'string' || val === '' || !SECTION_ALIGNS.includes(trueVal)) {
       this.removeAttribute('align');
+      trueVal = SECTION_ALIGNS[0];
     } else {
       this.setAttribute('align', val);
     }
@@ -107,7 +114,7 @@ class IdsToolbarSection extends IdsElement {
    * @returns {string} the current alignment value
    */
   get align() {
-    return this.getAttribute('align') || SECTION_ALIGNS[0];
+    return this.getAttribute('align') || 'start';
   }
 
   /**
@@ -128,7 +135,7 @@ class IdsToolbarSection extends IdsElement {
    * @returns {string} the type of section
    */
   get type() {
-    return this.getAttribute('type');
+    return this.getAttribute('type') || 'static';
   }
 }
 

--- a/src/ids-toolbar/ids-toolbar-section.scss
+++ b/src/ids-toolbar/ids-toolbar-section.scss
@@ -10,8 +10,6 @@ ids-toolbar-section + ids-toolbar-section[type='buttonset'] {
 }
 
 .ids-toolbar-section {
-  @include flex();
-
   white-space: nowrap;
   width: auto;
 
@@ -34,7 +32,13 @@ ids-toolbar-section + ids-toolbar-section[type='buttonset'] {
 
   // Buttonsets have top padding (accounts for button focus states)
   &.buttonset {
+    @include flex();
     @include py-4();
+  }
+
+  // Title sections are not Flex containers (so we can stack content)
+  &.title {
+    display: inline-block;
   }
 
   // Contains rows of buttons
@@ -58,11 +62,14 @@ ids-toolbar-section + ids-toolbar-section[type='buttonset'] {
   // Intended for use by developers that need "custom" sections that stretch to fit.
   // The default functionality is NOT to stretch.
   &.fluid {
+    @include flex();
+
     flex-grow: 1;
   }
 
   // Contains Searchfields
   &.search {
+    @include flex();
     @include px-12();
   }
 }

--- a/src/ids-toolbar/ids-toolbar-section.scss
+++ b/src/ids-toolbar/ids-toolbar-section.scss
@@ -65,7 +65,4 @@ ids-toolbar-section + ids-toolbar-section[type='buttonset'] {
   &.search {
     @include px-12();
   }
-
-  // ================================================
-  //
 }

--- a/src/ids-toolbar/ids-toolbar-section.scss
+++ b/src/ids-toolbar/ids-toolbar-section.scss
@@ -32,6 +32,11 @@ ids-toolbar-section + ids-toolbar-section[type='buttonset'] {
   // ================================================
   // Built-in Section Type Styles
 
+  // Buttonsets have top padding (accounts for button focus states)
+  &.buttonset {
+    @include py-4();
+  }
+
   // Contains rows of buttons
   &.title,
   &.buttonset {

--- a/src/ids-toolbar/ids-toolbar-section.scss
+++ b/src/ids-toolbar/ids-toolbar-section.scss
@@ -1,0 +1,61 @@
+@import '../ids-base/ids-base.scss';
+
+:host {
+  @include block();
+}
+
+.ids-toolbar-section {
+  white-space: nowrap;
+  width: auto;
+
+  // ================================================
+  // Alignments
+  &.align-start {
+    align-items: flex-start;
+  }
+
+  &.align-center {
+    align-items: center;
+  }
+
+  &.align-end {
+    align-items: flex-end;
+  }
+
+  // ================================================
+  // Built-in Section Type Styles
+
+  // Contains rows of buttons
+  &.buttonset {
+    @include px-4();
+  }
+
+  &.title,
+  &.buttonset {
+    flex-grow: 1;
+
+    &:not(.favor) {
+      overflow-x: hidden;
+      overflow-y: auto;
+      text-overflow: ellipsis;
+    }
+
+    &.static {
+      flex-grow: 0;
+    }
+  }
+
+  // Intended for use by developers that need "custom" sections that stretch to fit.
+  // The default functionality is NOT to stretch.
+  &.fluid {
+    flex-grow: 1;
+  }
+
+  // Contains Searchfields
+  &.search {
+    @include px-12();
+  }
+
+  // ================================================
+  //
+}

--- a/src/ids-toolbar/ids-toolbar-section.scss
+++ b/src/ids-toolbar/ids-toolbar-section.scss
@@ -1,37 +1,42 @@
 @import '../ids-base/ids-base.scss';
 
 :host {
-  @include block();
+  @include flex();
+}
+
+ids-toolbar-section + ids-toolbar-section[type='title'],
+ids-toolbar-section + ids-toolbar-section[type='buttonset'] {
+  padding-left: 10px;
 }
 
 .ids-toolbar-section {
+  @include flex();
+
   white-space: nowrap;
   width: auto;
 
   // ================================================
   // Alignments
   &.align-start {
-    align-items: flex-start;
+    justify-content: flex-start;
   }
 
   &.align-center {
-    align-items: center;
+    justify-content: center;
   }
 
   &.align-end {
-    align-items: flex-end;
+    justify-content: flex-end;
   }
 
   // ================================================
   // Built-in Section Type Styles
 
   // Contains rows of buttons
-  &.buttonset {
-    @include px-4();
-  }
-
   &.title,
   &.buttonset {
+    @include px-8();
+
     flex-grow: 1;
 
     &:not(.favor) {

--- a/src/ids-toolbar/ids-toolbar.d.ts
+++ b/src/ids-toolbar/ids-toolbar.d.ts
@@ -1,6 +1,22 @@
 import { IdsElement } from '../ids-base/ids-element';
 import IdsToolbarSection from './ids-toolbar-section';
+import IdsToolbarMoreActions from './ids-toolbar-more-actions';
 
-export default class IdsToolbar extends IdsElement {}
+export default class IdsToolbar extends IdsElement {
+  /** Provides a list of all available toolbar items */
+  readonly items: Array<HTMLElement>;
 
-export { IdsToolbarSection };
+  /** Provides a list of all available toolbar sections */
+  readonly sections: Array<IdsToolbarSection>;
+
+  /** References the currently-focused toolbar item, if applicable */
+  readonly focused: HTMLElement | undefined;
+
+  /* Uses a currently-highlighted menu item to "navigate" a specified number of steps to another menu item, highlighting it. */
+  navigate(amt: number, doFocus: boolean): Array<HTMLElement>;
+}
+
+export {
+  IdsToolbarSection,
+  IdsToolbarMoreActions
+};

--- a/src/ids-toolbar/ids-toolbar.d.ts
+++ b/src/ids-toolbar/ids-toolbar.d.ts
@@ -1,0 +1,8 @@
+import { IdsElement } from '../ids-base/ids-element';
+import IdsToolbarSection from './ids-toolbar-section';
+
+export default class IdsToolbar extends IdsElement {
+
+}
+
+export { IdsToolbarSection };

--- a/src/ids-toolbar/ids-toolbar.d.ts
+++ b/src/ids-toolbar/ids-toolbar.d.ts
@@ -1,8 +1,6 @@
 import { IdsElement } from '../ids-base/ids-element';
 import IdsToolbarSection from './ids-toolbar-section';
 
-export default class IdsToolbar extends IdsElement {
-
-}
+export default class IdsToolbar extends IdsElement {}
 
 export { IdsToolbarSection };

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -5,6 +5,7 @@ import styles from './ids-toolbar.scss';
 
 // Supporting Components
 import IdsToolbarSection, { TOOLBAR_ITEM_TAGNAMES } from './ids-toolbar-section';
+import IdsToolbarMoreActions from './ids-toolbar-more-actions';
 
 const TOOLBAR_PROPS = [];
 
@@ -47,8 +48,7 @@ class IdsToolbar extends IdsElement {
     });
     return i;
   }
-
 }
 
 export default IdsToolbar;
-export { IdsToolbarSection, TOOLBAR_ITEM_TAGNAMES };
+export { IdsToolbarSection, IdsToolbarMoreActions, TOOLBAR_ITEM_TAGNAMES };

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -1,4 +1,4 @@
-import { IdsElement, scss, customElement } from '../ids-base/ids-element';
+import { IdsElement, mix, scss, customElement } from '../ids-base/ids-element';
 import { props } from '../ids-base/ids-constants';
 // @ts-ignore
 import styles from './ids-toolbar.scss';
@@ -6,6 +6,10 @@ import styles from './ids-toolbar.scss';
 // Supporting Components
 import IdsToolbarSection, { TOOLBAR_ITEM_TAGNAMES } from './ids-toolbar-section';
 import IdsToolbarMoreActions from './ids-toolbar-more-actions';
+import IdsDOMUtils from '../ids-base/ids-dom-utils';
+
+import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
+import { IdsKeyboardMixin } from '../ids-base/ids-keyboard-mixin';
 
 const TOOLBAR_PROPS = [];
 
@@ -14,13 +18,94 @@ const TOOLBAR_PROPS = [];
  */
 @customElement('ids-toolbar')
 @scss(styles)
-class IdsToolbar extends IdsElement {
+class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
   constructor() {
     super();
   }
 
   static get properties() {
     return TOOLBAR_PROPS;
+  }
+
+  connectedCallback() {
+    this.setAttribute('role', 'toolbar');
+    this.handleKeys();
+  }
+
+  /**
+   * Sets up the connection to the global keyboard handler
+   * @returns {void}
+   */
+  handleKeys() {
+    // Arrow Up navigates focus backward
+    this.listen(['ArrowLeft'], this, (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // If the target is a menu item (either menu/actions button),
+      // attempt to close the menu.
+      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.isOpen)) {
+        return;
+      }
+      this.navigate(-1, true);
+    });
+
+    // Arrow Right navigates focus forward
+    this.listen(['ArrowRight'], this, (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // If the target is a menu item (either menu/actions button),
+      // attempt to close the menu.
+      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.isOpen)) {
+        return;
+      }
+      this.navigate(1, true);
+    });
+  }
+
+  /**
+   * Uses a currently-highlighted toolbar item to "navigate" a specified number
+   * of steps to another toolbar item, highlighting it.
+   * @param {number} [amt] the amount of items to navigate
+   * @param {boolean} [doFocus] if true, causes the new item to become focused.
+   * @returns {any} the item that will be focused
+   */
+  navigate(amt = 0, doFocus = false) {
+    const items = this.items;
+    let currentItem = this.focused || items[0];
+
+    if (typeof amt !== 'number') {
+      return currentItem;
+    }
+
+    // Calculate steps/meta
+    const negative = amt < 0;
+    let steps = Math.abs(amt);
+    let currentIndex = items.indexOf(currentItem);
+
+    // Step through items to the target
+    while (steps > 0) {
+      currentItem = items[currentIndex + (negative ? -1 : 1)];
+      currentIndex = items.indexOf(currentItem);
+
+      // "-1" means we've crossed the boundary and need to loop back around
+      if (currentIndex < 0) {
+        currentIndex = (negative ? items.length - 1 : 0);
+        currentItem = items[currentIndex];
+      }
+
+      // Don't count disabled items as "taking a step"
+      if (!currentItem.disabled) {
+        steps -= 1;
+      }
+    }
+
+    if (!currentItem.disabled && doFocus) {
+      currentItem.focus();
+    }
+
+    return currentItem;
   }
 
   template() {
@@ -31,10 +116,25 @@ class IdsToolbar extends IdsElement {
 
   /**
    * @readonly
+   * @returns {any} the currently focused menu item, if one exists
+   */
+  get focused() {
+    // @TODO clean this up / document why/how it works
+    // @ts-ignore
+    return this.items.find((item) => {
+      const container = IdsDOMUtils.getClosestContainerNode(item);
+      const focused = container.activeElement;
+      const isEqualNode = focused?.isEqualNode(item);
+      return isEqualNode;
+    });
+  }
+
+  /**
+   * @readonly
    * @returns {Array<any>} list of available sections within the toolbar
    */
   get sections() {
-    return [...this.children].filter((/** @type {any} */ e) => e.matches('ids-toolbar-section'));
+    return [...this.children].filter((e) => e.matches('ids-toolbar-section, ids-toolbar-more-actions'));
   }
 
   /**
@@ -44,7 +144,12 @@ class IdsToolbar extends IdsElement {
   get items() {
     let i = [];
     this.sections.forEach((section) => {
-      i = i.concat([...section.items]);
+      // Pass along the More Actions button, if applicable
+      if (section?.name === 'ids-toolbar-more-actions') {
+        i.push(section.button);
+      } else {
+        i = i.concat([...section.items]);
+      }
     });
     return i;
   }

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -4,7 +4,6 @@ import {
   scss,
   customElement
 } from '../ids-base/ids-element';
-import { props } from '../ids-base/ids-constants';
 
 // @ts-ignore
 import styles from './ids-toolbar.scss';
@@ -17,8 +16,6 @@ import IdsDOMUtils from '../ids-base/ids-dom-utils';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsKeyboardMixin } from '../ids-base/ids-keyboard-mixin';
 
-const TOOLBAR_PROPS = [];
-
 /**
  * IDS Toolbar Component
  */
@@ -30,7 +27,7 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
   }
 
   static get properties() {
-    return TOOLBAR_PROPS;
+    return [];
   }
 
   connectedCallback() {
@@ -40,6 +37,7 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
 
   /**
    * Sets up the connection to the global keyboard handler
+   * @private
    * @returns {void}
    */
   handleKeys() {
@@ -129,6 +127,7 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
     // @ts-ignore
     return this.items.find((item) => {
       const container = IdsDOMUtils.getClosestContainerNode(item);
+      // @ts-ignore
       const focused = container.activeElement;
       const isEqualNode = focused?.isEqualNode(item);
       return isEqualNode;

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -1,0 +1,66 @@
+import { IdsElement, scss, customElement } from '../ids-base/ids-element';
+import { props } from '../ids-base/ids-constants';
+// @ts-ignore
+import styles from './ids-toolbar.scss';
+
+// Supporting Components
+import IdsToolbarSection from './ids-toolbar-section';
+
+const TOOLBAR_PROPS = [];
+
+// Types of WebComponent Tagnames that are valid toolbar items
+const TOOLBAR_ITEM_TAGNAMES = [
+  'ids-button',
+  'ids-checkbox',
+  'ids-input',
+  'ids-menu-button',
+  'ids-radio'
+];
+
+/**
+ * IDS Toolbar Component
+ */
+@customElement('ids-toolbar')
+@scss(styles)
+class IdsToolbar extends IdsElement {
+  constructor() {
+    super();
+  }
+
+  static get properties() {
+    return TOOLBAR_PROPS;
+  }
+
+  template() {
+    return `<div class="ids-toolbar" role="toolbar">
+      <slot></slot>
+    </div>`;
+  }
+
+  /**
+   * @readonly
+   * @returns {Array<any>} list of available sections within the toolbar
+   */
+  get sections() {
+    return [...this.children].filter((/** @type {any} */ e) => e.matches('ids-toolbar-section'));
+  }
+
+  /**
+   * @readonly
+   * @returns {Array<any>} list of available items contained by the toolbar
+   */
+  get items() {
+    return [...this.children].filter((/** @type {any} */ e) => {
+      const elemTagName = e.tagName.toLowerCase();
+      return TOOLBAR_ITEM_TAGNAMES.includes(elemTagName);
+    });
+  }
+
+  /**
+   *
+   */
+
+}
+
+export default IdsToolbar;
+export { IdsToolbarSection };

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -138,9 +138,13 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
     }
 
     this.container.classList[trueVal ? 'add' : 'remove']('disabled');
-    this.items.forEach((item) => {
-      item.disabled = trueVal;
-    });
+
+    // Set disabled state on all relevant subcomponents
+    const setDisabledState = (elem) => {
+      elem.disabled = trueVal;
+    };
+    this.items.forEach(setDisabledState);
+    this.textElems.forEach(setDisabledState);
   }
 
   /**
@@ -168,7 +172,7 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
 
   /**
    * @readonly
-   * @returns {Array<any>} list of available items, separated per section
+   * @returns {Array<any>} list of all available toolbar items present in all toolbar sections
    */
   get items() {
     let i = [];
@@ -178,6 +182,20 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
         i.push(section.button);
       } else {
         i = i.concat([...section.items]);
+      }
+    });
+    return i;
+  }
+
+  /**
+   * @readonly
+   * @returns {Array<any>} list of all available text nodes present in all toolbar sections
+   */
+  get textElems() {
+    let i = [];
+    this.sections.forEach((section) => {
+      if (section?.name !== 'ids-toolbar-more-actions') {
+        i = i.concat([...section.textElems]);
       }
     });
     return i;

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -4,18 +4,9 @@ import { props } from '../ids-base/ids-constants';
 import styles from './ids-toolbar.scss';
 
 // Supporting Components
-import IdsToolbarSection from './ids-toolbar-section';
+import IdsToolbarSection, { TOOLBAR_ITEM_TAGNAMES } from './ids-toolbar-section';
 
 const TOOLBAR_PROPS = [];
-
-// Types of WebComponent Tagnames that are valid toolbar items
-const TOOLBAR_ITEM_TAGNAMES = [
-  'ids-button',
-  'ids-checkbox',
-  'ids-input',
-  'ids-menu-button',
-  'ids-radio'
-];
 
 /**
  * IDS Toolbar Component
@@ -47,20 +38,17 @@ class IdsToolbar extends IdsElement {
 
   /**
    * @readonly
-   * @returns {Array<any>} list of available items contained by the toolbar
+   * @returns {Array<any>} list of available items, separated per section
    */
   get items() {
-    return [...this.children].filter((/** @type {any} */ e) => {
-      const elemTagName = e.tagName.toLowerCase();
-      return TOOLBAR_ITEM_TAGNAMES.includes(elemTagName);
+    let i = [];
+    this.sections.forEach((section) => {
+      i = i.concat([...section.items]);
     });
+    return i;
   }
-
-  /**
-   *
-   */
 
 }
 
 export default IdsToolbar;
-export { IdsToolbarSection };
+export { IdsToolbarSection, TOOLBAR_ITEM_TAGNAMES };

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -1,5 +1,11 @@
-import { IdsElement, mix, scss, customElement } from '../ids-base/ids-element';
+import {
+  IdsElement,
+  mix,
+  scss,
+  customElement
+} from '../ids-base/ids-element';
 import { props } from '../ids-base/ids-constants';
+
 // @ts-ignore
 import styles from './ids-toolbar.scss';
 
@@ -44,7 +50,7 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
 
       // If the target is a menu item (either menu/actions button),
       // attempt to close the menu.
-      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.isOpen)) {
+      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.visible)) {
         return;
       }
       this.navigate(-1, true);
@@ -57,7 +63,7 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
 
       // If the target is a menu item (either menu/actions button),
       // attempt to close the menu.
-      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.isOpen)) {
+      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.visible)) {
         return;
       }
       this.navigate(1, true);

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -48,9 +48,9 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
       e.preventDefault();
       e.stopPropagation();
 
-      // If the target is a menu item (either menu/actions button),
-      // attempt to close the menu.
-      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.visible)) {
+      // If the target is a menu item, either a menu or actions button is currently open
+      // with its children focused, and navigation shouldn't continue
+      if (e.target.name === 'ids-menu-item') {
         return;
       }
       this.navigate(-1, true);
@@ -61,9 +61,9 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
       e.preventDefault();
       e.stopPropagation();
 
-      // If the target is a menu item (either menu/actions button),
-      // attempt to close the menu.
-      if (e.target.name === 'ids-menu-item' || (e.target.matches('ids-toolbar-more-actions') && e.target.menu.visible)) {
+      // If the target is a menu item, either a menu or actions button is currently open
+      // with its children focused, and navigation shouldn't continue
+      if (e.target.name === 'ids-menu-item') {
         return;
       }
       this.navigate(1, true);

--- a/src/ids-toolbar/ids-toolbar.scss
+++ b/src/ids-toolbar/ids-toolbar.scss
@@ -6,4 +6,27 @@
 
 .ids-toolbar {
   @include flex();
+
+  align-items: center;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+
+.ids-toolbar-section {
+  white-space: nowrap;
+  width: auto;
+
+  // =========================
+  // Alignments
+  &.align-start {
+    align-items: flex-start;
+  }
+
+  &.align-center {
+    align-items: center;
+  }
+
+  &.align-end {
+    align-items: flex-end;
+  }
 }

--- a/src/ids-toolbar/ids-toolbar.scss
+++ b/src/ids-toolbar/ids-toolbar.scss
@@ -16,7 +16,7 @@
   white-space: nowrap;
   width: auto;
 
-  // =========================
+  // ================================================
   // Alignments
   &.align-start {
     align-items: flex-start;
@@ -29,4 +29,40 @@
   &.align-end {
     align-items: flex-end;
   }
+
+  // ================================================
+  // Built-in Section Type Styles
+
+  // Contains rows of buttons
+  &.buttonset {
+    @include px-4();
+  }
+
+  &.title,
+  &.buttonset {
+    flex-grow: 1;
+
+    &:not(.favor) {
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
+
+    &.static {
+      flex-grow: 0;
+    }
+  }
+
+  // Intended for use by developers that need "custom" sections that stretch to fit.
+  // The default functionality is NOT to stretch.
+  &.fluid {
+    flex-grow: 1;
+  }
+
+  // Contains Searchfields
+  &.search {
+    @include px-12();
+  }
+
+  // ================================================
+  //
 }

--- a/src/ids-toolbar/ids-toolbar.scss
+++ b/src/ids-toolbar/ids-toolbar.scss
@@ -2,6 +2,10 @@
 
 :host {
   @include block();
+
+  ::slotted(ids-toolbar-section[type='fluid']) {
+    flex-grow: 1;
+  }
 }
 
 .ids-toolbar {
@@ -10,59 +14,4 @@
   align-items: center;
   flex-flow: row nowrap;
   justify-content: space-between;
-}
-
-.ids-toolbar-section {
-  white-space: nowrap;
-  width: auto;
-
-  // ================================================
-  // Alignments
-  &.align-start {
-    align-items: flex-start;
-  }
-
-  &.align-center {
-    align-items: center;
-  }
-
-  &.align-end {
-    align-items: flex-end;
-  }
-
-  // ================================================
-  // Built-in Section Type Styles
-
-  // Contains rows of buttons
-  &.buttonset {
-    @include px-4();
-  }
-
-  &.title,
-  &.buttonset {
-    flex-grow: 1;
-
-    &:not(.favor) {
-      overflow-x: hidden;
-      overflow-y: auto;
-    }
-
-    &.static {
-      flex-grow: 0;
-    }
-  }
-
-  // Intended for use by developers that need "custom" sections that stretch to fit.
-  // The default functionality is NOT to stretch.
-  &.fluid {
-    flex-grow: 1;
-  }
-
-  // Contains Searchfields
-  &.search {
-    @include px-12();
-  }
-
-  // ================================================
-  //
 }

--- a/src/ids-toolbar/ids-toolbar.scss
+++ b/src/ids-toolbar/ids-toolbar.scss
@@ -3,7 +3,9 @@
 :host {
   @include block();
 
-  ::slotted(ids-toolbar-section[type='fluid']) {
+  ::slotted(ids-toolbar-section[type='fluid']),
+  ::slotted(ids-toolbar-section[type='title']),
+  ::slotted(ids-toolbar-section[type='buttonset']) {
     flex-grow: 1;
   }
 }

--- a/src/ids-toolbar/ids-toolbar.scss
+++ b/src/ids-toolbar/ids-toolbar.scss
@@ -8,6 +8,12 @@
   ::slotted(ids-toolbar-section[type='buttonset']) {
     flex-grow: 1;
   }
+
+  &[disabled] {
+    ::slotted(.ids-text) {
+      color: text-slate-30();
+    }
+  }
 }
 
 .ids-toolbar {
@@ -16,4 +22,12 @@
   align-items: center;
   flex-flow: row nowrap;
   justify-content: space-between;
+
+  &.disabled {
+    color: text-slate-30();
+
+    .ids-text {
+      color: inherit;
+    }
+  }
 }

--- a/src/ids-toolbar/ids-toolbar.scss
+++ b/src/ids-toolbar/ids-toolbar.scss
@@ -1,0 +1,9 @@
+@import '../ids-base/ids-base.scss';
+
+:host {
+  @include block();
+}
+
+.ids-toolbar {
+  @include flex();
+}

--- a/test/ids-button/ids-button-func-test.js
+++ b/test/ids-button/ids-button-func-test.js
@@ -59,6 +59,12 @@ describe('IdsButton Component', () => {
     expect(btn.button instanceof HTMLElement).toBeTruthy();
   });
 
+  it('focuses the inner button component when told to focus', () => {
+    btn.focus();
+
+    expect(btn.shadowRoot.activeElement.isEqualNode(btn.button));
+  });
+
   it('can be disabled/enabled', () => {
     btn.disabled = true;
 

--- a/test/ids-menu-button/ids-menu-button-func-test.js
+++ b/test/ids-menu-button/ids-menu-button-func-test.js
@@ -124,4 +124,18 @@ describe('IdsMenuButton Component', () => {
 
     expect(buttonEl.shadowRoot.querySelector('.ids-icon-button')).toBeTruthy();
   });
+
+  it('focuses the button when the menu is closed with the `Escape` key', () => {
+    const closeEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    menuEl.show();
+
+    setTimeout(() => {
+      expect(menuEl.popup.visible).toBeTruthy();
+      menuEl.dispatchEvent(closeEvent);
+
+      setTimeout(() => {
+        expect(document.activeElement.isEqualNode(buttonEl)).toBeTruthy();
+      }, 20);
+    }, 20);
+  });
 });

--- a/test/ids-popup-menu/ids-popup-menu-func-test.js
+++ b/test/ids-popup-menu/ids-popup-menu-func-test.js
@@ -194,11 +194,13 @@ describe('IdsPopupMenu Component', () => {
 
     expect(menu.hidden).toBeFalsy();
     expect(menu.popup.visible).toBeTruthy();
+    expect(menu.visible).toBeTruthy();
 
     menu.hide();
 
     expect(menu.hidden).toBeTruthy();
     expect(menu.popup.visible).toBeFalsy();
+    expect(menu.visible).toBeFalsy();
   });
 
   it('can be prevented from showing with a vetoed `beforeshow` event', () => {

--- a/test/ids-toolbar/ids-toolbar-e2e-test.js
+++ b/test/ids-toolbar/ids-toolbar-e2e-test.js
@@ -1,0 +1,29 @@
+const { percySnapshot } = require('@percy/puppeteer');
+
+describe('Ids Toolbar e2e Tests', () => {
+  const url = 'http://localhost:4444/ids-toolbar';
+
+  beforeAll(async () => {
+    page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'load' });
+  });
+
+  it.skip('should not have errors', async () => {
+    await expect(page.title()).resolves.toMatch('IDS Toolbar Component');
+  });
+
+  // @TODO: Revisit and figure out accessibility issues
+  it.skip('should pass Axe accessibility tests', async () => {
+    page = await browser.newPage();
+    await page.setBypassCSP(true);
+    await page.goto(url, { waitUntil: 'load' });
+    await expect(page).toPassAxeTests();
+  });
+
+  it('should not have visual regressions (percy)', async () => {
+    page = await browser.newPage();
+    await page.setBypassCSP(true);
+    await page.goto('http://localhost:4444/ids-toolbar/standalone-css', { waitUntil: 'domcontentloaded' });
+    await percySnapshot(page, 'ids-toolbar-css');
+  });
+});

--- a/test/ids-toolbar/ids-toolbar-func-test.js
+++ b/test/ids-toolbar/ids-toolbar-func-test.js
@@ -68,14 +68,10 @@ const exampleHTML = `
 
 describe('IdsToolbar Component', () => {
   let toolbar;
-  let sectionAppMenu;
-  let sectionTitle;
-  let sectionButtonset;
   let sectionMore;
   let buttonAppMenu;
   let button1;
   let button2;
-  let button3;
   let button4;
 
   beforeEach(async () => {
@@ -85,14 +81,10 @@ describe('IdsToolbar Component', () => {
     toolbar.insertAdjacentHTML('afterbegin', exampleHTML);
 
     // Reference sections/items
-    sectionAppMenu = document.querySelector('#appmenu-section');
-    sectionTitle = document.querySelector('#title-section');
-    sectionButtonset = document.querySelector('#buttonset-section');
     sectionMore = document.querySelector('ids-toolbar-more-actions');
     buttonAppMenu = document.querySelector('#button-appmenu');
     button1 = document.querySelector('#button-1');
     button2 = document.querySelector('#button-2');
-    button3 = document.querySelector('#button-3');
     button4 = document.querySelector('#button-4');
   });
 

--- a/test/ids-toolbar/ids-toolbar-func-test.js
+++ b/test/ids-toolbar/ids-toolbar-func-test.js
@@ -46,6 +46,8 @@ const exampleHTML = `
       <span slot="text" class="audible">Trash</span>
       <ids-icon slot="icon" icon="delete"></ids-icon>
     </ids-button>
+
+    <a href="#">Outgoing Link</a>
   </ids-toolbar-section>
 
   <ids-toolbar-more-actions id="section-more">
@@ -72,6 +74,7 @@ describe('IdsToolbar Component', () => {
   let buttonAppMenu;
   let button1;
   let button2;
+  let button3;
   let button4;
 
   beforeEach(async () => {
@@ -85,6 +88,7 @@ describe('IdsToolbar Component', () => {
     buttonAppMenu = document.querySelector('#button-appmenu');
     button1 = document.querySelector('#button-1');
     button2 = document.querySelector('#button-2');
+    button3 = document.querySelector('#button-3');
     button4 = document.querySelector('#button-4');
   });
 
@@ -113,6 +117,51 @@ describe('IdsToolbar Component', () => {
 
     expect(items).toBeDefined();
     expect(items.length).toBe(6);
+  });
+
+  it('can be disabled and enabled', () => {
+    toolbar.disabled = true;
+
+    expect(toolbar.disabled).toBeTruthy();
+    expect(toolbar.container.classList.contains('disabled')).toBeTruthy();
+
+    toolbar.disabled = false;
+
+    expect(toolbar.disabled).toBeFalsy();
+    expect(toolbar.container.classList.contains('disabled')).toBeFalsy();
+
+    toolbar.setAttribute('disabled', true);
+
+    expect(toolbar.disabled).toBeTruthy();
+    expect(toolbar.container.classList.contains('disabled')).toBeTruthy();
+
+    toolbar.removeAttribute('disabled');
+
+    expect(toolbar.disabled).toBeFalsy();
+    expect(toolbar.container.classList.contains('disabled')).toBeFalsy();
+  });
+
+  it('can be configured to be navigated with Tab/Shift+Tab, or not, with the "tabbable" feature', () => {
+    toolbar.tabbable = true;
+
+    expect(toolbar.tabbable).toBeTruthy();
+    expect(button1.tabIndex).toBe(0);
+    expect(button2.tabIndex).toBe(0);
+
+    // Focus a button that isn't the first one, then disable "tabbable".
+    // The previously focused item should retain its zero tabIndex,
+    // while the others are all set to -1.
+    button2.focus();
+    toolbar.tabbable = false;
+
+    expect(toolbar.tabbable).toBeFalsy();
+    expect(button1.tabIndex).toBe(-1);
+    expect(button2.tabIndex).toBe(0);
+    expect(button3.tabIndex).toBe(-1);
+
+    const currentTabbableElem = toolbar.detectTabbable();
+
+    expect(currentTabbableElem).toBe(button2);
   });
 
   it('can announce what is focused and navigate among its items', () => {

--- a/test/ids-toolbar/ids-toolbar-func-test.js
+++ b/test/ids-toolbar/ids-toolbar-func-test.js
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment jsdom
+ */
+import IdsToolbar from '../../src/ids-toolbar/ids-toolbar';
+
+const exampleHTML = `
+  <ids-toolbar-section id="appmenu-section">
+    <ids-button icon="menu" role="button" id="button-appmenu">
+      <span slot="text" class="audible">Application Menu Trigger</span>
+    </ids-button>
+  </ids-toolbar-section id="title-section">
+  <ids-toolbar-section type="title">
+    <ids-text type="h3">My Toolbar</ids-text>
+  </ids-toolbar-section>
+  <ids-toolbar-section id="buttonset-section" type="buttonset" align="end">
+    <ids-button id="button-1" role="button">
+      <span slot="text">Text</span>
+    </ids-button>
+
+    <ids-menu-button role="button" id="button-2" menu="button-2-menu" dropdown-icon>
+      <span slot="text">Menu</span>
+    </ids-menu-button>
+    <ids-popup-menu id="button-2-menu" target="#button-2">
+      <ids-menu-group>
+        <ids-menu-item value="1">Item One</ids-menu-item>
+        <ids-menu-item value="2">Item Two</ids-menu-item>
+        <ids-menu-item value="3">Item Three</ids-menu-item>
+        <ids-menu-item>More Items
+          <ids-popup-menu>
+            <ids-menu-group>
+              <ids-menu-item value="4">Item Four</ids-menu-item>
+              <ids-menu-item value="4">Item Five</ids-menu-item>
+              <ids-menu-item value="4">Item Six</ids-menu-item>
+            </ids-menu-group>
+          </ids-popup-menu>
+        </ids-menu-item>
+      </ids-menu-group>
+    </ids-popup-menu>
+
+    <ids-button id="button-3" disabled>
+      <span slot="text" class="audible">Settings</span>
+      <ids-icon slot="icon" icon="settings"></ids-icon>
+    </ids-button>
+
+    <ids-button id="button-4">
+      <span slot="text" class="audible">Trash</span>
+      <ids-icon slot="icon" icon="delete"></ids-icon>
+    </ids-button>
+  </ids-toolbar-section>
+
+  <ids-toolbar-more-actions id="section-more">
+    <ids-menu-group>
+      <ids-menu-item value="1">Option One</ids-menu-item>
+      <ids-menu-item value="2">Option Two</ids-menu-item>
+      <ids-menu-item value="3">Option Three</ids-menu-item>
+      <ids-menu-item>More Options
+        <ids-popup-menu>
+          <ids-menu-group>
+            <ids-menu-item value="4">Option Four</ids-menu-item>
+            <ids-menu-item value="5">Option Five</ids-menu-item>
+            <ids-menu-item value="6">Option Six</ids-menu-item>
+          </ids-menu-group>
+        </ids-popup-menu>
+      </ids-menu-item>
+    </ids-menu-group>
+  </ids-toolbar-more-actions>
+`;
+
+describe('IdsToolbar Component', () => {
+  let toolbar;
+  let sectionAppMenu;
+  let sectionTitle;
+  let sectionButtonset;
+  let sectionMore;
+  let buttonAppMenu;
+  let button1;
+  let button2;
+  let button3;
+  let button4;
+
+  beforeEach(async () => {
+    const elem = new IdsToolbar();
+    document.body.appendChild(elem);
+    toolbar = document.querySelector('ids-toolbar');
+    toolbar.insertAdjacentHTML('afterbegin', exampleHTML);
+
+    // Reference sections/items
+    sectionAppMenu = document.querySelector('#appmenu-section');
+    sectionTitle = document.querySelector('#title-section');
+    sectionButtonset = document.querySelector('#buttonset-section');
+    sectionMore = document.querySelector('ids-toolbar-more-actions');
+    buttonAppMenu = document.querySelector('#button-appmenu');
+    button1 = document.querySelector('#button-1');
+    button2 = document.querySelector('#button-2');
+    button3 = document.querySelector('#button-3');
+    button4 = document.querySelector('#button-4');
+  });
+
+  afterEach(async () => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with no errors', () => {
+    const errors = jest.spyOn(global.console, 'error');
+    const elem = new IdsToolbar();
+    document.body.appendChild(elem);
+    elem.remove();
+    expect(document.querySelectorAll('ids-toolbar').length).toEqual(1);
+    expect(errors).not.toHaveBeenCalled();
+  });
+
+  it('can get a list of its sections', () => {
+    const sections = toolbar.sections;
+
+    expect(sections).toBeDefined();
+    expect(sections.length).toBe(4);
+  });
+
+  it('can get a list of its items', () => {
+    const items = toolbar.items;
+
+    expect(items).toBeDefined();
+    expect(items.length).toBe(6);
+  });
+
+  it('can announce what is focused and navigate among its items', () => {
+    const items = toolbar.items;
+
+    // Navigate forward (down) 2 items
+    toolbar.navigate(2, true);
+
+    // The component should be able to explain which of its items is focused
+    expect(toolbar.focused).toEqual(items[2]);
+
+    // Navigate backward (up) 1 item
+    toolbar.navigate(-1, true);
+
+    expect(toolbar.focused).toEqual(items[1]);
+
+    // Won't navigate anywhere if a junk/NaN value is provided
+    toolbar.navigate('forward', true);
+
+    expect(toolbar.focused).toEqual(items[1]);
+  });
+
+  it('navigates nowhere if no number of steps is provided', () => {
+    button1.focus();
+    toolbar.navigate();
+
+    expect(toolbar.focused).toEqual(button1);
+  });
+
+  it('loops around if `navigate()` tries to go too far', () => {
+    sectionMore.focus();
+    toolbar.navigate(1, true);
+
+    expect(toolbar.focused).toEqual(buttonAppMenu);
+
+    toolbar.navigate(-1, true);
+
+    expect(toolbar.focused).toEqual(sectionMore.button);
+  });
+
+  it('skips disabled items while navigating', () => {
+    button2.focus();
+    toolbar.navigate(1, true);
+
+    // Button 3 is disabled, Button 4 should become focused
+    expect(toolbar.focused).toEqual(button4);
+  });
+
+  it('navigates menu items using the keyboard', () => {
+    const navigateLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+    const navigateRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+
+    // Focus the first one
+    button1.focus();
+
+    expect(toolbar.focused).toEqual(button1);
+
+    // Navigate down one item
+    toolbar.dispatchEvent(navigateRightEvent);
+
+    expect(toolbar.focused).toEqual(button2);
+
+    // Navigate left two items (navigation will wrap to the bottom item)
+    toolbar.dispatchEvent(navigateLeftEvent);
+    toolbar.dispatchEvent(navigateLeftEvent);
+
+    expect(toolbar.focused).toEqual(buttonAppMenu);
+  });
+
+  it('cannot navigate away from an open menu button', () => {
+    const navigateLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+    const navigateRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+
+    // Button 2 is the Menu Button
+    button2.focus();
+    button2.menu.show();
+
+    toolbar.dispatchEvent(navigateRightEvent);
+
+    expect(toolbar.focused).toBe(button2);
+    expect(button2.menu.visible).toBeTruthy();
+
+    toolbar.dispatchEvent(navigateLeftEvent);
+
+    expect(toolbar.focused).toBe(button2);
+    expect(button2.menu.visible).toBeTruthy();
+  });
+});

--- a/test/ids-toolbar/ids-toolbar-more-actions-func-test.js
+++ b/test/ids-toolbar/ids-toolbar-more-actions-func-test.js
@@ -1,7 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import IdsToolbar from '../../src/ids-toolbar/ids-toolbar';
+import IdsToolbar, {
+  IdsToolbarSection,
+  IdsToolbarMoreActions
+} from '../../src/ids-toolbar/ids-toolbar';
 
 const exampleHTML = `
   <ids-toolbar-section id="appmenu-section">
@@ -66,7 +69,7 @@ const exampleHTML = `
   </ids-toolbar-more-actions>
 `;
 
-describe('IdsToolbar Component', () => {
+describe('IdsToolbarMoreActions Component', () => {
   let toolbar;
   let sectionAppMenu;
   let sectionTitle;
@@ -100,115 +103,30 @@ describe('IdsToolbar Component', () => {
     document.body.innerHTML = '';
   });
 
-  it('renders with no errors', () => {
-    const errors = jest.spyOn(global.console, 'error');
-    const elem = new IdsToolbar();
-    document.body.appendChild(elem);
-    elem.remove();
-    expect(document.querySelectorAll('ids-toolbar').length).toEqual(1);
-    expect(errors).not.toHaveBeenCalled();
+  it('has a menu button', () => {
+    expect(sectionMore.menu.tagName).toBe('IDS-POPUP-MENU');
+    expect(sectionMore.button.tagName).toBe('IDS-MENU-BUTTON');
   });
 
-  it('can get a list of its sections', () => {
-    const sections = toolbar.sections;
+  it('always returns a "more" type', () => {
+    expect(sectionMore.type).toBe('more');
 
-    expect(sections).toBeDefined();
-    expect(sections.length).toBe(4);
+    // It's not possible to change this to one of the other standard types
+    sectionMore.type = 'fluid';
+
+    expect(sectionMore.type).toBe('more');
   });
 
-  it('can get a list of its items', () => {
-    const items = toolbar.items;
-
-    expect(items).toBeDefined();
-    expect(items.length).toBe(6);
-  });
-
-  it('can announce what is focused and navigate among its items', () => {
-    const items = toolbar.items;
-
-    // Navigate forward (down) 2 items
-    toolbar.navigate(2, true);
-
-    // The component should be able to explain which of its items is focused
-    expect(toolbar.focused).toEqual(items[2]);
-
-    // Navigate backward (up) 1 item
-    toolbar.navigate(-1, true);
-
-    expect(toolbar.focused).toEqual(items[1]);
-
-    // Won't navigate anywhere if a junk/NaN value is provided
-    toolbar.navigate('forward', true);
-
-    expect(toolbar.focused).toEqual(items[1]);
-  });
-
-  it('navigates nowhere if no number of steps is provided', () => {
-    button1.focus();
-    toolbar.navigate();
-
-    expect(toolbar.focused).toEqual(button1);
-  });
-
-  it('loops around if `navigate()` tries to go too far', () => {
+  it('focuses the inner button component when told to focus', () => {
     sectionMore.focus();
-    toolbar.navigate(1, true);
 
-    expect(toolbar.focused).toEqual(buttonAppMenu);
-
-    toolbar.navigate(-1, true);
-
-    expect(toolbar.focused).toEqual(sectionMore.button);
+    expect(sectionMore.shadowRoot.activeElement.isEqualNode(sectionMore.button));
   });
 
-  it('skips disabled items while navigating', () => {
-    button2.focus();
-    toolbar.navigate(1, true);
+  // Tests code path in `ids-menu` that searches a slot for groups instead of using `querySelector`
+  it('gets slotted children when accessing its menu\'s `groups` property', () => {
+    const groups = sectionMore.menu.groups;
 
-    // Button 3 is disabled, Button 4 should become focused
-    expect(toolbar.focused).toEqual(button4);
-  });
-
-  it('navigates menu items using the keyboard', () => {
-    const navigateLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-    const navigateRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-
-    // Focus the first one
-    button1.focus();
-
-    expect(toolbar.focused).toEqual(button1);
-
-    // Navigate right one item
-    toolbar.dispatchEvent(navigateRightEvent);
-
-    expect(toolbar.focused).toEqual(button2);
-
-    // Navigate left two items (navigation will wrap to the bottom item)
-    toolbar.dispatchEvent(navigateLeftEvent);
-    toolbar.dispatchEvent(navigateLeftEvent);
-
-    expect(toolbar.focused).toEqual(buttonAppMenu);
-  });
-
-  it('cannot navigate away from an open menu button', (done) => {
-    const navigateLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true });
-    const navigateRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
-
-    // Button 2 is the Menu Button
-    button2.focus();
-    button2.menuEl.show();
-
-    // Wait for the menu to be open
-    setTimeout(() => {
-      const topMenuItem = button2.menuEl.items[0];
-      topMenuItem.dispatchEvent(navigateRightEvent);
-
-      expect(button2.menuEl.visible).toBeTruthy();
-
-      topMenuItem.dispatchEvent(navigateLeftEvent);
-
-      expect(button2.menuEl.visible).toBeTruthy();
-      done();
-    }, 30);
+    expect(groups.length).toBe(1);
   });
 });

--- a/test/ids-toolbar/ids-toolbar-more-actions-func-test.js
+++ b/test/ids-toolbar/ids-toolbar-more-actions-func-test.js
@@ -71,15 +71,7 @@ const exampleHTML = `
 
 describe('IdsToolbarMoreActions Component', () => {
   let toolbar;
-  let sectionAppMenu;
-  let sectionTitle;
-  let sectionButtonset;
   let sectionMore;
-  let buttonAppMenu;
-  let button1;
-  let button2;
-  let button3;
-  let button4;
 
   beforeEach(async () => {
     const elem = new IdsToolbar();
@@ -88,15 +80,7 @@ describe('IdsToolbarMoreActions Component', () => {
     toolbar.insertAdjacentHTML('afterbegin', exampleHTML);
 
     // Reference sections/items
-    sectionAppMenu = document.querySelector('#appmenu-section');
-    sectionTitle = document.querySelector('#title-section');
-    sectionButtonset = document.querySelector('#buttonset-section');
     sectionMore = document.querySelector('ids-toolbar-more-actions');
-    buttonAppMenu = document.querySelector('#button-appmenu');
-    button1 = document.querySelector('#button-1');
-    button2 = document.querySelector('#button-2');
-    button3 = document.querySelector('#button-3');
-    button4 = document.querySelector('#button-4');
   });
 
   afterEach(async () => {

--- a/test/ids-toolbar/ids-toolbar-section-func-test.js
+++ b/test/ids-toolbar/ids-toolbar-section-func-test.js
@@ -1,7 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import IdsToolbar from '../../src/ids-toolbar/ids-toolbar';
+import IdsToolbar, {
+  IdsToolbarSection
+} from '../../src/ids-toolbar/ids-toolbar';
 
 const exampleHTML = `
   <ids-toolbar-section id="appmenu-section">
@@ -66,7 +68,7 @@ const exampleHTML = `
   </ids-toolbar-more-actions>
 `;
 
-describe('IdsToolbar Component', () => {
+describe('IdsToolbarSection Component', () => {
   let toolbar;
   let sectionAppMenu;
   let sectionTitle;
@@ -100,115 +102,48 @@ describe('IdsToolbar Component', () => {
     document.body.innerHTML = '';
   });
 
-  it('renders with no errors', () => {
-    const errors = jest.spyOn(global.console, 'error');
-    const elem = new IdsToolbar();
-    document.body.appendChild(elem);
-    elem.remove();
-    expect(document.querySelectorAll('ids-toolbar').length).toEqual(1);
-    expect(errors).not.toHaveBeenCalled();
+  it('has items', () => {
+    const items = sectionButtonset.items;
+
+    expect(items.length).toBe(4);
   });
 
-  it('can get a list of its sections', () => {
-    const sections = toolbar.sections;
+  it('can have a specified type', () => {
+    expect(sectionAppMenu.type).toBe('static');
+    expect(sectionTitle.type).toBe('title');
+    expect(sectionButtonset.type).toBe('buttonset');
 
-    expect(sections).toBeDefined();
-    expect(sections.length).toBe(4);
+    sectionAppMenu.type = 'fluid';
+
+    expect(sectionAppMenu.type).toBe('fluid');
+
+    sectionAppMenu.type = 'search';
+
+    expect(sectionAppMenu.type).toBe('search');
+
+    // Setting a junk value defaults `type` to `static`
+    sectionAppMenu.type = 'junk';
+
+    expect(sectionAppMenu.type).toBe('static');
   });
 
-  it('can get a list of its items', () => {
-    const items = toolbar.items;
+  it('can be aligned', () => {
+    expect(sectionTitle.align).toBe('start');
+    expect(sectionTitle.container.classList.contains('align-start')).toBeTruthy();
 
-    expect(items).toBeDefined();
-    expect(items.length).toBe(6);
-  });
+    expect(sectionButtonset.align).toBe('end');
+    expect(sectionButtonset.container.classList.contains('align-end')).toBeTruthy();
 
-  it('can announce what is focused and navigate among its items', () => {
-    const items = toolbar.items;
+    sectionTitle.align = 'center';
 
-    // Navigate forward (down) 2 items
-    toolbar.navigate(2, true);
+    expect(sectionTitle.align).toBe('center');
+    expect(sectionTitle.container.classList.contains('align-center')).toBeTruthy();
 
-    // The component should be able to explain which of its items is focused
-    expect(toolbar.focused).toEqual(items[2]);
+    // Setting a junk value defaults to `align-start`, but removes the attribute
+    sectionTitle.align = 'junk';
 
-    // Navigate backward (up) 1 item
-    toolbar.navigate(-1, true);
-
-    expect(toolbar.focused).toEqual(items[1]);
-
-    // Won't navigate anywhere if a junk/NaN value is provided
-    toolbar.navigate('forward', true);
-
-    expect(toolbar.focused).toEqual(items[1]);
-  });
-
-  it('navigates nowhere if no number of steps is provided', () => {
-    button1.focus();
-    toolbar.navigate();
-
-    expect(toolbar.focused).toEqual(button1);
-  });
-
-  it('loops around if `navigate()` tries to go too far', () => {
-    sectionMore.focus();
-    toolbar.navigate(1, true);
-
-    expect(toolbar.focused).toEqual(buttonAppMenu);
-
-    toolbar.navigate(-1, true);
-
-    expect(toolbar.focused).toEqual(sectionMore.button);
-  });
-
-  it('skips disabled items while navigating', () => {
-    button2.focus();
-    toolbar.navigate(1, true);
-
-    // Button 3 is disabled, Button 4 should become focused
-    expect(toolbar.focused).toEqual(button4);
-  });
-
-  it('navigates menu items using the keyboard', () => {
-    const navigateLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-    const navigateRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-
-    // Focus the first one
-    button1.focus();
-
-    expect(toolbar.focused).toEqual(button1);
-
-    // Navigate right one item
-    toolbar.dispatchEvent(navigateRightEvent);
-
-    expect(toolbar.focused).toEqual(button2);
-
-    // Navigate left two items (navigation will wrap to the bottom item)
-    toolbar.dispatchEvent(navigateLeftEvent);
-    toolbar.dispatchEvent(navigateLeftEvent);
-
-    expect(toolbar.focused).toEqual(buttonAppMenu);
-  });
-
-  it('cannot navigate away from an open menu button', (done) => {
-    const navigateLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true });
-    const navigateRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
-
-    // Button 2 is the Menu Button
-    button2.focus();
-    button2.menuEl.show();
-
-    // Wait for the menu to be open
-    setTimeout(() => {
-      const topMenuItem = button2.menuEl.items[0];
-      topMenuItem.dispatchEvent(navigateRightEvent);
-
-      expect(button2.menuEl.visible).toBeTruthy();
-
-      topMenuItem.dispatchEvent(navigateLeftEvent);
-
-      expect(button2.menuEl.visible).toBeTruthy();
-      done();
-    }, 30);
+    expect(sectionTitle.align).toBe('start');
+    expect(sectionTitle.container.classList.contains('align-start')).toBeTruthy();
+    expect(sectionTitle.getAttribute('align')).toBe(null);
   });
 });

--- a/test/ids-toolbar/ids-toolbar-section-func-test.js
+++ b/test/ids-toolbar/ids-toolbar-section-func-test.js
@@ -73,12 +73,6 @@ describe('IdsToolbarSection Component', () => {
   let sectionAppMenu;
   let sectionTitle;
   let sectionButtonset;
-  let sectionMore;
-  let buttonAppMenu;
-  let button1;
-  let button2;
-  let button3;
-  let button4;
 
   beforeEach(async () => {
     const elem = new IdsToolbar();
@@ -90,12 +84,6 @@ describe('IdsToolbarSection Component', () => {
     sectionAppMenu = document.querySelector('#appmenu-section');
     sectionTitle = document.querySelector('#title-section');
     sectionButtonset = document.querySelector('#buttonset-section');
-    sectionMore = document.querySelector('ids-toolbar-more-actions');
-    buttonAppMenu = document.querySelector('#button-appmenu');
-    button1 = document.querySelector('#button-1');
-    button2 = document.querySelector('#button-2');
-    button3 = document.querySelector('#button-3');
-    button4 = document.querySelector('#button-4');
   });
 
   afterEach(async () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes a few additions:
- Fixes some issues in the construction of the `IdsPopupMenu` that prevented some of its components from communicating between each other when they were present inside a shadow root (infor-design/enterprise#4892).  A new library, `IdsDOMUtils`, has been added and includes some tools that enable traversal across Shadow DOM boundaries.
- Implements the `IdsToolbar`, `IdsToolbarSection`, and `IdsToolbarMoreActions` components. (infor-design/enterprise#4778)
- Adds most functionality from the Flex Toolbar into IdsToolbar (section types, alignments, API for accessing items/sections, disabled/tabbable on the Toolbar, keyboard handling).
- Tests/Examples/Docs/etc
- The Toolbar More Actions Button implementation demonstrates how a Menu Button works while in a shadow root

This PR doesn't yet implement the full functionality of the Overflow menu into the Toolbar's More Actions button.  We need to complete the work on IdsContainer, and add some additional improvements to the IdsPopup placement algorithm before that work can be completed.  The More Actions Button does support having pre-defined menu items, which is what all the samples will display for now.

**Related github/jira issue (required)**:
- Closes infor-design/enterprise#4892
- Closes infor-design/enterprise#4778

**Steps necessary to review your pull request (required)**:
- Pull, build, run
- Open http://localhost:4300/ids-toolbar
- Try navigation with the keyboard.  Arrow keys navigate.  Using Enter will open the Menu Buttons. The default example is exactly like the default 4.x, where only one item has a 0-or-more tabIndex at a time.  Also see http://localhost:4300/ids-toolbar/tabbable, which provides Tab/Shift+Tab as a way to navigate between items.
- Try using the More Actions button.  The base of the Menu Button structure exists in Shadow Root, but a slot is provided for passing in the contents of a Popup Menu.  It should not be possible to navigate the Toolbar while focus is on a Menu Button's menu item.
- See the disabled style:  http://localhost:4300/ids-toolbar/disabled - Toolbar contents shouldn't respond.  The text is currently not responding to changes in disabled state, but that should be fixed in an additional PR (@tmcconechy).
- http://localhost:4300/ids-toolbar/no-eyebrow shows a Toolbar sample without the additional "Eyebrow" text.
- http://localhost:4300/ids-toolbar/centered demonstrates a Toolbar with a center-aligned Buttonset element.
- http://localhost:4300/ids-toolbar/standalone-css shows the style only.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.