### PR TITLE
Ids text weight and default ellipsis overflow

### DIFF
--- a/app/ids-text/example.html
+++ b/app/ids-text/example.html
@@ -24,6 +24,6 @@
     </ids-text>
     <ids-text font-size="14">Size 14 (sm)</ids-text>
     <ids-text font-size="12">Size 12 (xs)</ids-text>
-      <ids-text font-size="10">Size 10</ids-text>
+    <ids-text font-size="10">Size 10</ids-text>
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/app/ids-text/example.html
+++ b/app/ids-text/example.html
@@ -12,8 +12,18 @@
     <ids-text font-size="24">Size 24 (lg)</ids-text>
     <ids-text font-size="20">Size 20</ids-text>
     <ids-text font-size="16">Size 16 (base)</ids-text>
+    <ids-text
+      font-size="16"
+      font-weight="bold"
+    >Size 16 + Bold
+    </ids-text>
+    <ids-text
+      font-size="16"
+      font-weight="bolder"
+    >Size 16 + Bolder
+    </ids-text>
     <ids-text font-size="14">Size 14 (sm)</ids-text>
     <ids-text font-size="12">Size 12 (xs)</ids-text>
-    <ids-text font-size="10">Size 10</ids-text>
+      <ids-text font-size="10">Size 10</ids-text>
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -71,6 +71,8 @@
   - If using properties/settings these are now attributes: dismissible, color
   - Markup has changed to a custom element `<ids-tag color="error">Text</ids-tag>`
   - Can now be imported as a single JS file and used with encapsulated styles
+- `[Text]` Add `overflow` attribute (default: `'ellipse'`, anything else will clip).
+- `[Text]` Add `font-weight` attribute (default: `'normal'`). Can specify `'bold'`/`'bolder'` now.
 - `[Textarea]` The Textarea component has been changed to a web component and renamed to ids-textarea.
   - Markup has changed to a custom element `<ids-textarea></ids-textarea>`
   - If using events, events are now plain JS events.

--- a/src/ids-base/ids-constants.js
+++ b/src/ids-base/ids-constants.js
@@ -37,6 +37,7 @@ export const props = {
   FIXED: 'fixed',
   FOCUSABLE: 'focusable',
   FONT_SIZE: 'font-size',
+  FONT_WEIGHT: 'font-weight',
   GAP: 'gap',
   GROUP: 'group',
   GROUP_DISABLED: 'group-disabled',

--- a/src/ids-base/ids-element.js
+++ b/src/ids-base/ids-element.js
@@ -80,6 +80,11 @@ class IdsElement extends HTMLElement {
 
     // Make template and shadow objects
     const template = document.createElement('template');
+
+    if (this.shadowRoot?.innerHTML) {
+      this.shadowRoot.innerHTML = '';
+    }
+
     if (!this.shadowRoot) {
       this.attachShadow({ mode: 'open' });
     }

--- a/src/ids-text/ids-text.js
+++ b/src/ids-text/ids-text.js
@@ -70,7 +70,6 @@ class IdsText extends IdsElement {
   set fontSize(value) {
     if (value) {
       this.setAttribute(props.FONT_SIZE, value);
-      this.container.classList.add(`ids-text-${value}`);
       this.render();
       return;
     }

--- a/src/ids-text/ids-text.js
+++ b/src/ids-text/ids-text.js
@@ -28,6 +28,7 @@ class IdsText extends IdsElement {
     return [
       props.TYPE,
       props.FONT_SIZE,
+      props.FONT_WEIGHT,
       props.AUDIBLE,
       'overflow'
     ];
@@ -40,20 +41,15 @@ class IdsText extends IdsElement {
   template() {
     const tag = this.type || 'span';
     let classList = 'ids-text';
-    classList += (
-      this.overflow == 'ellipsis' || !this.overflow
-    ) ? ' ellipsis' : '';
+    classList += (this.overflow === 'ellipsis') ? ' ellipsis' : '';
     classList += this.audible ? ' audible' : '';
     classList += this.fontSize ? ` ids-text-${this.fontSize}` : '';
 
     // @ts-ignore
     switch (this.fontWeight) {
-    case 'bold': {
-      classList += 'ids-text-bold';
-      break;
-    }
+    case 'bold':
     case 'bolder': {
-      classList += 'ids-text-bolder';
+      classList += ` ${this.fontWeight}`;
       break;
     }
     default: {
@@ -67,17 +63,6 @@ class IdsText extends IdsElement {
   }
 
   /**
-   * Rerender the component template
-   * @private
-   */
-  rerender() {
-    const template = document.createElement('template');
-    this.shadowRoot?.querySelector('.ids-text')?.remove();
-    template.innerHTML = this.template();
-    this.shadowRoot?.appendChild(template.content.cloneNode(true));
-  }
-
-  /**
    * Set the font size/style of the text with a class.
    * @param {string | null} value The font size in the font scheme
    * i.e. 10, 12, 16 or xs, sm, base, lg, xl
@@ -86,15 +71,28 @@ class IdsText extends IdsElement {
     if (value) {
       this.setAttribute(props.FONT_SIZE, value);
       this.container.classList.add(`ids-text-${value}`);
+      this.render();
       return;
     }
 
     this.removeAttribute(props.FONT_SIZE);
-    this.container.className = '';
-    this.container.classList.add('ids-text');
+    this.render();
   }
 
   get fontSize() { return this.getAttribute(props.FONT_SIZE); }
+
+  /**
+   * Adjust font weight; can be either "normal", "bold" or "bolder"
+   * @param {string} [value='normal'] font weight
+   */
+  set fontWeight(value) {
+    this.setAttribute(props.FONT_WEIGHT, value || 'normal');
+    this.render();
+  }
+
+  get fontWeight() {
+    return this.getAttribute(props.FONT_WEIGHT) || 'normal';
+  }
 
   /**
    * Set the type of element it is (h1-h6, span (default))
@@ -103,12 +101,12 @@ class IdsText extends IdsElement {
   set type(value) {
     if (value) {
       this.setAttribute(props.TYPE, value);
-      this.rerender();
+      this.render();
       return;
     }
 
     this.removeAttribute(props.TYPE);
-    this.rerender();
+    this.render();
   }
 
   get type() { return this.getAttribute(props.TYPE); }
@@ -120,11 +118,11 @@ class IdsText extends IdsElement {
   set audible(value) {
     if (value) {
       this.setAttribute(props.AUDIBLE, value);
-      this.rerender();
+      this.render();
       return;
     }
     this.removeAttribute(props.AUDIBLE);
-    this.rerender();
+    this.render();
   }
 
   get audible() { return this.getAttribute(props.AUDIBLE); }
@@ -133,9 +131,13 @@ class IdsText extends IdsElement {
     return this.getAttribute('overflow') || 'ellipsis';
   }
 
+  /**
+   * Set how content overflows; can specify 'ellipsis' or 'clip'
+   * @param {string} [value='ellipsis'] how content is overflow
+   */
   set overflow(value) {
     this.setAttribute('overflow', value || 'ellipsis');
-    this.rerender();
+    this.render();
   }
 }
 

--- a/src/ids-text/ids-text.js
+++ b/src/ids-text/ids-text.js
@@ -25,7 +25,12 @@ class IdsText extends IdsElement {
    * @returns {Array} The properties in an array
    */
   static get properties() {
-    return [props.TYPE, props.FONT_SIZE, props.AUDIBLE];
+    return [
+      props.TYPE,
+      props.FONT_SIZE,
+      props.AUDIBLE,
+      'overflow'
+    ];
   }
 
   /**
@@ -35,8 +40,27 @@ class IdsText extends IdsElement {
   template() {
     const tag = this.type || 'span';
     let classList = 'ids-text';
+    classList += (
+      this.overflow == 'ellipsis' || !this.overflow
+    ) ? ' ellipsis' : '';
     classList += this.audible ? ' audible' : '';
     classList += this.fontSize ? ` ids-text-${this.fontSize}` : '';
+
+    // @ts-ignore
+    switch (this.fontWeight) {
+    case 'bold': {
+      classList += 'ids-text-bold';
+      break;
+    }
+    case 'bolder': {
+      classList += 'ids-text-bolder';
+      break;
+    }
+    default: {
+      break;
+    }
+    }
+
     classList = ` class="${classList}"`;
 
     return `<${tag}${classList}><slot></slot></${tag}>`;
@@ -104,6 +128,15 @@ class IdsText extends IdsElement {
   }
 
   get audible() { return this.getAttribute(props.AUDIBLE); }
+
+  get overflow() {
+    return this.getAttribute('overflow') || 'ellipsis';
+  }
+
+  set overflow(value) {
+    this.setAttribute('overflow', value || 'ellipsis');
+    this.rerender();
+  }
 }
 
 export default IdsText;

--- a/src/ids-text/ids-text.scss
+++ b/src/ids-text/ids-text.scss
@@ -15,6 +15,14 @@
   &.ellipsis {
     @include ellipsis;
   }
+
+  &.bold {
+    @include font-bold;
+  }
+
+  &.bolder {
+    @include font-extrabold;
+  }
 }
 
 :host(.inline) {

--- a/src/ids-text/ids-text.scss
+++ b/src/ids-text/ids-text.scss
@@ -11,6 +11,10 @@
   &.audible {
     @include audible();
   }
+
+  &.ellipsis {
+    @include ellipsis;
+  }
 }
 
 :host(.inline) {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
- For `IdsText`, overflow text ellipsis was not possible as it is in a span which has a quirk in CSS. Added `overflow` property which defaults to `ellipsis` behavior. Specifying `clip` or `none` would remove this functionality.
- Also added a `font-weight` property as the component injects `font-weight: 400`. 

Aliased `extrabold` as `bolder` since `extrabold` can be confused with two words without hyphen but internally in our code does not have hyphen.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Needed to address infor-design/enterprise-wc#56

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull branch `ids-text-weight-and-default-ellipsis-overflow` and run dev server locally via `npm run start`.
- visit http://localhost:4300/ and scroll to `TEXTS/TYPOGRAPHY`
- in Chrome Inspector, set `<ids-layout-grid-cell>` surrounding the text demo section to have `element.style` `max-width: 100px` and see that text ellipsis properly.
![image](https://user-images.githubusercontent.com/1799905/113883365-18aae280-978c-11eb-98d2-c061b645d689.png)
- edit an `ids-text` component to have font weight of `bold`. Notice that the text changes properly.
![Kapture 2021-04-07 at 10 51 20](https://user-images.githubusercontent.com/1799905/113887159-43e30100-978f-11eb-9b47-e4f8a9274777.gif)

--------------------

+ also have a fix in this PR so that calling `this.render()` clears inner shadow DOM HTML if it existed already without duplicating markup. 

This allows us to use it predictably in lifecycle without having to add second `rerender()` methods when all we would like to do is modify the template.

Spoke with @EdwardCoyle on this change but if there's any problems it creates please let me know.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [X] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
