### PR TITLE
5077 - Add support for input and trigger field sizes

### DIFF
--- a/app/ids-input/standalone-css.html
+++ b/app/ids-input/standalone-css.html
@@ -1,4 +1,5 @@
-{{> ../layouts/head.html }}
+{{> ../layouts/head-visible.html }}
+
 <link rel="stylesheet" href="ids-input.css"/>
 <link rel="stylesheet" href="../ids-layout-grid/ids-layout-grid.css"/>
 <link rel="stylesheet" href="../ids-text/ids-text.css"/>
@@ -14,59 +15,163 @@
 
     <div class="ids-input">
       <label for="input-first-name" class="ids-text label-text">First Name</label>
-      <input class="ids-input-field" id="input-first-name" name="input-first-name" placeholder="Normal text Field"/>
+      <div class="field-container">
+        <input class="ids-input-field" id="input-first-name" name="input-first-name" placeholder="Normal text Field"/>
+      </div>
     </div>
 
     <div class="ids-input disabled">
       <label for="input-disabled" class="ids-text label-text">Disabled</label>
-      <input class="ids-input-field" disabled id="input-disabled" name="input-disabled" value="Field not editable"/>
+      <div class="field-container">
+        <input class="ids-input-field" disabled id="input-disabled" name="input-disabled" value="Field not editable"/>
+      </div>
     </div>
 
     <div class="ids-input readonly">
       <label for="input-readonly" class="ids-text label-text">Readonly</label>
-      <input class="ids-input-field" readonly id="input-readonly" name="input-readonly" value="02006"/>
+      <div class="field-container">
+        <input class="ids-input-field" readonly id="input-readonly" name="input-readonly" value="02006"/>
+      </div>
     </div>
 
     <div class="ids-input">
       <label for="input-default-align" class="ids-text label-text">Default align (left)</label>
-      <input class="ids-input-field" id="input-default-align" name="input-default-align" value="Default align"/>
+      <div class="field-container">
+        <input class="ids-input-field" id="input-default-align" name="input-default-align" value="Default align"/>
+      </div>
     </div>
 
     <div class="ids-input">
       <label for="input-left-align" class="ids-text label-text">Left align</label>
-      <input class="ids-input-field left" id="input-left-align" name="input-left-align" value="Left align"/>
+      <div class="field-container">
+        <input class="ids-input-field left" id="input-left-align" name="input-left-align" value="Left align"/>
+      </div>
     </div>
 
     <div class="ids-input">
       <label for="input-center-align" class="ids-text label-text">Center align</label>
-      <input class="ids-input-field center" id="input-center-align" name="input-center-align" value="Center align"/>
+      <div class="field-container">
+        <input class="ids-input-field center" id="input-center-align" name="input-center-align" value="Center align"/>
+      </div>
     </div>
 
     <div class="ids-input">
       <label for="input-right-align" class="ids-text label-text">Right align</label>
-      <input class="ids-input-field right" id="input-right-align" name="input-right-align" value="Right align"/>
+      <div class="field-container">
+        <input class="ids-input-field right" id="input-right-align" name="input-right-align" value="Right align"/>
+      </div>
     </div>
+  </div>
+</div>
+
+<div class="ids-layout-grid">
+  <div class="ids-layout-grid-cell">
+    <h2 class="ids-text ids-text-12">Ids Input - Compact</h2>
+  </div>
+</div>
+<div class="ids-layout-grid">
+  <div class="ids-layout-grid-cell">
 
     <div class="ids-input">
-      <label for="input-xtra-small" class="ids-text label-text">Xtra Small</label>
-      <input class="ids-input-field xs" id="input-xtra-small" name="input-xtra-small"/>
-    </div>
-
-    <div class="ids-input">
-      <label for="input-small" class="ids-text label-text">Small</label>
-      <input class="ids-input-field sm" id="input-small" name="input-small"/>
-    </div>
-
-    <div class="ids-input">
-      <label for="input-small-medium" class="ids-text label-text">Small - Medium</label>
-      <input class="ids-input-field mm" id="input-small-medium" name="input-small-medium"/>
-    </div>
-
-    <div class="ids-input">
-      <label for="input-medium" class="ids-text label-text">Medium</label>
-      <input class="ids-input-field md" id="input-medium" name="input-medium"/>
+      <label for="input-compact" class="ids-text label-text">Compact</label>
+      <div class="field-container compact">
+        <input class="ids-input-field" id="input-compact" name="input-compact"/>
+      </div>
     </div>
 
   </div>
 </div>
+
+<div class="ids-layout-grid">
+  <div class="ids-layout-grid-cell">
+    <h2 class="ids-text ids-text-12">Ids Input - Row Heights (Height)</h2>
+  </div>
+</div>
+<div class="ids-layout-grid">
+  <div class="ids-layout-grid-cell">
+
+    <div class="ids-input">
+      <label for="input-height-extra-small" class="ids-text label-text">Extra Small</label>
+      <div class="field-container row-height-xs">
+        <input class="ids-input-field" id="input-height-extra-small" name="input-height-extra-small"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-height-small" class="ids-text label-text">Small</label>
+      <div class="field-container row-height-sm">
+        <input class="ids-input-field" id="input-height-small" name="input-height-small"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-height-medium" class="ids-text label-text">Medium (default)</label>
+      <div class="field-container row-height-md">
+        <input class="ids-input-field" id="input-height-medium" name="input-height-medium"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-height-large" class="ids-text label-text">Large</label>
+      <div class="field-container row-height-lg">
+        <input class="ids-input-field" id="input-height-large" name="input-height-large"/>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<div class="ids-layout-grid">
+  <div class="ids-layout-grid-cell">
+    <h2 class="ids-text ids-text-12">Ids Input - Sizes (Width)</h2>
+  </div>
+</div>
+<div class="ids-layout-grid">
+  <div class="ids-layout-grid-cell">
+
+    <div class="ids-input">
+      <label for="input-size-extra-small" class="ids-text label-text">Extra Small</label>
+      <div class="field-container xs">
+        <input class="ids-input-field" id="input-size-extra-small" name="input-size-extra-small"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-size-small" class="ids-text label-text">Small</label>
+      <div class="field-container sm">
+        <input class="ids-input-field" id="input-size-small" name="input-size-small"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-size-small-medium" class="ids-text label-text">Small - Medium</label>
+      <div class="field-container mm">
+        <input class="ids-input-field" id="input-size-small-medium" name="input-size-small-medium"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-size-medium" class="ids-text label-text">Medium</label>
+      <div class="field-container md">
+        <input class="ids-input-field" id="input-size-medium" name="input-size-medium"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-size-large" class="ids-text label-text">Large</label>
+      <div class="field-container lg">
+        <input class="ids-input-field" id="input-size-large" name="input-size-large"/>
+      </div>
+    </div>
+
+    <div class="ids-input">
+      <label for="input-size-full" class="ids-text label-text">Full</label>
+      <div class="field-container full">
+        <input class="ids-input-field" id="input-size-full" name="input-size-full"/>
+      </div>
+    </div>
+
+  </div>
+</div>
+
 {{> ../layouts/footer.html }}

--- a/app/ids-input/test-sizes.html
+++ b/app/ids-input/test-sizes.html
@@ -1,0 +1,50 @@
+{{> ../layouts/head.html }}
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Ids Input - Defaults</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-input label="Basic"></ids-input>
+    <ids-input label="Compact" compact="true"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Ids Input - Row Heights (Height)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Row Heights: [xs, sm, md, lg] -->
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-input row-height="xs" label="Extra Small (compact)"></ids-input>
+    <ids-input row-height="sm" label="Small"></ids-input>
+    <ids-input row-height="md" label="Medium (default)"></ids-input>
+    <ids-input row-height="lg" label="Large"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Ids Input - Sizes (Width)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Sizes: [xs, sm, mm, md, lg, full] -->
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-input size="xs" label="Extra Small"></ids-input>
+    <ids-input size="sm" label="Small"></ids-input>
+    <ids-input size="mm" label="Small - Medium"></ids-input>
+    <ids-input size="md" label="Medium (default)"></ids-input>
+    <ids-input size="lg" label="Large"></ids-input>
+    <ids-input size="full" label="Full"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+{{> ../layouts/footer.html }}

--- a/app/ids-textarea/standalone-css.html
+++ b/app/ids-textarea/standalone-css.html
@@ -1,4 +1,5 @@
-{{> ../layouts/head.html }}
+{{> ../layouts/head-visible.html }}
+
 <link rel="stylesheet" href="ids-textarea.css"/>
 <link rel="stylesheet" href="../ids-layout-grid/ids-layout-grid.css"/>
 <link rel="stylesheet" href="../ids-text/ids-text.css"/>
@@ -14,69 +15,96 @@
 
     <div class="ids-textarea">
       <label for="textarea-basic" class="ids-text label-text">Basic</label>
-      <textarea class="ids-textarea-field" id="textarea-basic" name="textarea-basic">Line One</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field" id="textarea-basic" name="textarea-basic">Line One</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea disabled">
       <label for="textarea-disabled" class="ids-text label-text">Disabled</label>
-      <textarea class="ids-textarea-field" disabled id="textarea-disabled" name="textarea-disabled">Line One</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field" disabled id="textarea-disabled" name="textarea-disabled">Line One</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea readonly">
       <label for="textarea-readonly" class="ids-text label-text">Readonly</label>
-      <textarea class="ids-textarea-field" readonly id="textarea-readonly" name="textarea-readonly">Line One</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field" readonly id="textarea-readonly" name="textarea-readonly">Line One</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-resizable" class="ids-text label-text">Resizable</label>
-      <textarea class="ids-textarea-field resizable" id="textarea-resizable" name="textarea-resizable" placeholder="Type your notes here..."></textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field resizable" id="textarea-resizable" name="textarea-resizable" placeholder="Type your notes here..."></textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-rows" class="ids-text label-text">Rows</label>
-      <textarea class="ids-textarea-field" rows="15" id="textarea-rows" name="textarea-rows">Line One</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field" rows="15" id="textarea-rows" name="textarea-rows">Line One</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-default-align" class="ids-text label-text">Default align (left)</label>
-      <textarea class="ids-textarea-field" id="textarea-default-align" name="textarea-default-align">Default align</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field" id="textarea-default-align" name="textarea-default-align">Default align</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-left-align" class="ids-text label-text">Left align</label>
-      <textarea class="ids-textarea-field left" id="textarea-left-align" name="textarea-left-align">Left align</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field left" id="textarea-left-align" name="textarea-left-align">Left align</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-center-align" class="ids-text label-text">Center align</label>
-      <textarea class="ids-textarea-field center" id="textarea-center-align" name="textarea-center-align">Center align</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field center" id="textarea-center-align" name="textarea-center-align">Center align</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-right-align" class="ids-text label-text">Right align</label>
-      <textarea class="ids-textarea-field right" id="textarea-right-align" name="textarea-right-align">Right align</textarea>
+      <div class="field-container">
+        <textarea class="ids-textarea-field right" id="textarea-right-align" name="textarea-right-align">Right align</textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-small" class="ids-text label-text">Small</label>
-      <textarea class="ids-textarea-field sm" id="textarea-small" name="textarea-small" placeholder="Type your notes here..."></textarea>
+      <div class="field-container sm">
+        <textarea class="ids-textarea-field" id="textarea-small" name="textarea-small" placeholder="Type your notes here..."></textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-medium" class="ids-text label-text">Medium</label>
-      <textarea class="ids-textarea-field md" id="textarea-medium" name="textarea-medium" placeholder="Type your notes here..."></textarea>
+      <div class="field-container md">
+        <textarea class="ids-textarea-field" id="textarea-medium" name="textarea-medium" placeholder="Type your notes here..."></textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-large" class="ids-text label-text">Large</label>
-      <textarea class="ids-textarea-field lg" id="textarea-large" name="textarea-large" placeholder="Type your notes here..."></textarea>
+      <div class="field-container lg">
+        <textarea class="ids-textarea-field" id="textarea-large" name="textarea-large" placeholder="Type your notes here..."></textarea>
+      </div>
     </div>
 
     <div class="ids-textarea">
       <label for="textarea-full" class="ids-text label-text">Full</label>
-      <textarea class="ids-textarea-field full" id="textarea-full" name="textarea-full" placeholder="Type your notes here..."></textarea>
+      <div class="field-container full">
+        <textarea class="ids-textarea-field" id="textarea-full" name="textarea-full" placeholder="Type your notes here..."></textarea>
+      </div>
     </div>
 
   </div>
 </div>
+
 {{> ../layouts/footer.html }}

--- a/app/ids-trigger-field/test-sizes.html
+++ b/app/ids-trigger-field/test-sizes.html
@@ -1,0 +1,137 @@
+{{> ../layouts/head.html }}
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Trigger Field - Defaults</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+
+    <ids-trigger-field>
+      <ids-input label="Basic"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input label="Compact" compact="true"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+
+    </ids-trigger-field>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Trigger Field - Row Heights (Height)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Row Heights: [xs, sm, md, lg] -->
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+
+    <ids-trigger-field>
+      <ids-input row-height="xs" label="Extra Small (compact)"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input row-height="sm" label="Small"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input row-height="md" label="Medium (default)"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input row-height="lg" label="Large"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Trigger Field - Sizes (Width)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Sizes: [xs, sm, mm, md, lg, full] -->
+<ids-layout-grid>
+  <ids-layout-grid-cell>
+
+    <ids-trigger-field>
+      <ids-input size="xs" label="Extra Small"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input size="sm" label="Small"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input size="mm" label="Small - Medium"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input size="md" label="Medium (default)"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input size="lg" label="Large"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+    <ids-trigger-field>
+      <ids-input size="full" label="Full"></ids-input>
+      <ids-trigger-button>
+        <ids-text audible="true">Date Field trigger</ids-text>
+        <ids-icon slot="icon" icon="schedule"></ids-icon>
+      </ids-trigger-button>
+    </ids-trigger-field>
+
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+{{> ../layouts/footer.html }}

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -25,6 +25,7 @@
   - Markup has changed to a custom element `<ids-input></ids-input>`
   - If using events, events are now plain JS events.
   - Can now be imported as a single JS file and used with encapsulated styles
+  - Can now be use variation of sizes (width/height)
   - If using a clearable X on the input the x is now tabbable by default for accessibility
 - `[ListView]` The List View component has been changed to a web component and renamed to ids-list-view.
   - If using properties/settings these are now attributes.

--- a/src/ids-base/ids-clearable-mixin.scss
+++ b/src/ids-base/ids-clearable-mixin.scss
@@ -7,18 +7,15 @@
     ~ .btn-clear {
       @include outline-none();
 
-      margin-left: 1px;
-      margin-top: -24px;
-      position: absolute;
+      margin-top: -4px;
 
       &.is-empty {
         display: none;
       }
 
       [slot='icon'] {
+        @include ml-0();
         @include text-slate-60();
-
-        margin-left: -1px;
       }
 
       &:hover [slot='icon'] {
@@ -27,14 +24,14 @@
     }
 
     &.has-clearable {
-      @include pr-28();
+      @include pr-32();
 
       &.has-triggerfield {
-        padding-right: 50px;
+        padding-right: 55px;
       }
 
       &.has-triggerfield ~ .btn-clear {
-        margin-left: -23px;
+        margin-left: -25px;
       }
     }
   }

--- a/src/ids-base/ids-constants.js
+++ b/src/ids-base/ids-constants.js
@@ -18,6 +18,7 @@ export const props = {
   CHECKED: 'checked',
   CLEARABLE: 'clearable',
   CLEARABLE_FORCED: 'clearable-forced',
+  COMPACT: 'compact',
   COL_END: 'col-end',
   COL_SPAN: 'col-span',
   COL_START: 'col-start',

--- a/src/ids-base/ids-dirty-tracker-mixin.scss
+++ b/src/ids-base/ids-dirty-tracker-mixin.scss
@@ -4,12 +4,15 @@
   @include absolute();
   @include m-4();
   @include text-alert-caution();
+
+  top: 0;
 }
 
 // Radio
 .ids-radio-group {
   .icon-dirty {
     margin: 8px 0 0 -2px;
+    top: auto;
   }
 
   &.first-item-checked .icon-dirty {

--- a/src/ids-input/ids-input.scss
+++ b/src/ids-input/ids-input.scss
@@ -11,8 +11,16 @@ $input-size-md: 300px;
 $input-size-lg: 400px;
 $input-size-full: 100%;
 
-// Set default size
+// Field Row Height
+$input-row-height-xs: 28px;
+$input-row-height-sm: 30px;
+$input-row-height-md: 38px;
+$input-row-height-lg: 48px;
+
+// Set default
 $input-size-default: $input-size-md;
+$input-row-height-default: $input-row-height-md;
+$input-compact-height: $input-row-height-xs;
 
 .ids-input {
   @include block();
@@ -56,9 +64,60 @@ $input-size-default: $input-size-md;
   }
 
   .field-container {
-    @include block();
     @include m-0();
     @include p-0();
+    @include relative();
+
+    align-items: center;
+    display: flex;
+    max-width: $input-size-default;
+
+    // input sizes: [xs, sm, mm, md, lg, full]
+    &.xs {
+      max-width: $input-size-xs;
+    }
+
+    &.sm {
+      max-width: $input-size-sm;
+    }
+
+    &.mm {
+      max-width: $input-size-mm;
+    }
+
+    &.md {
+      max-width: $input-size-md;
+    }
+
+    &.lg {
+      max-width: $input-size-lg;
+    }
+
+    &.full {
+      max-width: $input-size-full;
+    }
+
+    // input row-heights: [xs, sm, md, lg]
+    &.row-height-xs .ids-input-field {
+      height: $input-row-height-xs;
+    }
+
+    &.row-height-sm .ids-input-field {
+      height: $input-row-height-sm;
+    }
+
+    &.row-height-md .ids-input-field {
+      height: $input-row-height-md;
+    }
+
+    &.row-height-lg .ids-input-field {
+      height: $input-row-height-lg;
+    }
+
+    // input compact
+    &.compact .ids-input-field {
+      height: $input-compact-height;
+    }
   }
 
   .ids-input-field {
@@ -73,16 +132,15 @@ $input-size-default: $input-size-md;
     @include rounded-default();
     @include text-14();
     @include text-black();
+    @include w-full();
 
     -webkit-appearance: none;
     border-collapse: separate;
     border-radius: 2px;
     display: inline-block;
-    height: 38px;
-    max-width: 100%;
+    height: $input-row-height-default;
     resize: none;
     text-align: left;
-    width: $input-size-default;
 
     &:hover {
       @include border-slate-90();
@@ -140,31 +198,6 @@ $input-size-default: $input-size-md;
 
     &.right {
       text-align: right;
-    }
-
-    // input sizes: [xs, sm, mm, md, lg, full]
-    &.xs {
-      width: $input-size-xs;
-    }
-
-    &.sm {
-      width: $input-size-sm;
-    }
-
-    &.mm {
-      width: $input-size-mm;
-    }
-
-    &.md {
-      width: $input-size-md;
-    }
-
-    &.lg {
-      width: $input-size-lg;
-    }
-
-    &.full {
-      width: $input-size-full;
     }
 
     // input message: [alert, error, info, success]

--- a/src/ids-textarea/ids-textarea.js
+++ b/src/ids-textarea/ids-textarea.js
@@ -108,8 +108,6 @@ class IdsTextarea extends mix(IdsElement).with(
    */
   connectedCallback() {
     /** @type {any} */
-    this.rootEl = this.shadowRoot.querySelector('.ids-textarea');
-    /** @type {any} */
     this.input = this.shadowRoot.querySelector(`#${ID}`);
     /** @type {any} */
     this.labelEl = this.shadowRoot.querySelector(`[for="${ID}"]`);
@@ -136,7 +134,7 @@ class IdsTextarea extends mix(IdsElement).with(
     const counter = isCounter ? '<span class="textarea-character-counter"></span>' : '';
     let textareaState = stringUtils.stringToBool(this.readonly) ? ' readonly' : '';
     textareaState = stringUtils.stringToBool(this.disabled) ? ' disabled' : textareaState;
-    let textareaClass = `ids-textarea-field ${this.size} ${this.textAlign}`;
+    let textareaClass = `ids-textarea-field ${this.textAlign}`;
     textareaClass += stringUtils.stringToBool(this.resizable) ? ' resizable' : '';
     textareaClass = ` class="${textareaClass}"`;
 
@@ -147,7 +145,7 @@ class IdsTextarea extends mix(IdsElement).with(
         <label for="${ID}" class="label-text">
           <ids-text part="label">${this.label}</ids-text>
         </label>
-        <div class="field-container">
+        <div class="field-container ${this.size}">
           <textarea part="textarea" id="${ID}"${textareaClass}${placeholder}${textareaState}${maxlength}${rows} value="${value}"></textarea>
         </div>
         ${counter}
@@ -171,15 +169,18 @@ class IdsTextarea extends mix(IdsElement).with(
       };
       if (options.val) {
         this.input?.removeAttribute(options.prop2);
-        this.rootEl?.classList.remove(options.prop2);
+        this.container.classList.remove(options.prop2);
+        this.container.querySelector('ids-text').removeAttribute(options.prop2);
         msgNodes.forEach((x) => x.classList.remove(options.prop2));
 
         this.input?.setAttribute(options.prop1, 'true');
-        this.rootEl?.classList.add(options.prop1);
+        this.container.classList.add(options.prop1);
+        this.container.querySelector('ids-text').setAttribute(options.prop1, 'true');
         msgNodes.forEach((x) => x.classList.add(options.prop1));
       } else {
         this.input?.removeAttribute(options.prop1);
-        this.rootEl?.classList.remove(options.prop1);
+        this.container.classList.remove(options.prop1);
+        this.container.querySelector('ids-text').removeAttribute(options.prop1);
         msgNodes.forEach((x) => x.classList.remove(options.prop1));
       }
     }
@@ -309,7 +310,7 @@ class IdsTextarea extends mix(IdsElement).with(
       if (!elem) {
         elem = document.createElement('span');
         elem.className = 'textarea-character-counter';
-        this.rootEl?.appendChild(elem);
+        this.container.appendChild(elem);
       }
       this.updateCounter();
     } else {
@@ -330,7 +331,7 @@ class IdsTextarea extends mix(IdsElement).with(
         elem = document.createElement('span');
         elem.className = 'textarea-print';
         elem.textContent = this.value;
-        this.rootEl?.prepend(elem);
+        this.container.prepend(elem);
       }
     } else {
       elem?.remove();
@@ -617,10 +618,8 @@ class IdsTextarea extends mix(IdsElement).with(
     const val = stringUtils.stringToBool(value);
     if (val) {
       this.setAttribute(props.DISABLED, val.toString());
-      this.container.querySelector('ids-text').setAttribute(props.DISABLED, 'true');
     } else {
       this.removeAttribute(props.DISABLED);
-      this.container.querySelector('ids-text').removeAttribute(props.DISABLED);
     }
     this.setTextareaState(props.DISABLED);
   }
@@ -760,10 +759,11 @@ class IdsTextarea extends mix(IdsElement).with(
    * @param {string} value [sm, md, lg, full]
    */
   set size(value) {
+    const fieldContainer = this.shadowRoot.querySelector('.field-container');
     const size = SIZES[value];
     this.setAttribute(props.SIZE, size || SIZES.default);
-    this.input?.classList.remove(...Object.values(SIZES));
-    this.input?.classList.add(size || SIZES.default);
+    fieldContainer?.classList.remove(...Object.values(SIZES));
+    fieldContainer?.classList.add(size || SIZES.default);
   }
 
   get size() { return this.getAttribute(props.SIZE) || SIZES.default; }

--- a/src/ids-textarea/ids-textarea.scss
+++ b/src/ids-textarea/ids-textarea.scss
@@ -31,6 +31,7 @@ $textarea-size-default-height: 120px;
   }
 
   .textarea-character-counter {
+    display: inline-block;
     min-height: auto;
     width: $textarea-size-default;
 
@@ -77,10 +78,45 @@ $textarea-size-default-height: 120px;
   }
 
   .field-container {
-    @include block();
     @include m-0();
     @include p-0();
     @include relative();
+
+    display: flex;
+    max-width: $textarea-size-default;
+
+    // textarea sizes: [sm, md, lg, full]
+    &.sm {
+      max-width: $textarea-size-sm;
+
+      ~ .textarea-character-counter {
+        width: $textarea-size-sm;
+      }
+    }
+
+    &.md {
+      max-width: $textarea-size-md;
+
+      ~ .textarea-character-counter {
+        width: $textarea-size-md;
+      }
+    }
+
+    &.lg {
+      max-width: $textarea-size-lg;
+
+      ~ .textarea-character-counter {
+        width: $textarea-size-lg;
+      }
+    }
+
+    &.full {
+      max-width: $textarea-size-full;
+
+      ~ .textarea-character-counter {
+        width: $textarea-size-full;
+      }
+    }
   }
 
   .ids-textarea-field {
@@ -96,16 +132,15 @@ $textarea-size-default-height: 120px;
     @include rounded-default();
     @include text-16();
     @include text-black();
+    @include w-full();
 
     -webkit-appearance: none;
     border-collapse: separate;
     border-radius: 2px;
     display: inline-block;
-    max-width: 100%;
     min-height: $textarea-size-default-height;
     resize: none;
     text-align: left;
-    width: $textarea-size-default;
 
     &:hover {
       @include border-slate-90();
@@ -177,39 +212,6 @@ $textarea-size-default-height: 120px;
       text-align: right;
     }
 
-    // textarea sizes: [sm, md, lg, full]
-    &.sm {
-      width: $textarea-size-sm;
-
-      ~ .textarea-wordcount {
-        width: $textarea-size-sm;
-      }
-    }
-
-    &.md {
-      width: $textarea-size-md;
-
-      ~ .textarea-wordcount {
-        width: $textarea-size-md;
-      }
-    }
-
-    &.lg {
-      width: $textarea-size-lg;
-
-      ~ .textarea-wordcount {
-        width: $textarea-size-lg;
-      }
-    }
-
-    &.full {
-      width: $textarea-size-full;
-
-      ~ .textarea-wordcount {
-        width: $textarea-size-full;
-      }
-    }
-
     // textarea message: [alert, error, info, success]
     &.alert,
     &.alert:hover {
@@ -276,6 +278,13 @@ $textarea-size-default-height: 120px;
         @include border-emerald-30();
         @include text-emerald-30();
       }
+    }
+
+    ~ .btn-clear {
+      @include absolute();
+      @include mt-4();
+
+      right: 0;
     }
   }
 

--- a/src/ids-trigger-field/ids-trigger-button.scss
+++ b/src/ids-trigger-field/ids-trigger-button.scss
@@ -10,7 +10,6 @@
 
   height: 28px;
   margin-left: -32px;
-  margin-top: 29px;
   width: 28px;
 
   &:focus {

--- a/src/ids-trigger-field/ids-trigger-field.js
+++ b/src/ids-trigger-field/ids-trigger-field.js
@@ -40,6 +40,8 @@ class IdsTriggerField extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin
    * @returns {void}
    */
   connectedCallback() {
+    this.input = this.querySelector('ids-input');
+    this.input?.setAttribute(props.TRIGGERFIELD, 'true');
     this.handleEvents();
     super.connectedCallback();
   }
@@ -112,6 +114,17 @@ class IdsTriggerField extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin
    * @returns {object} The object for chaining.
    */
   handleEvents() {
+    if (this.input) {
+      const className = 'has-validation-message';
+      this.onEvent('validated', this.input, (e) => {
+        if (e.detail?.isValid) {
+          this.container?.classList?.remove(className);
+        } else {
+          this.container?.classList?.add(className);
+        }
+      });
+    }
+
     if (this.disableNativeEvents) {
       return false;
     }

--- a/src/ids-trigger-field/ids-trigger-field.scss
+++ b/src/ids-trigger-field/ids-trigger-field.scss
@@ -1,15 +1,59 @@
 @import '../ids-base/ids-base';
 
-.ids-trigger-field {
-  @include w-full();
+// Field Sizes
+$input-size-xs: 75px;
+$input-size-sm: 150px;
+$input-size-mm: 225px;
+$input-size-md: 300px;
+$input-size-lg: 400px;
+$input-size-full: 100%;
+$input-size-default: $input-size-md;
 
+.ids-trigger-field {
+  align-items: center;
   display: flex;
+
+  &.has-validation-message ::slotted(ids-trigger-button) {
+    margin-top: -16px;
+  }
+}
+
+::slotted(ids-trigger-button) {
+  @include relative();
+  @include mt-4();
+
+  flex: 0;
+  z-index: 2;
 }
 
 ::slotted(ids-input) {
-  display: inline;
+  @include relative();
+
+  flex: 1;
+  max-width: $input-size-default;
+  z-index: 1;
+}
+
+::slotted(ids-input[size='xs']) {
+  max-width: $input-size-xs;
+}
+
+::slotted(ids-input[size='sm']) {
+  max-width: $input-size-sm;
+}
+
+::slotted(ids-input[size='mm']) {
+  max-width: $input-size-mm;
+}
+
+::slotted(ids-input[size='md']) {
+  max-width: $input-size-md;
+}
+
+::slotted(ids-input[size='lg']) {
+  max-width: $input-size-lg;
 }
 
 ::slotted(ids-input[size='full']) {
-  width: 100%;
+  max-width: $input-size-full;
 }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
- Added support for `ids-input` and `ids-trigger-field` sizes.
- Update standalone-css example page for `ids-input`
- Update standalone-css examples page and some clean-up for `ids-textarea`, saw it was not working

**Related github/jira issue (required)**:
Closes infor-design/enterprise#5077

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

Check the variation of sizes (width/height)
- http://localhost:4300/ids-input/test-sizes
- http://localhost:4300/ids-trigger-field/test-sizes
- http://localhost:4300/ids-input/standalone-css
- http://localhost:4300/ids-textarea/standalone-css (see this should be loading fine now)

Check for `Clearable`, `Dirty Tracker` and `Validation` examples
- http://localhost:4300/ids-input
- http://localhost:4300/ids-trigger-field
- http://localhost:4300/ids-textarea

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
