### PR TITLE
IdsElement ::host support and mock test decoupling

### DIFF
--- a/src/ids-base/ids-element.js
+++ b/src/ids-base/ids-element.js
@@ -112,8 +112,10 @@ class IdsElement extends HTMLElement {
       const style = document.createElement('style');
       // @ts-ignore
       style.textContent = this.cssStyles;
-      if (style.textContent?.indexOf(':host') === 0) {
-        style.textContent = style.textContent.replace(':host', `.${this.name}`);
+      // @ts-ignore
+      if (/^:?:host/.test(style.textContent)) {
+        // @ts-ignore
+        style.textContent = style.textContent.replace(/^:?:host/, `.${this.name}`);
       }
       style.setAttribute('nonce', '0a59a005'); // TODO: Make this a setting
       this.shadowRoot?.appendChild(style);

--- a/src/ids-base/ids-element.js
+++ b/src/ids-base/ids-element.js
@@ -111,8 +111,12 @@ class IdsElement extends HTMLElement {
     if (this.cssStyles && !this.shadowRoot.adoptedStyleSheets && typeof this.cssStyles === 'string') {
       const style = document.createElement('style');
       // @ts-ignore
-      style.textContent = this.cssStyles.replace(/^:(:)?host/, `.${this.name}`);
+      style.textContent = this.cssStyles;
       // @ts-ignore
+      if (/^:(:)?host/.test(style.textContent)) {
+        // @ts-ignore
+        style.textContent = style.textContent.replace(/^:(:)?host/, `.${this.name}`);
+      }
       style.setAttribute('nonce', '0a59a005'); // TODO: Make this a setting
       this.shadowRoot?.appendChild(style);
     }

--- a/src/ids-base/ids-element.js
+++ b/src/ids-base/ids-element.js
@@ -113,9 +113,9 @@ class IdsElement extends HTMLElement {
       // @ts-ignore
       style.textContent = this.cssStyles;
       // @ts-ignore
-      if (/^:?:host/.test(style.textContent)) {
+      if (/^:(:)?host/.test(style.textContent)) {
         // @ts-ignore
-        style.textContent = style.textContent.replace(/^:?:host/, `.${this.name}`);
+        style.textContent = style.textContent.replace(/^:(:)?host/, `.${this.name}`);
       }
       style.setAttribute('nonce', '0a59a005'); // TODO: Make this a setting
       this.shadowRoot?.appendChild(style);

--- a/src/ids-base/ids-element.js
+++ b/src/ids-base/ids-element.js
@@ -111,12 +111,8 @@ class IdsElement extends HTMLElement {
     if (this.cssStyles && !this.shadowRoot.adoptedStyleSheets && typeof this.cssStyles === 'string') {
       const style = document.createElement('style');
       // @ts-ignore
-      style.textContent = this.cssStyles;
+      style.textContent = this.cssStyles.replace(/^:(:)?host/, `.${this.name}`);
       // @ts-ignore
-      if (/^:(:)?host/.test(style.textContent)) {
-        // @ts-ignore
-        style.textContent = style.textContent.replace(/^:(:)?host/, `.${this.name}`);
-      }
       style.setAttribute('nonce', '0a59a005'); // TODO: Make this a setting
       this.shadowRoot?.appendChild(style);
     }

--- a/test/ids-base/ids-base-func-test.js
+++ b/test/ids-base/ids-base-func-test.js
@@ -3,6 +3,7 @@
  */
 import IdsTag from '../../src/ids-tag/ids-tag';
 import { IdsElement } from '../../src/ids-base/ids-element';
+import styleMock from '../helpers/style-mock';
 
 describe('IdsBase Tests', () => {
   afterEach(async () => {
@@ -24,12 +25,15 @@ describe('IdsBase Tests', () => {
 
   it('replace host with name of the component when adoptedStyleSheets are not supported (mocked)', () => {
     const elem = new IdsTag();
-    elem.cssStyles = `:host {}`;
+    const expectedStyleContent = styleMock.replace(':host', `.${elem.tagName.toLowerCase()}`);
+    elem.cssStyles = styleMock;
     elem.render();
-    expect(elem.shadowRoot.querySelector('style').textContent).toEqual('.ids-tag { background-color: transparent; }');
+    expect(elem.shadowRoot.querySelector('style').textContent).toEqual(expectedStyleContent);
 
-    elem.cssStyles = `::host {}`;
+    // also test with '::host' for good measure
+    elem.cssStyles = styleMock.replace(`:host`, '::host');
     elem.render();
-    expect(elem.shadowRoot.querySelector('style').textContent).toEqual('.ids-tag { background-color: transparent; }');
+
+    expect(elem.shadowRoot.querySelector('style').textContent).toEqual(expectedStyleContent);
   });
 });

--- a/test/ids-base/ids-base-func-test.js
+++ b/test/ids-base/ids-base-func-test.js
@@ -35,5 +35,10 @@ describe('IdsBase Tests', () => {
     elem.render();
 
     expect(elem.shadowRoot.querySelector('style').textContent).toEqual(expectedStyleContent);
+
+    // add coverage where there is pre-formatted styles
+    elem.cssStyles = expectedStyleContent;
+    elem.render();
+    expect(elem.shadowRoot.querySelector('style').textContent).toEqual(expectedStyleContent);
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
There were potential issues with `::host` (vs `:host`) not tested that make IdsElement unpredictable in some use cases, since this is a criteria. So added support for that small variant + de-hardcoded/coupled stylemock from some related tests that were also having issue there on another branch.

Pushing this here separately as not to further bloat upcoming PRs.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Related to work on enterprise/issues/5026 -- but can help others not figure out what went wrong on tests in future scenarios.

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull `ids-element-host-css-and-mock-iteration`
- `npm run test -- ids-base-func-test`

Should work as expected.

**Included in this Pull Request**:
- [X] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
