### PR TITLE
5049 - Typescript Typings Support iteration/cleanup

### DIFF
--- a/src/ids-accordion/ids-accordion-header.js
+++ b/src/ids-accordion/ids-accordion-header.js
@@ -6,11 +6,8 @@ import {
   mix
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-accordion-header.scss';
-// @ts-ignore
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
-// @ts-ignore
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 
 // Default Icons

--- a/src/ids-accordion/ids-accordion-panel.js
+++ b/src/ids-accordion/ids-accordion-panel.js
@@ -9,7 +9,6 @@ import {
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsKeyboardMixin } from '../ids-base/ids-keyboard-mixin';
 
-// @ts-ignore
 import styles from './ids-accordion-panel.scss';
 
 /**

--- a/src/ids-accordion/ids-accordion.js
+++ b/src/ids-accordion/ids-accordion.js
@@ -6,15 +6,10 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-accordion.scss';
-// @ts-ignore
 import IdsAccordionHeader from './ids-accordion-header';
-// @ts-ignore
 import IdsAccordionPanel from './ids-accordion-panel';
-// @ts-ignore
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
-// @ts-ignore
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 
 /**

--- a/src/ids-alert/ids-alert.js
+++ b/src/ids-alert/ids-alert.js
@@ -9,11 +9,9 @@ import {
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import IdsIcon from '../ids-icon/ids-icon';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore
 import styles from './ids-alert.scss';
 
 /**

--- a/src/ids-badge/ids-badge.js
+++ b/src/ids-badge/ids-badge.js
@@ -9,7 +9,6 @@ import {
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import styles from './ids-badge.scss';
 
 /**

--- a/src/ids-base/ids-data-source.js
+++ b/src/ids-base/ids-data-source.js
@@ -54,7 +54,6 @@ class IdsDataSource {
    * @param  {Function|null} primer Optional primer function
    */
   sort(field, reverse, primer) {
-    // @ts-ignore
     const sort = this.sortFunction(field, reverse, primer);
     this.currentData.sort(sort);
   }

--- a/src/ids-base/ids-deep-clone-utils.js
+++ b/src/ids-base/ids-deep-clone-utils.js
@@ -25,9 +25,7 @@ const IdsDeepCloneUtils = {
     }
 
     const objClone = {};
-    // @ts-ignore
     this.refs.push(obj);
-    // @ts-ignore
     this.refsNew.push(objClone);
 
     for (const k in obj) {
@@ -41,7 +39,6 @@ const IdsDeepCloneUtils = {
       } else if (cur instanceof Date) {
         objClone[k] = new Date(cur);
       } else {
-        // @ts-ignore
         const i = this.refs.indexOf(cur);
         if (i !== -1) {
           objClone[k] = this.refsNew[i];
@@ -74,7 +71,6 @@ const IdsDeepCloneUtils = {
       } else if (cur instanceof Date) {
         arrClone[k] = new Date(cur);
       } else {
-        // @ts-ignore
         const index = this.refs.indexOf(cur);
         if (index !== -1) {
           arrClone[k] = this.refsNew[index];

--- a/src/ids-base/ids-dirty-tracker-mixin.js
+++ b/src/ids-base/ids-dirty-tracker-mixin.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 import IdsIcon from '../ids-icon/ids-icon';
 
 /**

--- a/src/ids-base/ids-element.js
+++ b/src/ids-base/ids-element.js
@@ -46,15 +46,11 @@ class IdsElement extends HTMLElement {
    * in a component you can just call super.
    */
   disconnectedCallback() {
-    // @ts-ignore
     if (this.detachAllEvents) {
-      // @ts-ignore
       this.detachAllEvents();
     }
 
-    // @ts-ignore
     if (this.detachAllListeners) {
-      // @ts-ignore
       this.detachAllListeners();
     }
   }
@@ -64,7 +60,6 @@ class IdsElement extends HTMLElement {
    * @type {Array}
    */
   static get observedAttributes() {
-    // @ts-ignore
     return this.properties;
   }
 
@@ -80,7 +75,6 @@ class IdsElement extends HTMLElement {
    * @returns {object} The object for chaining.
    */
   render() {
-    // @ts-ignore
     if (!this.template || !this.template()) {
       return this;
     }
@@ -97,7 +91,6 @@ class IdsElement extends HTMLElement {
     }
 
     this.appendStyles();
-    // @ts-ignore
     template.innerHTML = this.template();
     this.shadowRoot?.appendChild(template.content.cloneNode(true));
     /** @type {any} */
@@ -122,26 +115,19 @@ class IdsElement extends HTMLElement {
    * Append Styles if present
    */
   appendStyles() {
-    // @ts-ignore
     if (this.cssStyles && !this.shadowRoot.adoptedStyleSheets && typeof this.cssStyles === 'string') {
       const style = document.createElement('style');
-      // @ts-ignore
       style.textContent = this.cssStyles;
-      // @ts-ignore
       if (/^:(:)?host/.test(style.textContent)) {
-        // @ts-ignore
         style.textContent = style.textContent.replace(/^:(:)?host/, `.${this.name}`);
       }
       style.setAttribute('nonce', '0a59a005'); // TODO: Make this a setting
       this.shadowRoot?.appendChild(style);
     }
 
-    // @ts-ignore
     if (this.cssStyles && this.shadowRoot.adoptedStyleSheets) {
       const style = new CSSStyleSheet();
-      // @ts-ignore
       style.replaceSync(this.cssStyles);
-      // @ts-ignore
       this.shadowRoot.adoptedStyleSheets = [style];
     }
   }

--- a/src/ids-base/ids-events-mixin.js
+++ b/src/ids-base/ids-events-mixin.js
@@ -74,7 +74,6 @@ const IdsEventsMixin = (superclass) => class extends superclass {
     if (isValidName && this.handledEvents.has(eventName)) {
       const event = this.handledEvents.get(eventName);
 
-      // @ts-ignore
       this.offEvent(eventName, event.target, event.options);
     }
   };

--- a/src/ids-base/ids-mixin.js
+++ b/src/ids-base/ids-mixin.js
@@ -15,7 +15,6 @@ class MixinBuilder {
    * @returns {HTMLElement} the new "mixed" Class
    */
   with(...mixins) {
-    // @ts-ignore
     return mixins.reduce((c, mixin) => mixin(c), this.superclass);
   }
 }

--- a/src/ids-base/ids-resize-mixin.js
+++ b/src/ids-base/ids-resize-mixin.js
@@ -26,9 +26,7 @@ const IdsResizeMixin = (superclass) => class extends superclass {
    * @returns {void}
    */
   checkForIDS() {
-    // @ts-ignore
     if (!window.Ids) {
-      // @ts-ignore
       window.Ids = {};
     }
   }
@@ -43,10 +41,8 @@ const IdsResizeMixin = (superclass) => class extends superclass {
     // Build the global instance of it doesn't exist.
     // The global resize handler will attempt to run a `refresh` method
     // if it finds one on any registered component.
-    // @ts-ignore
     if (!window.Ids.resizeObserver && typeof ResizeObserver !== 'undefined') {
       /* istanbul ignore next */
-      // @ts-ignore
       window.Ids.resizeObserver = new ResizeObserver(() => {
         resizeTargets.forEach((e) => {
           if (typeof e.refresh === 'function') {
@@ -59,7 +55,6 @@ const IdsResizeMixin = (superclass) => class extends superclass {
     // Connect the `ro` property to the global instance
     /* istanbul ignore next */
     if (!this.ro) {
-      // @ts-ignore
       this.ro = window.Ids.resizeObserver;
     }
 
@@ -89,7 +84,6 @@ const IdsResizeMixin = (superclass) => class extends superclass {
    * for Resize instructions.
    */
   shouldResize() {
-    // @ts-ignore
     return typeof ResizeObserver !== 'undefined' && this.ro instanceof ResizeObserver;
   }
 

--- a/src/ids-block-grid/ids-block-grid-item.js
+++ b/src/ids-block-grid/ids-block-grid-item.js
@@ -3,7 +3,6 @@ import {
   customElement,
   scss
 } from '../ids-base/ids-element';
-// @ts-ignore
 import styles from './ids-block-grid-item.scss';
 
 /**

--- a/src/ids-block-grid/ids-block-grid.js
+++ b/src/ids-block-grid/ids-block-grid.js
@@ -4,7 +4,6 @@ import {
   scss
 } from '../ids-base/ids-element';
 import { props } from '../ids-base/ids-constants';
-// @ts-ignore
 import styles from './ids-block-grid.scss';
 
 /**

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -11,7 +11,6 @@ import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsRenderLoopMixin, IdsRenderLoopItem } from '../ids-render-loop/ids-render-loop-mixin';
 
-// @ts-ignore
 import styles from './ids-button.scss';
 
 // Button Styles
@@ -346,7 +345,6 @@ class IdsButton extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixin,
    * @returns {undefined|string} a defined IdsIcon's `icon` attribute, if one is present
    */
   get icon() {
-    // @ts-ignore
     return this.querySelector('ids-icon')?.getAttribute('icon');
   }
 
@@ -610,7 +608,7 @@ class IdsButton extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixin,
     if (this.rippleTimeout) {
       this.rippleTimeout.destroy(true);
     }
-    // @ts-ignore
+
     this.rippleTimeout = this.rl.register(new IdsRenderLoopItem({
       duration: 1200,
       timeoutCallback() {

--- a/src/ids-card/ids-card.js
+++ b/src/ids-card/ids-card.js
@@ -9,7 +9,6 @@ import {
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import styles from './ids-card.scss';
 
 /**

--- a/src/ids-checkbox/ids-checkbox.js
+++ b/src/ids-checkbox/ids-checkbox.js
@@ -6,7 +6,6 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-checkbox.scss';
 
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
@@ -15,8 +14,6 @@ import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsDirtyTrackerMixin } from '../ids-base/ids-dirty-tracker-mixin';
 import { IdsValidationMixin } from '../ids-base/ids-validation-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
-
-// @ts-ignore
 import IdsText from '../ids-text/ids-text';
 
 /**
@@ -243,7 +240,7 @@ class IdsCheckbox extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.DIRTY_TRACKER);
     }
-    // @ts-ignore
+
     this.handleDirtyTracker();
   }
 
@@ -357,7 +354,7 @@ class IdsCheckbox extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATE);
     }
-    // @ts-ignore
+
     this.handleValidation();
   }
 
@@ -373,7 +370,6 @@ class IdsCheckbox extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATION_EVENTS);
     }
-    // @ts-ignore
     this.handleValidation();
   }
 

--- a/src/ids-container/ids-container.js
+++ b/src/ids-container/ids-container.js
@@ -11,7 +11,6 @@ import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore Import inline styles
 import styles from './ids-container.scss';
 
 /**

--- a/src/ids-data-grid/ids-data-grid.js
+++ b/src/ids-data-grid/ids-data-grid.js
@@ -14,9 +14,7 @@ import { IdsKeyboardMixin } from '../ids-base/ids-keyboard-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import IdsVirtualScroll from '../ids-virtual-scroll/ids-virtual-scroll';
-// @ts-ignore
 import styles from './ids-data-grid.scss';
 
 /**
@@ -491,7 +489,6 @@ class IdsDataGrid extends mix(IdsElement).with(
 
     this.activeCell.node = cellNode;
     cellNode.setAttribute('tabindex', '0');
-    // @ts-ignore
     cellNode.focus();
 
     this.triggerEvent('activecellchanged', this, { detail: { elem: this, activeCell: this.activeCell } });

--- a/src/ids-expandable-area/ids-expandable-area.js
+++ b/src/ids-expandable-area/ids-expandable-area.js
@@ -9,7 +9,6 @@ import {
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import styles from './ids-expandable-area.scss';
 
 const EXPANDABLE_AREA_TYPES = [
@@ -40,10 +39,8 @@ class IdsExpandableArea extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMix
     /** @type {HTMLElement | undefined | null} */
     this.expander = this.shadowRoot?.querySelector('[data-expander]');
     /** @type {HTMLElement | undefined | null} */
-    // @ts-ignore
     this.expanderDefault = this.shadowRoot?.querySelector('[name="expander-default"]');
     /** @type {HTMLElement | undefined | null} */
-    // @ts-ignore
     this.expanderExpanded = this.shadowRoot?.querySelector('[name="expander-expanded"]');
     /** @type {HTMLElement | undefined | null} */
     this.pane = this.shadowRoot?.querySelector('.ids-expandable-area-pane');

--- a/src/ids-hyperlink/ids-hyperlink.js
+++ b/src/ids-hyperlink/ids-hyperlink.js
@@ -11,7 +11,6 @@ import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore
 import styles from './ids-hyperlink.scss';
 
 /**

--- a/src/ids-icon/ids-icon.js
+++ b/src/ids-icon/ids-icon.js
@@ -6,7 +6,6 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-icon.scss';
 
 // Setting Defaults

--- a/src/ids-input/ids-input.js
+++ b/src/ids-input/ids-input.js
@@ -6,15 +6,11 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-input.scss';
 
 // Supporting components
-// @ts-ignore
 import IdsIcon from '../ids-icon/ids-icon';
-// @ts-ignore
 import IdsText from '../ids-text/ids-text';
-// @ts-ignore
 import IdsTriggerButton from '../ids-trigger-field/ids-trigger-button';
 
 // Mixins
@@ -359,7 +355,6 @@ class IdsInput extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.CLEARABLE);
     }
-    // @ts-ignore
     this.handleClearable();
   }
 
@@ -376,7 +371,6 @@ class IdsInput extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.CLEARABLE_FORCED);
     }
-    // @ts-ignore
     this.handleClearable();
   }
 
@@ -393,7 +387,6 @@ class IdsInput extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.DIRTY_TRACKER);
     }
-    // @ts-ignore
     this.handleDirtyTracker();
   }
 
@@ -549,7 +542,6 @@ class IdsInput extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATE);
     }
-    // @ts-ignore
     this.handleValidation();
   }
 
@@ -565,7 +557,6 @@ class IdsInput extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATION_EVENTS);
     }
-    // @ts-ignore
     this.handleValidation();
   }
 

--- a/src/ids-layout-grid/ids-layout-grid.js
+++ b/src/ids-layout-grid/ids-layout-grid.js
@@ -5,7 +5,6 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-layout-grid.scss';
 
 /**

--- a/src/ids-list-view/ids-list-view.js
+++ b/src/ids-list-view/ids-list-view.js
@@ -11,9 +11,7 @@ import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 
-// @ts-ignore
 import IdsVirtualScroll from '../ids-virtual-scroll/ids-virtual-scroll';
-// @ts-ignore
 import styles from './ids-list-view.scss';
 
 /**
@@ -59,11 +57,9 @@ class IdsListView extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
   template() {
     let html = '';
 
-    // @ts-ignore
     if (this?.data.length > 0 && this.virtualScroll !== 'true') {
       html = `<div class="ids-list-view" part="container"><ul part="list">`;
 
-      // @ts-ignore
       this.data.forEach((item) => {
         html += `<li part="list-item">${this.itemTemplate(item)}</li>`;
       });
@@ -72,7 +68,6 @@ class IdsListView extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
       return html;
     }
 
-    // @ts-ignore
     if (this?.data.length > 0 && this.virtualScroll === 'true') {
       html = `<ids-virtual-scroll height="310">
           <div class="ids-list-view" part="container">
@@ -91,7 +86,6 @@ class IdsListView extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
    * @returns {string} The html for this item
    */
   itemTemplate(item) {
-    // @ts-ignore
     return stringUtils.injectTemplate(this.defaultTemplate, item);
   }
 
@@ -103,25 +97,18 @@ class IdsListView extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
     const template = document.createElement('template');
     const html = this.template();
 
-    // @ts-ignore
     this.shadowRoot.innerHTML = '';
     template.innerHTML = html;
-    // @ts-ignore
     this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-    // @ts-ignore
     if (stringUtils.stringToBool(this.virtualScroll) && this?.data.length > 0) {
       /** @type {object} */
-      // @ts-ignore
       this.virtualScrollContainer = this.shadowRoot.querySelector('ids-virtual-scroll');
       this.virtualScrollContainer.itemTemplate = (/** @type {object} */ item) => `<li part="listitem">${this.itemTemplate(item)}</li>`;
-      // @ts-ignore
       this.virtualScrollContainer.itemCount = this.data.length;
-      // @ts-ignore
       this.virtualScrollContainer.itemHeight = this.checkTemplateHeight(`<li id="height-tester">${this.itemTemplate(this.datasource.data[0])}</li>`);
       this.virtualScrollContainer.data = this.data;
 
-      // @ts-ignore
       this.shadowRoot.querySelector('.ids-list-view').style.overflow = 'initial';
     }
     this.container = this.shadowRoot.querySelector('.ids-list-view');
@@ -134,10 +121,8 @@ class IdsListView extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
    * @returns {number} The item height
    */
   checkTemplateHeight(itemTemplate) {
-    // @ts-ignore
     this.shadowRoot.querySelector('.ids-list-view ul').insertAdjacentHTML('beforeEnd', itemTemplate);
     /** @type {object} */
-    // @ts-ignore
     const tester = this.shadowRoot.querySelector('#height-tester');
     const height = tester.offsetHeight;
     tester.remove();

--- a/src/ids-loader/ids-loader.js
+++ b/src/ids-loader/ids-loader.js
@@ -9,7 +9,6 @@ import {
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import styles from './ids-loader.scss';
 
 /**

--- a/src/ids-menu-button/ids-menu-button.js
+++ b/src/ids-menu-button/ids-menu-button.js
@@ -5,15 +5,11 @@ import {
 } from '../ids-base/ids-element';
 import IdsDOMUtils from '../ids-base/ids-dom-utils';
 
-// @ts-ignore
 import { IdsButton, BUTTON_PROPS } from '../ids-button/ids-button';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
-
 import IdsIcon from '../ids-icon/ids-icon';
-// @ts-ignore
 import IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
 
-// @ts-ignore
 import styles from '../ids-button/ids-button.scss';
 
 // Property names
@@ -52,7 +48,6 @@ class IdsMenuButton extends IdsButton {
   connectedCallback() {
     this.configureMenu();
     this.handleEvents();
-    // @ts-ignore
     IdsButton.prototype.connectedCallback.apply(this);
   }
 
@@ -60,7 +55,6 @@ class IdsMenuButton extends IdsButton {
    * @returns {void}
    */
   handleEvents() {
-    // @ts-ignore
     IdsButton.prototype.handleEvents.apply(this);
   }
 
@@ -146,19 +140,15 @@ class IdsMenuButton extends IdsButton {
     }
     this.resizeMenu();
     this.setPopupArrow();
-    // @ts-ignore
     this.menuEl.trigger = 'click';
-    // @ts-ignore
     this.menuEl.target = this;
 
     // ====================================================================
     // Setup menu-specific event listeners, if they aren't already applied
 
-    // @ts-ignore
     const hasBeforeShow = this?.handledEvents?.get('beforeshow');
     if (!hasBeforeShow) {
       // On the Popup Menu's `beforeshow` event, set the menu's size to the Menu Button's
-      // @ts-ignore
       this.onEvent('beforeshow', this.menuEl, () => {
         this.resizeMenu();
       });

--- a/src/ids-menu/ids-menu-group.js
+++ b/src/ids-menu/ids-menu-group.js
@@ -9,7 +9,6 @@ import {
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 
-// @ts-ignore
 import styles from './ids-menu-group.scss';
 
 // Menu Selection Types
@@ -120,7 +119,6 @@ class IdsMenuGroup extends mix(IdsElement).with(IdsEventsMixin) {
    */
   // @TODO: TypeScript Compiler complains about this because the method is actually called from
   // the menu item.
-  // @ts-ignore
   updateIconAlignment() {
     this.items.forEach((item) => {
       // NOTE: Sometimes the group invokes before the items, making item methods inaccessible.
@@ -211,7 +209,6 @@ class IdsMenuGroup extends mix(IdsElement).with(IdsEventsMixin) {
    * @returns {void}
    */
   deselectAllExcept(keptItems) {
-    // @ts-ignore
     const keptItemsArr = [].concat(keptItems);
     this.items.forEach((item) => {
       if (!keptItemsArr.includes(item) && item.selected) {

--- a/src/ids-menu/ids-menu-header.js
+++ b/src/ids-menu/ids-menu-header.js
@@ -6,7 +6,6 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-menu-header.scss';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';

--- a/src/ids-menu/ids-menu-item.js
+++ b/src/ids-menu/ids-menu-item.js
@@ -11,10 +11,8 @@ import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsRenderLoopMixin, IdsRenderLoopItem } from '../ids-render-loop/ids-render-loop-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import IdsIcon from '../ids-icon/ids-icon';
 
-// @ts-ignore
 import styles from './ids-menu-item.scss';
 
 // @TODO handle other menu-item sizes
@@ -222,14 +220,12 @@ class IdsMenuItem extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixi
       clearHideSubmenuTimeout();
       if (!this.disabled && this.hasSubmenu) {
         clearHoverTimeout();
-        // @ts-ignore
         hoverTimeout = new IdsRenderLoopItem({
           duration: 200,
           timeoutCallback() {
             self.showSubmenu();
           }
         });
-        // @ts-ignore
         this.rl.register(hoverTimeout);
       }
 
@@ -255,7 +251,6 @@ class IdsMenuItem extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixi
 
       if (this.hasSubmenu && !this.submenu.hidden) {
         clearHideSubmenuTimeout();
-        // @ts-ignore
         hideSubmenuTimeout = new IdsRenderLoopItem({
           duration: 200,
           timeoutCallback() {
@@ -268,7 +263,6 @@ class IdsMenuItem extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixi
             }
           }
         });
-        // @ts-ignore
         this.rl.register(hideSubmenuTimeout);
       } else {
         this.unhighlight();
@@ -323,7 +317,6 @@ class IdsMenuItem extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixi
     const currentAttr = this.hasAttribute(props.DISABLED);
 
     if (trueVal) {
-      // @ts-ignore
       a.disabled = true;
       a.setAttribute(props.DISABLED, '');
       this.tabIndex = -1;
@@ -336,7 +329,6 @@ class IdsMenuItem extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixi
       return;
     }
 
-    // @ts-ignore
     a.disabled = false;
     a.removeAttribute(props.DISABLED);
     this.tabIndex = 0;
@@ -441,7 +433,6 @@ class IdsMenuItem extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEventsMixi
     // First look specifically for an icon slot.
     const icon = this.querySelector(`ids-icon[slot="icon"]`); // @TODO check for submenu icons here
     if (icon) {
-      // @ts-ignore
       icon.icon = iconName;
     } else {
       this.insertAdjacentHTML('afterbegin', `<ids-icon slot="icon" icon="${iconName}" size="${MENU_ITEM_SIZE}" class="ids-icon ids-menu-item-display-icon"></ids-icon>`);

--- a/src/ids-menu/ids-menu.js
+++ b/src/ids-menu/ids-menu.js
@@ -15,7 +15,6 @@ import IdsMenuHeader from './ids-menu-header';
 import IdsMenuItem from './ids-menu-item';
 import IdsSeparator from './ids-separator';
 
-// @ts-ignore
 import styles from './ids-menu.scss';
 import IdsDOMUtils from '../ids-base/ids-dom-utils';
 
@@ -28,7 +27,7 @@ import IdsDOMUtils from '../ids-base/ids-dom-utils';
  */
 function isValidGroup(menuGroup, idsMenu) {
   let hasGroup;
-  // @ts-ignore
+
   const isElem = menuGroup instanceof IdsMenuGroup;
   idsMenu.groups.forEach((group) => {
     if ((isElem && group.isEqualNode(menuGroup)) || (group?.id === menuGroup)) {
@@ -45,7 +44,6 @@ function isValidGroup(menuGroup, idsMenu) {
  * @returns {boolean} true if the provided element is a "currently-usable" IdsMenuItem type.
  */
 function isUsableItem(item, idsMenu) {
-  // @ts-ignore
   const isItem = item instanceof IdsMenuItem;
   if (!isItem) {
     return false;
@@ -56,9 +54,7 @@ function isUsableItem(item, idsMenu) {
 
   // In some nested cases, we need to detect the item's Shadow Root containment to accurately
   // figure out if it's slotted inside the same menu.
-  // @ts-ignore
   const closestItemRoot = IdsDOMUtils.getClosestRootNode(item.assignedSlot);
-  // @ts-ignore
   const itemInMenuShadow = closestItemRoot?.menu?.isEqualNode(idsMenu);
 
   return (itemInMenuShadow || menuHasItem) && !item.disabled;
@@ -372,11 +368,8 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
    * @returns {IdsMenuItem|undefined} the currently focused menu item, if one exists
    */
   get focused() {
-    // @ts-ignore
     return this.items.find((item) => {
-      // @ts-ignore
       const containerNode = IdsDOMUtils.getClosestContainerNode(this);
-      // @ts-ignore
       return containerNode?.activeElement?.isEqualNode(item);
     });
   }
@@ -446,7 +439,6 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
    * @returns {void}
    */
   highlightItem(menuItem) {
-    // @ts-ignore
     if (!isUsableItem(menuItem, this)) {
       return;
     }
@@ -533,7 +525,6 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
    * @returns {Array<IdsMenuItem>} list of selected menu items
    */
   getSelectedItems(menuGroup) {
-    // @ts-ignore
     const group = isValidGroup(menuGroup, this);
     return this.items.filter((item) => {
       if (group) {
@@ -558,7 +549,6 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
    * @returns {void}
    */
   selectItem(menuItem) {
-    // @ts-ignore
     if (!isUsableItem(menuItem, this)) {
       return;
     }
@@ -592,7 +582,6 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
    * @returns {void}
    */
   clearSelectedItems(menuGroup) {
-    // @ts-ignore
     const group = isValidGroup(menuGroup, this);
     this.items.forEach((item) => {
       let doDeselect;

--- a/src/ids-menu/ids-separator.js
+++ b/src/ids-menu/ids-separator.js
@@ -9,7 +9,6 @@ import {
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import styles from './ids-separator.scss';
 
 /**

--- a/src/ids-popup-menu/ids-popup-menu.js
+++ b/src/ids-popup-menu/ids-popup-menu.js
@@ -10,7 +10,6 @@ import { IdsRenderLoopItem, IdsRenderLoopMixin } from '../ids-render-loop/ids-re
 import IdsMenu from '../ids-menu/ids-menu';
 import IdsPopup from '../ids-popup/ids-popup';
 
-// @ts-ignore
 import styles from './ids-popup-menu.scss';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 
@@ -73,7 +72,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
       this.popup.align = 'right, top';
     }
 
-    // @ts-ignore
     IdsMenu.prototype.connectedCallback.apply(this);
   }
 
@@ -82,12 +80,10 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
    * @returns {void}
    */
   handleEvents() {
-    // @ts-ignore
     IdsMenu.prototype.handleEvents.apply(this);
 
     // This handler runs whenever an item contained by the Popupmenu needs to become focused.
     const doFocusHandler = () => {
-      // @ts-ignore
       this.rl.register(new IdsRenderLoopItem({
         duration: 1,
         timeoutCallback: () => {
@@ -116,7 +112,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
    * @returns {void}
    */
   handleKeys() {
-    // @ts-ignore
     IdsMenu.prototype.handleKeys.apply(this);
 
     // Arrow Right on an item containing a submenu causes that submenu to open
@@ -274,7 +269,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
    */
   addOpenEvents() {
     // Attach all these events on a Renderloop-staggered timeout
-    // @ts-ignore
     this.rl.register(new IdsRenderLoopItem({
       duration: 1,
       timeoutCallback: () => {
@@ -297,7 +291,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     if (!this.hasOpenEvents) {
       return;
     }
-    // @ts-ignore
     this.offEvent('click.toplevel', window);
     this.hasOpenEvents = false;
   }
@@ -334,7 +327,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     const beforeShowResponse = (/** @type {any} */ veto) => {
       canShow = !!veto;
     };
-    // @ts-ignore
     this.triggerEvent('beforeshow', this, {
       detail: {
         elem: this,
@@ -374,7 +366,6 @@ class IdsPopupMenu extends mix(IdsMenu).with(IdsRenderLoopMixin, IdsEventsMixin)
     submenus.forEach((submenu) => {
       const submenuIsIgnored = focusedSubmenu && focusedSubmenu.isEqualNode(submenu);
       if (!submenu.hidden && !submenuIsIgnored) {
-        // @ts-ignore
         submenu.hide();
       }
     });

--- a/src/ids-popup/ids-popup.js
+++ b/src/ids-popup/ids-popup.js
@@ -13,7 +13,6 @@ import { IdsRenderLoopMixin, IdsRenderLoopItem } from '../ids-render-loop/ids-re
 
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsResizeMixin } from '../ids-base/ids-resize-mixin';
-// @ts-ignore
 import styles from './ids-popup.scss';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
@@ -126,9 +125,7 @@ class IdsPopup extends mix(IdsElement).with(
     this.animated = this.hasAttribute('animated');
     this.trueType = this.getAttribute('type') || this.trueType;
     this.isVisible = this.hasAttribute('visible');
-    // @ts-ignore
     this.setupDetectMutations();
-    // @ts-ignore
     this.setupResize();
     this.handleEvents();
     super.connectedCallback();
@@ -144,15 +141,11 @@ class IdsPopup extends mix(IdsElement).with(
   disconnectedCallback() {
     IdsElement.prototype.disconnectedCallback.apply(this);
 
-    // @ts-ignore
     if (this.shouldResize()) {
-      // @ts-ignore
       this.disconnectResize();
     }
 
-    // @ts-ignore
     if (this.shouldDetectMutations()) {
-      // @ts-ignore
       this.disconnectDetectMutations();
     }
   }
@@ -190,7 +183,6 @@ class IdsPopup extends mix(IdsElement).with(
    * Sets the element to align with via a css selector
    * @param {string | HTMLElement | undefined} val ['string|HTMLElement'] a CSS selector string
    */
-  // @ts-ignore
   set alignTarget(val) {
     const isString = typeof val === 'string' && val.length;
     const isElem = val instanceof HTMLElement;
@@ -205,9 +197,7 @@ class IdsPopup extends mix(IdsElement).with(
     let elem;
     if (isString) {
       // @TODO Harden for security (XSS)
-      // @ts-ignore
       const rootNode = IdsDOMUtils.getClosestRootNode(this);
-      // @ts-ignore
       elem = rootNode.querySelector(val);
       if (!(elem instanceof HTMLElement)) {
         return;
@@ -217,7 +207,6 @@ class IdsPopup extends mix(IdsElement).with(
       elem = val;
     }
 
-    // @ts-ignore
     this.alignment.target = elem;
     this.refresh();
   }
@@ -226,7 +215,6 @@ class IdsPopup extends mix(IdsElement).with(
    * @returns {HTMLElement| undefined} the element in the page that the Popup will take
    * coordinates from for relative placement
    */
-  // @ts-ignore
   get alignTarget() {
     return this.alignment.target;
   }
@@ -465,13 +453,11 @@ class IdsPopup extends mix(IdsElement).with(
    * Sets the element to align with via a css selector
    * @param {any} val ['string|HTMLElement'] a CSS selector string
    */
-  // @ts-ignore
   set arrowTarget(val) {
     const isString = typeof val === 'string' && val.length;
     const isElem = val instanceof HTMLElement;
 
     if (!isString && !isElem) {
-      // @ts-ignore
       this.state.arrowTarget = undefined;
       this.removeAttribute('arrow-target');
       this.refresh();
@@ -481,9 +467,7 @@ class IdsPopup extends mix(IdsElement).with(
     let elem;
     if (isString) {
       // @TODO Harden for security (XSS)
-      // @ts-ignore
       const rootNode = IdsDOMUtils.getClosestRootNode(this);
-      // @ts-ignore
       elem = rootNode.querySelector(val);
       if (!(elem instanceof HTMLElement)) {
         return;
@@ -501,9 +485,7 @@ class IdsPopup extends mix(IdsElement).with(
    * @returns {HTMLElement} the element in the page that the Popup will take
    * coordinates from for relative placement
    */
-  // @ts-ignore
   get arrowTarget() {
-    // @ts-ignore
     return this.state.arrowTarget || this.alignTarget;
   }
 
@@ -592,9 +574,7 @@ class IdsPopup extends mix(IdsElement).with(
     // (this doesn't need updating)
     // @TODO possibly replace `this.resizeDetectionTarget()`
     // with IdsPopupBoundary (specifically to contain)
-    // @ts-ignore
     if (this.shouldResize()) {
-      // @ts-ignore
       this.addObservedElement(this.resizeDetectionTarget());
     }
 
@@ -625,9 +605,7 @@ class IdsPopup extends mix(IdsElement).with(
         this.arrowEl.hidden = true;
       }
     });
-    // @ts-ignore
     if (this.arrow !== 'none' && !arrowElCl.contains(this.arrow)) {
-      // @ts-ignore
       arrowElCl.add(this.arrow);
       this.arrowEl.hidden = false;
     }
@@ -637,9 +615,7 @@ class IdsPopup extends mix(IdsElement).with(
     if (!alignTarget) {
       // Remove an established MutationObserver if one exists.
       if (this.hasMutations) {
-        // @ts-ignore
         this.mo.disconnect();
-        // @ts-ignore
         this.disconnectDetectMutations();
         delete this.hasMutations;
       }
@@ -647,9 +623,7 @@ class IdsPopup extends mix(IdsElement).with(
       this.placeAtCoords();
     } else {
       // connect the alignTarget to the global MutationObserver, if applicable.
-      // @ts-ignore
       if (this.shouldDetectMutations() && !this.hasMutations) {
-        // @ts-ignore
         this.mo.observe(this.alignTarget, {
           attributes: true,
           attributeFilter: ['style', 'height', 'width'],
@@ -667,7 +641,6 @@ class IdsPopup extends mix(IdsElement).with(
       this.openCheck.destroy(true);
     }
 
-    // @ts-ignore
     this.openCheck = this.rl.register(new IdsRenderLoopItem({
       duration: 70,
       timeoutCallback: () => {
@@ -694,7 +667,6 @@ class IdsPopup extends mix(IdsElement).with(
     if (this.animatedCheck) {
       this.animatedCheck.destroy(true);
     }
-    // @ts-ignore
     this.animatedCheck = this.rl.register(new IdsRenderLoopItem({
       duration: 200,
       timeoutCallback: () => {
@@ -750,9 +722,7 @@ class IdsPopup extends mix(IdsElement).with(
       break;
     }
 
-    // @ts-ignore
     this.container.style.left = `${x}px`;
-    // @ts-ignore
     this.container.style.top = `${y}px`;
   }
 
@@ -767,7 +737,6 @@ class IdsPopup extends mix(IdsElement).with(
 
     // Detect sizes/locations of the popup and the alignment target Element
     const popupRect = this.container.getBoundingClientRect();
-    // @ts-ignore
     const targetRect = this.alignTarget.getBoundingClientRect();
     const { alignEdge } = this;
     let alignXCentered = false;
@@ -838,9 +807,7 @@ class IdsPopup extends mix(IdsElement).with(
       }
     }
 
-    // @ts-ignore
     this.container.style.left = `${x}px`;
-    // @ts-ignore
     this.container.style.top = `${y}px`;
   }
 
@@ -904,7 +871,6 @@ class IdsPopup extends mix(IdsElement).with(
     }
 
     // Round the number up
-    // @ts-ignore
     d = Math.ceil(d);
 
     // Hide the arrow if it goes beyond the element boundaries

--- a/src/ids-progress/ids-progress.js
+++ b/src/ids-progress/ids-progress.js
@@ -6,7 +6,6 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-progress.scss';
 
 // Mixins

--- a/src/ids-radio/ids-radio-group.js
+++ b/src/ids-radio/ids-radio-group.js
@@ -11,10 +11,7 @@ import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsDirtyTrackerMixin } from '../ids-base/ids-dirty-tracker-mixin';
 import { IdsValidationMixin } from '../ids-base/ids-validation-mixin';
 
-// @ts-ignore
 import styles from './ids-radio-group.scss';
-
-// @ts-ignore
 import IdsText from '../ids-text/ids-text';
 
 /**
@@ -130,9 +127,7 @@ class IdsRadioGroup extends mix(IdsElement).with(
     this.handleHorizontal();
     this.handleDisabled();
     this.handleEvents();
-    // @ts-ignore
     this.handleDirtyTracker();
-    // @ts-ignore
     this.handleValidation();
   }
 
@@ -164,7 +159,6 @@ class IdsRadioGroup extends mix(IdsElement).with(
   clear() {
     this.value = null;
     this.checked = null;
-    // @ts-ignore
     this.removeAllMessages();
     const radio = this.querySelector('ids-radio');
     const rootEl = radio.shadowRoot?.querySelector('.ids-radio');
@@ -301,7 +295,6 @@ class IdsRadioGroup extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.DIRTY_TRACKER);
     }
-    // @ts-ignore
     this.handleDirtyTracker();
   }
 
@@ -389,7 +382,6 @@ class IdsRadioGroup extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATE);
     }
-    // @ts-ignore
     this.handleValidation();
   }
 
@@ -405,7 +397,6 @@ class IdsRadioGroup extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATION_EVENTS);
     }
-    // @ts-ignore
     this.handleValidation();
   }
 
@@ -421,7 +412,6 @@ class IdsRadioGroup extends mix(IdsElement).with(
       const state = { on: [], off: [] };
       radioArr.forEach((/** @type {HTMLElement | never} */ r) => {
         const rVal = r.getAttribute(props.VALUE);
-        // @ts-ignore
         state[rVal === val ? 'on' : 'off'].push(r);
       });
       state.off.forEach((/** @type {HTMLElement} */ r) => r.removeAttribute(props.CHECKED));

--- a/src/ids-radio/ids-radio.js
+++ b/src/ids-radio/ids-radio.js
@@ -10,11 +10,8 @@ import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore
 import styles from './ids-radio.scss';
-// @ts-ignore
 import IdsText from '../ids-text/ids-text';
-// @ts-ignore
 import IdsRadioGroup from './ids-radio-group';
 
 /**

--- a/src/ids-render-loop/ids-render-loop-item.js
+++ b/src/ids-render-loop/ids-render-loop-item.js
@@ -107,14 +107,12 @@ class IdsRenderLoopItem extends Object {
    *  to an `updateCallback()` method.
    * @returns {void}
    */
-  // @ts-ignore
   update(timeInfo, ...callbackArgs) {
     if (typeof this.updateCallback !== 'function' || !this.canUpdate) {
       return;
     }
 
     // NOTE: This runs in this `IdsRenderLoopItem`s context
-    // @ts-ignore
     this.updateCallback(timeInfo, ...callbackArgs);
     this.setNextUpdateTime();
   }

--- a/src/ids-skip-link/ids-skip-link.js
+++ b/src/ids-skip-link/ids-skip-link.js
@@ -10,9 +10,7 @@ import {
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 
-// @ts-ignore
 import styles from './ids-skip-link.scss';
-// @ts-ignore
 import IdsHyperlink from '../ids-hyperlink/ids-hyperlink';
 
 /**

--- a/src/ids-switch/ids-switch.js
+++ b/src/ids-switch/ids-switch.js
@@ -10,9 +10,7 @@ import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore
 import styles from './ids-switch.scss';
-// @ts-ignore
 import IdsText from '../ids-text/ids-text';
 
 /**
@@ -54,7 +52,6 @@ class IdsSwitch extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
    */
   connectedCallback() {
     /** @type {object} */
-    // @ts-ignore
     this.input = this.shadowRoot.querySelector('input[type="checkbox"]');
     this.labelEl = this.shadowRoot.querySelector('label');
 

--- a/src/ids-tag/ids-tag.js
+++ b/src/ids-tag/ids-tag.js
@@ -11,7 +11,6 @@ import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsKeyboardMixin } from '../ids-base/ids-keyboard-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore Import inline styles
 import styles from './ids-tag.scss';
 
 /**

--- a/src/ids-text/ids-text.d.ts
+++ b/src/ids-text/ids-text.d.ts
@@ -1,6 +1,9 @@
 // Ids is a JavaScript project, but we define TypeScript declarations so we can
 // confirm our code is type safe, and to support TypeScript users.
 
+/**
+ * a segment of text with standardized settings, theming and fonts
+ */
 export default class IdsText extends HTMLElement {
   /** Set the type of element it is (h1-h6, span (default)) */
   type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | string | null;

--- a/src/ids-text/ids-text.d.ts
+++ b/src/ids-text/ids-text.d.ts
@@ -1,9 +1,7 @@
 // Ids is a JavaScript project, but we define TypeScript declarations so we can
 // confirm our code is type safe, and to support TypeScript users.
 
-/** A segment of text with standardized settings, theming and fonts*/
- * a segment of text with standardized settings, theming and fonts
- */
+/** A segment of text with standardized settings, theming and fonts */
 export default class IdsText extends HTMLElement {
   /** Set the type of element it is (h1-h6, span (default)) */
   type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | string | null;

--- a/src/ids-text/ids-text.d.ts
+++ b/src/ids-text/ids-text.d.ts
@@ -1,7 +1,7 @@
 // Ids is a JavaScript project, but we define TypeScript declarations so we can
 // confirm our code is type safe, and to support TypeScript users.
 
-/**
+/** A segment of text with standardized settings, theming and fonts*/
  * a segment of text with standardized settings, theming and fonts
  */
 export default class IdsText extends HTMLElement {

--- a/src/ids-text/ids-text.js
+++ b/src/ids-text/ids-text.js
@@ -11,7 +11,6 @@ import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore
 import styles from './ids-text.scss';
 
 const fontSizes = ['xs', 'sm', 'base', 'lg', 'xl', 10, 12, 14, 16, 20, 24, 28, 32, 40, 48, 60, 72];
@@ -112,9 +111,7 @@ class IdsText extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
     this.container?.classList.remove(...fontWeightClasses);
 
     if (hasValue) {
-      // @ts-ignore
       this.setAttribute(props.FONT_WEIGHT, value);
-      // @ts-ignore
       this.container?.classList.add(value);
       return;
     }
@@ -151,7 +148,6 @@ class IdsText extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
 
     if (isValueTruthy && this.container && !this.container?.classList.contains('audible')) {
       this.container.classList.add('audible');
-      // @ts-ignore
       this.setAttribute(props.AUDIBLE, value);
     }
 

--- a/src/ids-textarea/ids-textarea.js
+++ b/src/ids-textarea/ids-textarea.js
@@ -6,15 +6,11 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-textarea.scss';
 
 // Supporting components
-// @ts-ignore
 import IdsIcon from '../ids-icon/ids-icon';
-// @ts-ignore
 import IdsText from '../ids-text/ids-text';
-// @ts-ignore
 import IdsTriggerButton from '../ids-trigger-field/ids-trigger-button';
 
 // Mixins
@@ -118,7 +114,6 @@ class IdsTextarea extends mix(IdsElement).with(
     /** @type {any} */
     this.labelEl = this.shadowRoot.querySelector(`[for="${ID}"]`);
 
-    // @ts-ignore
     this.handleClearable();
     this.handleEvents();
     super.connectedCallback();
@@ -231,7 +226,6 @@ class IdsTextarea extends mix(IdsElement).with(
    * @returns {void}
    */
   setBrowser() {
-    // @ts-ignore
     const ua = navigator.userAgent || navigator.vendor || window.opera;
     const browser = (/** @type {any} */ s) => ua.toLowerCase().indexOf(s) > -1;
     this.isSafari = browser('safari') && !browser('chrome') && !browser('android');
@@ -432,9 +426,7 @@ class IdsTextarea extends mix(IdsElement).with(
     this.handleSlotchangeEvent();
     this.handleNativeEvents();
     this.handleTextareaChangeEvent();
-    // @ts-ignore
     this.handleDirtyTracker();
-    // @ts-ignore
     this.handleValidation();
   }
 
@@ -596,7 +588,6 @@ class IdsTextarea extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.CLEARABLE);
     }
-    // @ts-ignore
     this.handleClearable();
   }
 
@@ -613,7 +604,6 @@ class IdsTextarea extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.DIRTY_TRACKER);
     }
-    // @ts-ignore
     this.handleDirtyTracker();
   }
 
@@ -801,7 +791,6 @@ class IdsTextarea extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATE);
     }
-    // @ts-ignore
     this.handleValidation();
   }
 
@@ -817,7 +806,6 @@ class IdsTextarea extends mix(IdsElement).with(
     } else {
       this.removeAttribute(props.VALIDATION_EVENTS);
     }
-    // @ts-ignore
     this.handleValidation();
   }
 
@@ -833,7 +821,6 @@ class IdsTextarea extends mix(IdsElement).with(
     if (this.input && this.input.value !== v) {
       this.input.value = this.getMaxValue(v);
       this.input.dispatchEvent(new Event('change', { bubbles: true }));
-      // @ts-ignore
       this.resetDirtyTracker();
     }
     this.updateCounter();

--- a/src/ids-theme-switcher/ids-theme-switcher.js
+++ b/src/ids-theme-switcher/ids-theme-switcher.js
@@ -7,10 +7,8 @@ import {
 } from '../ids-base/ids-element';
 
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
-// @ts-ignore
 import IdsMenuButton from '../ids-menu-button/ids-menu-button';
 
-// @ts-ignore
 import styles from './ids-theme-switcher.scss';
 
 /**

--- a/src/ids-toggle-button/ids-toggle-button.js
+++ b/src/ids-toggle-button/ids-toggle-button.js
@@ -3,12 +3,9 @@ import {
   scss
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import { IdsButton, BUTTON_PROPS, BUTTON_TYPES } from '../ids-button/ids-button';
-// @ts-ignore
 import IdsIcon from '../ids-icon/ids-icon';
 
-// @ts-ignore
 import styles from '../ids-button/ids-button.scss';
 
 // Default Toggle Button Icons
@@ -53,7 +50,6 @@ class IdsToggleButton extends IdsButton {
    * @returns {void}
    */
   connectedCallback() {
-    // @ts-ignore
     IdsButton.prototype.connectedCallback.apply(this);
     this.refreshIcon();
     this.refreshText();
@@ -65,7 +61,6 @@ class IdsToggleButton extends IdsButton {
    */
   set pressed(val) {
     const trueVal = val === true || val === 'true';
-    // @ts-ignore
     this.state.pressed = trueVal;
     this.shouldUpdate = false;
 
@@ -81,7 +76,6 @@ class IdsToggleButton extends IdsButton {
   }
 
   get pressed() {
-    // @ts-ignore
     return this.state.pressed;
   }
 
@@ -90,9 +84,7 @@ class IdsToggleButton extends IdsButton {
    * @param {string} _val a valid
    * @returns {void}
    */
-  // @ts-ignore
   set type(_val) {
-    // @ts-ignore
     this.state.type = BUTTON_TYPES[0];
 
     if (this.hasAttribute('type')) {
@@ -100,7 +92,6 @@ class IdsToggleButton extends IdsButton {
       this.removeAttribute('type');
       this.shouldUpdate = true;
     }
-    // @ts-ignore
     this.setTypeClass(this.state.type);
   }
 

--- a/src/ids-toolbar/ids-toolbar-more-actions.js
+++ b/src/ids-toolbar/ids-toolbar-more-actions.js
@@ -1,6 +1,5 @@
 import { IdsElement, scss, customElement } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-toolbar-more-actions.scss';
 
 // Subcomponents

--- a/src/ids-toolbar/ids-toolbar-section.js
+++ b/src/ids-toolbar/ids-toolbar-section.js
@@ -1,6 +1,5 @@
 import { IdsElement, scss, customElement } from '../ids-base/ids-element';
 import { props } from '../ids-base/ids-constants';
-// @ts-ignore
 import styles from './ids-toolbar-section.scss';
 
 const TOOLBAR_SECTION_PROPS = [

--- a/src/ids-toolbar/ids-toolbar.js
+++ b/src/ids-toolbar/ids-toolbar.js
@@ -5,7 +5,6 @@ import {
   customElement
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-toolbar.scss';
 
 // Supporting Components
@@ -160,10 +159,8 @@ class IdsToolbar extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) 
    */
   get focused() {
     // @TODO clean this up / document why/how it works
-    // @ts-ignore
     return this.items.find((item) => {
       const container = IdsDOMUtils.getClosestContainerNode(item);
-      // @ts-ignore
       const focused = container.activeElement;
       const isEqualNode = focused?.isEqualNode(item);
       return isEqualNode;

--- a/src/ids-trigger-field/ids-trigger-button.js
+++ b/src/ids-trigger-field/ids-trigger-button.js
@@ -7,7 +7,6 @@ import {
 import { IdsButton } from '../ids-button/ids-button';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore
 import styles from './ids-trigger-button.scss';
 
 /**

--- a/src/ids-trigger-field/ids-trigger-field.js
+++ b/src/ids-trigger-field/ids-trigger-field.js
@@ -10,15 +10,11 @@ import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import styles from './ids-trigger-field.scss';
 
 // Supporting components
-// @ts-ignore
 import { IdsButton } from '../ids-button/ids-button';
-// @ts-ignore
 import IdsInput from '../ids-input/ids-input';
-// @ts-ignore
 import IdsTriggerButton from './ids-trigger-button';
 
 /**

--- a/src/ids-upload-advanced/ids-upload-advanced-file.js
+++ b/src/ids-upload-advanced/ids-upload-advanced-file.js
@@ -7,13 +7,9 @@ import {
 } from '../ids-base/ids-element';
 
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
-// @ts-ignore
 import styles from './ids-upload-advanced-file.scss';
-// @ts-ignore
 import IdsAlert from '../ids-alert/ids-alert';
-// @ts-ignore
 import IdsTriggerButton from '../ids-trigger-field/ids-trigger-button';
-// @ts-ignore
 import IdsProgress from '../ids-progress/ids-progress';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsUploadAdvancedShared as shared } from './ids-upload-advanced-shared';

--- a/src/ids-upload-advanced/ids-upload-advanced.js
+++ b/src/ids-upload-advanced/ids-upload-advanced.js
@@ -6,7 +6,6 @@ import {
   props
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-upload-advanced.scss';
 
 // Mixins
@@ -15,9 +14,7 @@ import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsThemeMixin } from '../ids-base/ids-theme-mixin';
 
-// @ts-ignore
 import IdsUploadAdvancedFile from './ids-upload-advanced-file';
-// @ts-ignore
 import IdsHyperLink from '../ids-hyperlink/ids-hyperlink';
 
 /**

--- a/src/ids-upload/ids-upload.js
+++ b/src/ids-upload/ids-upload.js
@@ -6,7 +6,6 @@ import {
   mix
 } from '../ids-base/ids-element';
 
-// @ts-ignore
 import styles from './ids-upload.scss';
 import { IdsEventsMixin } from '../ids-base/ids-events-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
@@ -73,7 +72,6 @@ class IdsUpload extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
     /** @type {any} */
     this.textInput = this.shadowRoot.querySelector('ids-input');
     /** @type {any} */
-    // @ts-ignore
     this.fileInput = this.shadowRoot.querySelector(`#${ID}`);
 
     this.files = this.fileInput.files;
@@ -197,7 +195,6 @@ class IdsUpload extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin) {
     this.onEvent('change', this.fileInput, (/** @type {any} */ e) => {
       const files = this.fileInput.files;
       /* istanbul ignore next */
-      // @ts-ignore
       this.value = [].slice.call(files).map((f) => f.name).join(', ');
       this.dispatchChangeEvent(e);
     });

--- a/src/ids-virtual-scroll/ids-virtual-scroll.js
+++ b/src/ids-virtual-scroll/ids-virtual-scroll.js
@@ -10,7 +10,6 @@ import { IdsDataSource } from '../ids-base/ids-data-source';
 import { IdsRenderLoopMixin } from '../ids-render-loop/ids-render-loop-mixin';
 import { IdsStringUtils as stringUtils } from '../ids-base/ids-string-utils';
 
-// @ts-ignore
 import styles from './ids-virtual-scroll.scss';
 
 /**
@@ -141,7 +140,6 @@ class IdsVirtualScroll extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEvent
    * @returns {number} The array of visible data
    */
   visibleItemCount() {
-    // @ts-ignore
     let count = Math.ceil(this.height / this.itemHeight) + (2 * this.bufferSize);
     count = Math.min(Number(this.itemCount) - this.startIndex, count);
     return count;
@@ -215,7 +213,6 @@ class IdsVirtualScroll extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEvent
    * Set the scroll top position and scroll down to that location
    * @param {number|string} value The number of pixels from the top
    */
-  // @ts-ignore - because html elements also have this
   set scrollTop(value) {
     if (value !== null && value !== undefined) {
       this.setAttribute('scroll-top', value.toString());
@@ -227,7 +224,6 @@ class IdsVirtualScroll extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEvent
     this.removeAttribute('scroll-top');
   }
 
-  // @ts-ignore - because html elements also have this
   get scrollTop() { return this.getAttribute('scroll-top') || 0; }
 
   /**
@@ -295,12 +291,10 @@ class IdsVirtualScroll extends mix(IdsElement).with(IdsRenderLoopMixin, IdsEvent
       return;
     }
 
-    // @ts-ignore
     this.datasource.data = null;
   }
 
   get data() {
-    // @ts-ignore
     return this?.datasource?.data;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "checkJs": true,
+    "checkJs": false,
     "noEmit": true,
     // We'd like to use noImplicitAny: true, but we often need to access
     // arbitrary data on elements, and have not yet worked out an easy way to


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
In our local development environment for WC, we are using both Typescript "classes" and Javascript "classes" within the same classname/namespace. We are also performing strict typescript checking in pure JavaScript and to prevent issues working around namespace/var resolution via `@ts-ignore` comments.

Since there's a fundamental compatibility between using the same d.ts class and javascript with native ES7 classes that share names, we have to disable strict type-checking within JS specifically. This does not interfere with detection of `d.ts` externally (demonstrated below).

This does not fully resolve infor-design/enterprise#5049 , but it allows us to test our repo externally with the other test projects non-theoretically + iteratively.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->

Partially addresses infor-design/enterprise#5049.

Will also attempt to create an external demo/code sandbox to test our React and Angular projects, as well as vet out further issues on another branch since this would be much easier once we have this change pushed to the repo. This likely is also the only opportunity to do this while other apps are not consuming it in production.

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

- pull `5049-ts-typings-support-iteration` locally
- open VSCode (and with ESLint plug and other typical dev env set up)
- Type Cmd + P (Mac) or Cntrl + P (Windows) and look up `ids-checkbox.js` @ `src/ids-checkbox/ids-checkbox.js`
- Copy and paste the following in lines 19-20
```
const idsText = new IdsText();
idsText.type = 'h1';
```
(1) hover over IdsText in import @ ln 17 and see the content is taken from the `.d.ts` and not the `.js` file.
(2) while hovering on IdsText, press Cmd and notice the source code is the `ids-text.d.ts` and not `ids-text.js`.
(3) hover over `idsText.type` and see the preview is from the `ids-text.d.ts` file and not the JSDoc in the `.js` file.

(and of course that all test pass here)

![typescript-in-local-dev](https://user-images.githubusercontent.com/1799905/115787128-bce97780-a38f-11eb-9d28-68e24a2bb3ba.gif)


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
