### PR TITLE
EP#4974 - Allow decimal input on replacement of number masked field value

### DIFF
--- a/src/ids-mask/ids-mask-api.js
+++ b/src/ids-mask/ids-mask-api.js
@@ -408,6 +408,10 @@ class MaskAPI {
         // We substring from the beginning until the position after the last filled
         // placeholder char.
         resultStr = resultStr.substr(0, indexOfLastFilledPlaceholderChar + 1);
+      } else if (rawValue !== '' && resultStr.indexOf(rawValue) > -1) {
+        // The raw value provided exists within the character literals left by processing, so
+        // we simply do nothing to the results string in this case.
+        caretPos += rawValue.length;
       } else {
         // If we couldn't find `indexOfLastFilledPlaceholderChar` that means the user deleted
         // the first character in the mask. So we return an empty string.

--- a/src/ids-mask/ids-masks.js
+++ b/src/ids-mask/ids-masks.js
@@ -152,11 +152,15 @@ export function numberMask(rawValue, options) {
 
   //
   if (thisRawValue === EMPTY_STRING || (thisRawValue[0] === PREFIX[0] && rawValueLength === 1)) {
-    mask = PREFIX.split(EMPTY_STRING).concat([DIGITS_REGEX]).concat(SUFFIX.split(EMPTY_STRING));
+    mask = PREFIX.split(EMPTY_STRING)
+      .concat([DIGITS_REGEX])
+      .concat(SUFFIX.split(EMPTY_STRING));
   }
   // If the only item in the rawValue is a decimal, build out a simple 0 mask
   if (thisRawValue === DECIMAL && thisOptions.allowDecimal) {
-    mask = PREFIX.split(EMPTY_STRING).concat(['0', DECIMAL, DIGITS_REGEX]).concat(SUFFIX.split(EMPTY_STRING));
+    mask = PREFIX.split(EMPTY_STRING)
+      .concat(['0', CARET_TRAP, DECIMAL, CARET_TRAP, DIGITS_REGEX])
+      .concat(SUFFIX.split(EMPTY_STRING));
   }
 
   // If the mask is populated at this point, return it

--- a/test/ids-mask/ids-mask-input-func-test.js
+++ b/test/ids-mask/ids-mask-input-func-test.js
@@ -87,6 +87,25 @@ describe('IdsInput (Masked)', () => {
     expect(input.value).toEqual('1234.56');
   });
 
+  it('pre-fills a value with a zero if a decimal is typed and allowed', () => {
+    input.mask = numberMask;
+    input.maskOptions = {
+      locale: 'en-US',
+      allowDecimal: true,
+      allowNegative: true,
+      decimalLimit: 3,
+      integerLimit: 4,
+    };
+    input.value = '123.123';
+
+    expect(input.value).toEqual('123.123');
+
+    input.value = '.';
+
+    // Zero is filled in ahead of the typed decimal
+    expect(input.value).toEqual('0.');
+  });
+
   it('can use the shorthand "number" to actviate the built-in number mask', () => {
     input.mask = 'number';
 

--- a/test/ids-mask/ids-mask-number-api-func-test.js
+++ b/test/ids-mask/ids-mask-number-api-func-test.js
@@ -347,8 +347,8 @@ describe('Number Mask function', () => {
       }
     });
 
-    // Resulting mask will be [/\d/, '.', /\d/]
-    expect(result.mask.length).toBe(3);
+    // Resulting mask will be [/\d/, '[]', '.', '[]', /\d/]
+    expect(result.mask.length).toBe(5);
   });
 
   it('should handle multiple decimals in the value', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR contains a fix for number masks that's identical to infor-design/enterprise#5209, but applied to the updated Mask API in this repo.

**Related github/jira issue (required)**:
Related to infor-design/enterprise#4974
Related to infor-design/enterprise#5209

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4300/ids-mask
- In the number mask field, type "123.12"
- Select all the text in the field (CTRL/CMD + A)
- Type the decimal ".".  The field value after replacement should read "0."

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.