### PR TITLE
139 - ids-button: accessibility options

### DIFF
--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -12,6 +12,8 @@ import { IdsRenderLoopMixin, IdsRenderLoopItem } from '../ids-mixins/ids-render-
 
 import styles from './ids-button.scss';
 
+const { stringToBool } = stringUtils;
+
 // Button Styles
 const BUTTON_TYPES = [
   'default',
@@ -106,7 +108,10 @@ class IdsButton extends mix(IdsElement).with(
     this.setIconAlignment();
     this.shouldUpdate = true;
     super.connectedCallback();
-    this.setAttribute('role', 'button');
+
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'button');
+    }
   }
 
   /**
@@ -286,16 +291,19 @@ class IdsButton extends mix(IdsElement).with(
    * @param {boolean|string} val true if the button will be disabled
    */
   set disabled(val) {
+    const isValueTruthy = stringToBool(val);
     this.shouldUpdate = false;
-    this.removeAttribute(props.DISABLED);
-    this.shouldUpdate = true;
+    if (isValueTruthy) {
+      this.setAttribute(props.DISABLED, '');
+    } else {
+      this.removeAttribute(props.DISABLED);
+    }
 
-    const trueVal = stringUtils.stringToBool(val);
-    this.state.disabled = trueVal;
+    this.state.disabled = isValueTruthy;
 
     /* istanbul ignore next */
     if (this.button) {
-      this.button.disabled = trueVal;
+      this.button.disabled = isValueTruthy;
     }
   }
 
@@ -309,9 +317,6 @@ class IdsButton extends mix(IdsElement).with(
    * @returns {void}
    */
   set tabIndex(val) {
-    // Remove the webcomponent tabIndex
-    this.shouldUpdate = false;
-    this.removeAttribute(props.TABINDEX);
     this.shouldUpdate = true;
 
     const trueVal = Number(val);

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -323,8 +323,10 @@ class IdsButton extends mix(IdsElement).with(
     if (Number.isNaN(trueVal) || trueVal < -1) {
       this.state.tabIndex = 0;
       this.button.setAttribute(props.TABINDEX, '0');
+      this.removeAttribute(props.TABINDEX);
       return;
     }
+
     this.state.tabIndex = trueVal;
     this.button.setAttribute(props.TABINDEX, `${trueVal}`);
   }

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -90,10 +90,13 @@ class IdsButton extends mix(IdsElement).with(
       switch (name) {
       // Convert "tabindex" to "tabIndex"
       case 'tabindex':
+        if (Number.isNaN(Number.parseInt(newValue))) {
+          this.tabIndex = null;
+        }
         this.tabIndex = Number(newValue);
         break;
       default:
-        IdsElement.prototype.attributeChangedCallback.apply(this, [name, oldValue, newValue]);
+        super.attributeChangedCallback.apply(this, [name, oldValue, newValue]);
         break;
       }
     }
@@ -295,6 +298,7 @@ class IdsButton extends mix(IdsElement).with(
       this.removeAttribute(props.DISABLED);
     }
 
+    this.shouldUpdate = true;
     this.state.disabled = isValueTruthy;
 
     /* istanbul ignore next */
@@ -316,6 +320,7 @@ class IdsButton extends mix(IdsElement).with(
     this.shouldUpdate = true;
 
     const trueVal = Number(val);
+
     if (Number.isNaN(trueVal) || trueVal < -1) {
       this.state.tabIndex = 0;
       this.button.setAttribute(props.TABINDEX, '0');

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -108,10 +108,6 @@ class IdsButton extends mix(IdsElement).with(
     this.setIconAlignment();
     this.shouldUpdate = true;
     super.connectedCallback();
-
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'button');
-    }
   }
 
   /**

--- a/src/ids-button/ids-button.js
+++ b/src/ids-button/ids-button.js
@@ -317,8 +317,6 @@ class IdsButton extends mix(IdsElement).with(
    * @returns {void}
    */
   set tabIndex(val) {
-    this.shouldUpdate = true;
-
     const trueVal = Number(val);
 
     if (Number.isNaN(trueVal) || trueVal < -1) {

--- a/test/ids-button/ids-button-func-test.js
+++ b/test/ids-button/ids-button-func-test.js
@@ -68,7 +68,7 @@ describe('IdsButton Component', () => {
   it('can be disabled/enabled', () => {
     btn.disabled = true;
 
-    expect(btn.hasAttribute('disabled')).toBeFalsy();
+    expect(btn.hasAttribute('disabled')).toBeTruthy();
     expect(btn.disabled).toBeTruthy();
     expect(btn.button.hasAttribute('disabled')).toBeTruthy();
     expect(btn.state.disabled).toBeTruthy();
@@ -105,7 +105,7 @@ describe('IdsButton Component', () => {
 
     btn.setAttribute('tabindex', '0');
 
-    expect(btn.hasAttribute('tabindex')).toBeFalsy();
+    expect(btn.hasAttribute('tabindex')).toBeTruthy();
     expect(btn.tabIndex).toEqual(0);
     expect(btn.button.getAttribute('tabindex')).toEqual('0');
     expect(btn.state.tabIndex).toEqual(0);

--- a/test/ids-button/ids-button-func-test.js.snap
+++ b/test/ids-button/ids-button-func-test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsButton Component renders correctly 1`] = `"<ids-button css-class=\\"test-class\\" disabled=\\"\\" icon=\\"add\\" role=\\"button\\"><span>test</span><ids-icon slot=\\"icon\\" icon=\\"add\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;
+exports[`IdsButton Component renders correctly 1`] = `"<ids-button css-class=\\"test-class\\" disabled=\\"\\" icon=\\"add\\"><span>test</span><ids-icon slot=\\"icon\\" icon=\\"add\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;
 
-exports[`IdsButton Component renders icons on the opposite side correctly 1`] = `"<ids-button id=\\"test-button\\" icon=\\"settings\\" role=\\"button\\"><span>Settings</span><ids-icon slot=\\"icon\\" icon=\\"settings\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;
+exports[`IdsButton Component renders icons on the opposite side correctly 1`] = `"<ids-button id=\\"test-button\\" icon=\\"settings\\"><span>Settings</span><ids-icon slot=\\"icon\\" icon=\\"settings\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;

--- a/test/ids-button/ids-button-func-test.js.snap
+++ b/test/ids-button/ids-button-func-test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsButton Component renders correctly 1`] = `"<ids-button css-class=\\"test-class\\" icon=\\"add\\" role=\\"button\\"><span>test</span><ids-icon slot=\\"icon\\" icon=\\"add\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;
+exports[`IdsButton Component renders correctly 1`] = `"<ids-button css-class=\\"test-class\\" disabled=\\"\\" icon=\\"add\\" role=\\"button\\"><span>test</span><ids-icon slot=\\"icon\\" icon=\\"add\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;
 
 exports[`IdsButton Component renders icons on the opposite side correctly 1`] = `"<ids-button id=\\"test-button\\" icon=\\"settings\\" role=\\"button\\"><span>Settings</span><ids-icon slot=\\"icon\\" icon=\\"settings\\" class=\\"ids-icon\\"></ids-icon></ids-button>"`;

--- a/test/ids-menu-button/ids-menu-button-func-test.js.snap
+++ b/test/ids-menu-button/ids-menu-button-func-test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsMenuButton Component renders correctly 1`] = `"<ids-menu-button id=\\"new-button\\" role=\\"button\\" menu=\\"new-menu\\"></ids-menu-button>"`;
+exports[`IdsMenuButton Component renders correctly 1`] = `"<ids-menu-button id=\\"new-button\\" menu=\\"new-menu\\"></ids-menu-button>"`;

--- a/test/ids-theme-switcher/ids-theme-switcher-func-test.js.snap
+++ b/test/ids-theme-switcher/ids-theme-switcher-func-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IdsThemeSwitcher Component renders correctly 1`] = `
-"<style nonce=\\"0a59a005\\">.ids-theme-switcher { background-color: transparent; }</style><ids-menu-button id=\\"ids-theme-switcher\\" menu=\\"ids-theme-menu\\" mode=\\"light\\" version=\\"new\\" role=\\"button\\">
+"<style nonce=\\"0a59a005\\">.ids-theme-switcher { background-color: transparent; }</style><ids-menu-button id=\\"ids-theme-switcher\\" menu=\\"ids-theme-menu\\" mode=\\"light\\" version=\\"new\\">
             <ids-icon slot=\\"icon\\" icon=\\"more\\"></ids-icon>
             <span class=\\"audible\\">Theme Switcher</span>
         </ids-menu-button>

--- a/test/ids-trigger-button/ids-trigger-button-func-test.js.snap
+++ b/test/ids-trigger-button/ids-trigger-button-func-test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsTriggerButton Component renders correctly 1`] = `"<ids-trigger-button role=\\"button\\"></ids-trigger-button>"`;
+exports[`IdsTriggerButton Component renders correctly 1`] = `"<ids-trigger-button></ids-trigger-button>"`;

--- a/test/ids-trigger-field/ids-trigger-field-func-test.js.snap
+++ b/test/ids-trigger-field/ids-trigger-field-func-test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsTriggerField Component renders correctly 1`] = `"<ids-trigger-field><ids-input id=\\"ids-input-2\\" triggerfield=\\"true\\"></ids-input><ids-trigger-button role=\\"button\\"></ids-trigger-button></ids-trigger-field>"`;
+exports[`IdsTriggerField Component renders correctly 1`] = `"<ids-trigger-field><ids-input id=\\"ids-input-2\\" triggerfield=\\"true\\"></ids-input><ids-trigger-button></ids-trigger-button></ids-trigger-field>"`;
 
-exports[`IdsTriggerField Component renders correctly 2`] = `"<ids-trigger-field><ids-input id=\\"ids-input-2\\" triggerfield=\\"true\\"></ids-input><ids-trigger-button role=\\"button\\"></ids-trigger-button></ids-trigger-field>"`;
+exports[`IdsTriggerField Component renders correctly 2`] = `"<ids-trigger-field><ids-input id=\\"ids-input-2\\" triggerfield=\\"true\\"></ids-input><ids-trigger-button></ids-trigger-button></ids-trigger-field>"`;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
This branch is mainly to add accessibility options so that both Axe tests and Vox tool works properly with WC for some compound components (in this case for the IdsSpinbox). 

(1) Because of some quirks in the shadowDOM, tabIndex has to persist for -1 to the WC as well for disabling things.
(2) There was also some inconsistency with disabled not applying to the button when toggling enabled => disabled that (discovered during dev on the spinbox component for #139).
(3) remove setting role="button" on LightDOM due to axe tools errors (button itself can handle it) [added after PR pushed]

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Supports #139 but does not have a direct ticket on JIRA.

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull this branch (`139-ids-button-accessibility-options`)
- do a quick sanity check that buttons do not behave abnormally/regressively with tabbing on test page.
- see that tests pass on PR

**Included in this Pull Request**:
- [X] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
