### PR TITLE
5112 - Implement Shared Mixin Properties

### DIFF
--- a/app/ids-button/performance.html
+++ b/app/ids-button/performance.html
@@ -1,0 +1,10 @@
+{{> ../layouts/head.html }}
+
+<ids-layout-grid>
+  <ids-text font-size="12" type="h1">IdsButton Performance Test</ids-text>
+</ids-layout-grid>
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell></ids-layout-grid-cell>
+</ids-layout-grid>
+
+{{> ../layouts/footer.html }}

--- a/app/ids-button/performance.js
+++ b/app/ids-button/performance.js
@@ -1,0 +1,17 @@
+import IdsButton from '../../src/ids-button/ids-button';
+
+const appendTestItems = () => {
+  const section = document.querySelector('ids-layout-grid-cell');
+  for (let index = 0; index < 1000; index++) {
+    let html = '';
+    html += `<ids-button id="button-${index}" type="secondary">
+      Button ${index}
+    </ids-button>`;
+    section.insertAdjacentHTML('beforeend', html);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  appendTestItems();
+  console.info(window.performance.now());
+});

--- a/src/ids-base/ids-element.js
+++ b/src/ids-base/ids-element.js
@@ -69,6 +69,13 @@ class IdsElement extends HTMLElement {
   }
 
   /**
+   * @returns {Array<string>} this component's observable properties
+   */
+  static get properties() {
+    return [];
+  }
+
+  /**
    * Render the component using the defined template.
    * @returns {object} The object for chaining.
    */

--- a/src/ids-base/ids-theme-mixin.js
+++ b/src/ids-base/ids-theme-mixin.js
@@ -17,6 +17,15 @@ const IdsThemeMixin = (superclass) => class extends superclass {
     ]);
   }
 
+  /*
+  static get properties() {
+    return [...super.properties,
+      props.MODE,
+      props.VERSION
+    ];
+  }
+  */
+
   connectedCallback() {
     this.initThemeHandlers();
   }

--- a/src/ids-base/ids-theme-mixin.js
+++ b/src/ids-base/ids-theme-mixin.js
@@ -1,3 +1,5 @@
+import { props } from './ids-constants';
+
 /**
  * A mixin that adds theming functionality to components
  * @param {any} superclass Accepts a superclass and creates a new subclass from it
@@ -6,6 +8,13 @@
 const IdsThemeMixin = (superclass) => class extends superclass {
   constructor() {
     super();
+  }
+
+  static get properties() {
+    return super.properties.concat([
+      props.MODE,
+      props.VERSION
+    ]);
   }
 
   connectedCallback() {

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -40,9 +40,7 @@ const BUTTON_PROPS = [
   props.ID,
   props.TEXT,
   props.TYPE,
-  props.TABINDEX,
-  props.MODE,
-  props.VERSION
+  props.TABINDEX
 ];
 
 // Icon alignments
@@ -111,7 +109,7 @@ class IdsButton extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixin,
    * @returns {Array} The properties in an array
    */
   static get properties() {
-    return BUTTON_PROPS;
+    return super.properties.concat(BUTTON_PROPS);
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR is an example of how we could solve the issue of sharing specific properties from the mixins up the prototype chain, better separating out the concerns of the mixin from the base classes.  In this PR, the `IdsThemeMixin`'s properties have been moved into the theme mixin code, and are shared via concatenation to the `IdsButton` base class, which looks for `super.properties` and concatenates its own properties there.

This reduced case is basically what I showed in our 4/20/2021 call, but applied to something already in the codebase.  We can discuss/change/etc here.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#5112

**Steps necessary to review your pull request (required)**:
- Pull, build, run
- Open http://localhost:4300/ids-button
- Open dev tools and inspect the first button element.  Change its `mode` property to `contrast`.  the button color should change, responding to the altering the property defined in the mixin.  Also change `version` to `classic` to see that property change.

*For checking performance: Open http://localhost:4300/ids-button/performance*
This page has 1000 buttons loaded into the DOM after a `DOMContentLoaded` event is fired.  After the button render completes, a console message displays with a reading from `window.performance.now()`.  I was also testing this with the performance tab in Dev Tools, but both are showing on average that the spread syntax is slightly faster here (maybe on average 300-500ms).

Note that the theme mixin still works throughout other components here because all the other components still contain `mode` and `version` in their own properties arrays, and will need to be modified to actually accept the shared properties if we choose this route.

cc @lucacolumbu 
