### PR TITLE
139 - ids input: optional labels and unique ids for WC accessibility

### DIFF
--- a/app/ids-input/standalone-css.html
+++ b/app/ids-input/standalone-css.html
@@ -14,49 +14,49 @@
   <div class="ids-layout-grid-cell">
 
     <div class="ids-input">
-      <label for="input-first-name" class="ids-text label-text">First Name</label>
+      <label for="input-first-name" class="ids-text ids-label-text">First Name</label>
       <div class="field-container">
         <input class="ids-input-field" id="input-first-name" name="input-first-name" placeholder="Normal text Field"/>
       </div>
     </div>
 
     <div class="ids-input disabled">
-      <label for="input-disabled" class="ids-text label-text">Disabled</label>
+      <label for="input-disabled" class="ids-text ids-label-text">Disabled</label>
       <div class="field-container">
         <input class="ids-input-field" disabled id="input-disabled" name="input-disabled" value="Field not editable"/>
       </div>
     </div>
 
     <div class="ids-input readonly">
-      <label for="input-readonly" class="ids-text label-text">Readonly</label>
+      <label for="input-readonly" class="ids-text ids-label-text">Readonly</label>
       <div class="field-container">
         <input class="ids-input-field" readonly id="input-readonly" name="input-readonly" value="02006"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-default-align" class="ids-text label-text">Default align (left)</label>
+      <label for="input-default-align" class="ids-text ids-label-text">Default align (left)</label>
       <div class="field-container">
         <input class="ids-input-field" id="input-default-align" name="input-default-align" value="Default align"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-left-align" class="ids-text label-text">Left align</label>
+      <label for="input-left-align" class="ids-text ids-label-text">Left align</label>
       <div class="field-container">
         <input class="ids-input-field left" id="input-left-align" name="input-left-align" value="Left align"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-center-align" class="ids-text label-text">Center align</label>
+      <label for="input-center-align" class="ids-text ids-label-text">Center align</label>
       <div class="field-container">
         <input class="ids-input-field center" id="input-center-align" name="input-center-align" value="Center align"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-right-align" class="ids-text label-text">Right align</label>
+      <label for="input-right-align" class="ids-text ids-label-text">Right align</label>
       <div class="field-container">
         <input class="ids-input-field right" id="input-right-align" name="input-right-align" value="Right align"/>
       </div>
@@ -73,7 +73,7 @@
   <div class="ids-layout-grid-cell">
 
     <div class="ids-input">
-      <label for="input-compact" class="ids-text label-text">Compact</label>
+      <label for="input-compact" class="ids-text ids-label-text">Compact</label>
       <div class="field-container compact">
         <input class="ids-input-field" id="input-compact" name="input-compact"/>
       </div>
@@ -91,28 +91,28 @@
   <div class="ids-layout-grid-cell">
 
     <div class="ids-input">
-      <label for="input-height-extra-small" class="ids-text label-text">Extra Small</label>
+      <label for="input-height-extra-small" class="ids-text ids-label-text">Extra Small</label>
       <div class="field-container field-height-xs">
         <input class="ids-input-field" id="input-height-extra-small" name="input-height-extra-small"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-height-small" class="ids-text label-text">Small</label>
+      <label for="input-height-small" class="ids-text ids-label-text">Small</label>
       <div class="field-container field-height-sm">
         <input class="ids-input-field" id="input-height-small" name="input-height-small"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-height-medium" class="ids-text label-text">Medium (default)</label>
+      <label for="input-height-medium" class="ids-text ids-label-text">Medium (default)</label>
       <div class="field-container field-height-md">
         <input class="ids-input-field" id="input-height-medium" name="input-height-medium"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-height-large" class="ids-text label-text">Large</label>
+      <label for="input-height-large" class="ids-text ids-label-text">Large</label>
       <div class="field-container field-height-lg">
         <input class="ids-input-field" id="input-height-large" name="input-height-large"/>
       </div>
@@ -130,42 +130,42 @@
   <div class="ids-layout-grid-cell">
 
     <div class="ids-input">
-      <label for="input-size-extra-small" class="ids-text label-text">Extra Small</label>
+      <label for="input-size-extra-small" class="ids-text ids-label-text">Extra Small</label>
       <div class="field-container xs">
         <input class="ids-input-field" id="input-size-extra-small" name="input-size-extra-small"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-size-small" class="ids-text label-text">Small</label>
+      <label for="input-size-small" class="ids-text ids-label-text">Small</label>
       <div class="field-container sm">
         <input class="ids-input-field" id="input-size-small" name="input-size-small"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-size-small-medium" class="ids-text label-text">Small - Medium</label>
+      <label for="input-size-small-medium" class="ids-text ids-label-text">Small - Medium</label>
       <div class="field-container mm">
         <input class="ids-input-field" id="input-size-small-medium" name="input-size-small-medium"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-size-medium" class="ids-text label-text">Medium</label>
+      <label for="input-size-medium" class="ids-text ids-label-text">Medium</label>
       <div class="field-container md">
         <input class="ids-input-field" id="input-size-medium" name="input-size-medium"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-size-large" class="ids-text label-text">Large</label>
+      <label for="input-size-large" class="ids-text ids-label-text">Large</label>
       <div class="field-container lg">
         <input class="ids-input-field" id="input-size-large" name="input-size-large"/>
       </div>
     </div>
 
     <div class="ids-input">
-      <label for="input-size-full" class="ids-text label-text">Full</label>
+      <label for="input-size-full" class="ids-text ids-label-text">Full</label>
       <div class="field-container full">
         <input class="ids-input-field" id="input-size-full" name="input-size-full"/>
       </div>

--- a/src/ids-base/ids-constants.js
+++ b/src/ids-base/ids-constants.js
@@ -56,6 +56,7 @@ export const props = {
   KEEP_OPEN: 'keep-open',
   LABEL: 'label',
   LABEL_AUDIBLE: 'label-audible',
+  LABEL_HIDDEN: 'label-hidden',
   LABEL_REQUIRED: 'label-required',
   LABEL_FILETYPE: 'label-filetype',
   MAX: 'max',

--- a/src/ids-input/README.md
+++ b/src/ids-input/README.md
@@ -142,5 +142,6 @@ The IDS Input component is now a WebComponent. Instead of using classes to defin
 1. Can be consumed in NG/Vue/React (pull it in standalone/built see it works standalone)
 
 ## Accessibility Guidelines
+There should be a label on all inputs to give an indication what the value means.
 
 ## Regional Considerations

--- a/src/ids-input/ids-input.js
+++ b/src/ids-input/ids-input.js
@@ -173,7 +173,7 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
     containerClass += stringUtils.stringToBool(this.compact) ? ' compact' : '';
 
     const labelHtml = !this.label || this.getAttribute(props.LABEL_HIDDEN) ? '' : (
-      `<label for="${this.id}-input" class="label-text">
+      `<label for="${this.id}-input" class="ids-label-text">
         <ids-text part="label" label="true" color-unset>${this.label}</ids-text>
       </label>`
     );
@@ -203,10 +203,25 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
 
   /**
    * @readonly
-   * @returns {HTMLLabelElement} the inner `label` element
+   * @returns {HTMLLabelElement} the inner `label` element or
+   * reference to what was last provided by setLabelElement
    */
   get labelEl() {
-    return this.shadowRoot?.querySelector(`label`);
+    if(!this.#labelEl) {
+      return (
+        this.#labelEl ||
+        this.shadowRoot?.querySelector(`[for="${this.id}input"]`)
+      );
+    }
+  }
+
+  /**
+   * setter for label element; since reflected attributes
+   * cannot be non serializable refs
+   * @param {HTMLElement} el element representing the label
+   */
+  setLabelElement(el) {
+    this.#labelEl = el;
   }
 
   /**
@@ -250,9 +265,14 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
    * @returns {void}
    */
   setLabelText(value) {
-    const labelText = this.shadowRoot.querySelector(`[for="${this.id}-input"] ids-text`);
-    if (labelText) {
-      labelText.innerHTML = value || '';
+    if (this.#labelEl) {
+      this.#labelEl.innerHTML = value || '';
+      return;
+    }
+
+    const labelEl = this.shadowRoot.querySelector(`[for="${this.id}-input"] ids-text`);
+    if (labelEl) {
+      labelEl.innerHTML = value || '';
     }
   }
 
@@ -499,6 +519,11 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
   }
 
   get disabled() { return this.getAttribute(props.DISABLED); }
+
+  /**
+   * internal reference to a label element a user provides
+   */
+  #labelEl;
 
   /**
    * Set the `label` text of input label

--- a/src/ids-input/ids-input.js
+++ b/src/ids-input/ids-input.js
@@ -207,12 +207,11 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
    * reference to what was last provided by setLabelElement
    */
   get labelEl() {
-    if(!this.#labelEl) {
-      return (
-        this.#labelEl ||
-        this.shadowRoot?.querySelector(`[for="${this.id}input"]`)
-      );
-    }
+
+    return (
+      this.#labelEl ||
+      this.shadowRoot?.querySelector(`[for="${this.id}-input"]`)
+    );
   }
 
   /**
@@ -281,9 +280,31 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
    */
   set labelHidden(value) {
     if (stringUtils.stringToBool(value)) {
-      this?.setAttribute(props.LABEL_HIDDEN, '');
+      this?.setAttribute(props.LABEL_HIDDEN, true);
+      const existingLabel = this.shadowRoot.querySelector('label');
+      if (existingLabel) {
+        existingLabel.remove();
+      }
+
+      this.input?.setAttribute?.('aria-label', this.label);
     } else {
       this?.removeAttribute(props.LABEL_HIDDEN);
+
+      /* istanbul ignore else */
+      if (this.input) {
+        this.input?.removeAttribute('aria-label');
+
+        const labelTemplate = document.createElement('template');;
+        labelTemplate.innerHTML = (
+          `<label for="${this.id}-input" class="ids-label-text">
+            <ids-text part="label" label="true" color-unset>${this.label}</ids-text>
+          </label>`
+        );
+        this.container.insertBefore(
+          labelTemplate.content.childNodes[0],
+          this.container.querySelector('field-container')
+        );
+      }
     }
   }
 

--- a/src/ids-input/ids-input.js
+++ b/src/ids-input/ids-input.js
@@ -207,10 +207,9 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
    * reference to what was last provided by setLabelElement
    */
   get labelEl() {
-
     return (
-      this.#labelEl ||
-      this.shadowRoot?.querySelector(`[for="${this.id}-input"]`)
+      this.#labelEl
+      || this.shadowRoot?.querySelector(`[for="${this.id}-input"]`)
     );
   }
 
@@ -294,7 +293,7 @@ class IdsInput extends mix(IdsElement).with(...appliedMixins) {
       if (this.input) {
         this.input?.removeAttribute('aria-label');
 
-        const labelTemplate = document.createElement('template');;
+        const labelTemplate = document.createElement('template');
         labelTemplate.innerHTML = (
           `<label for="${this.id}-input" class="ids-label-text">
             <ids-text part="label" label="true" color-unset>${this.label}</ids-text>

--- a/src/ids-input/ids-input.scss
+++ b/src/ids-input/ids-input.scss
@@ -22,10 +22,49 @@ $input-size-default: $input-size-md;
 $input-field-height-default: $input-field-height-md;
 $input-compact-height: $input-field-height-xs;
 
+/* in case of external label in compound component */
+.ids-label-text {
+  @include antialiased();
+  @include font-sans();
+  @include text-slate-60();
+  @include mb-4();
+
+  align-items: baseline;
+  display: flex;
+
+  &.required {
+    &::after {
+      @include relative();
+      @include font-sans();
+      @include mx-2();
+      @include text-20();
+      @include text-alert-danger();
+
+      content: '*';
+      margin-top: -10px;
+      top: 1px;
+    }
+
+    &.no-required-indicator::after {
+      content: '';
+    }
+  }
+}
+
+.disabled {
+  .ids-label-text {
+    @include text-slate-30();
+
+    &.required::after {
+      @include text-ruby-30();
+    }
+  }
+}
+
 @mixin input-extra-small-height($h: $input-field-height-xs) {
   @include mb-12();
 
-  .label-text {
+  .ids-label-text {
     @include text-14();
   }
 
@@ -46,44 +85,6 @@ $input-compact-height: $input-field-height-xs;
 .ids-input {
   @include block();
   @include mb-16();
-
-  .label-text {
-    @include antialiased();
-    @include font-sans();
-    @include text-slate-60();
-    @include mb-4();
-
-    align-items: baseline;
-    display: flex;
-
-    &.required {
-      &::after {
-        @include relative();
-        @include font-sans();
-        @include mx-2();
-        @include text-20();
-        @include text-alert-danger();
-
-        content: '*';
-        margin-top: -10px;
-        top: 1px;
-      }
-
-      &.no-required-indicator::after {
-        content: '';
-      }
-    }
-  }
-
-  &.disabled {
-    .label-text {
-      @include text-slate-30();
-
-      &.required::after {
-        @include text-ruby-30();
-      }
-    }
-  }
 
   .field-container {
     @include m-0();

--- a/test/ids-input/ids-input-func-test.js
+++ b/test/ids-input/ids-input-func-test.js
@@ -243,7 +243,7 @@ describe('IdsInput Component', () => {
     expect(input.input.classList).not.toContain('text-ellipsis');
   });
 
-  it('should setup dirty tracking', () => {
+  it('should setup dirty tracking', async () => {
     input.dirtyTracker = true;
     input.input.remove();
     input.dirtyTrackerEvents();
@@ -257,6 +257,12 @@ describe('IdsInput Component', () => {
     input.handleDirtyTracker();
     expect(input.dirty).toEqual({ original: '' });
     document.body.innerHTML = '';
+    const template = document.createElement('template');
+    template.innerHTML = '<ids-input label="testing input"></ids-input>';
+    elem = template.content.childNodes[0];
+    document.body.appendChild(elem);
+    await processAnimFrame();
+
     elem = new IdsInput();
     document.body.appendChild(elem);
     input = document.querySelector('ids-input');

--- a/test/ids-input/ids-input-func-test.js
+++ b/test/ids-input/ids-input-func-test.js
@@ -143,8 +143,8 @@ describe('IdsInput Component', () => {
     expect(input.labelRequired).toEqual('true');
   });
 
-  it('should have an input with "aria-label" set when label-hidden ' +
-  'is flagged and a label exists, then toggles this by unsetting it', async () => {
+  it('should have an input with "aria-label" set when label-hidden '
+  + 'is flagged and a label exists, then toggles this by unsetting it', async () => {
     input.labelHidden = true;
     expect(input.labelHidden).toBeTruthy();
     await processAnimFrame();
@@ -164,7 +164,15 @@ describe('IdsInput Component', () => {
     const errors = jest.spyOn(global.console, 'error');
 
     const template = document.createElement('template');
-    template.innerHTML = '<ids-input label="testing input" label-hidden></ids-input>';
+    template.innerHTML = '<ids-input label="testing input" label-hidden="true"></ids-input>';
+
+    input = template.content.childNodes[0];
+    document.body.appendChild(input);
+    await processAnimFrame();
+
+    expect(errors).not.toHaveBeenCalled();
+
+    template.innerHTML = '<ids-input label-hidden="true"></ids-input>';
 
     input = template.content.childNodes[0];
     document.body.appendChild(input);
@@ -173,8 +181,8 @@ describe('IdsInput Component', () => {
     expect(errors).not.toHaveBeenCalled();
   });
 
-  it('should be able to assign an external label element via setLabelElement ' +
-  'setter', async () => {
+  it('should be able to assign an external label element via setLabelElement '
+  + 'setter', async () => {
     input.label = undefined;
     input.render();
     await processAnimFrame();

--- a/test/ids-input/ids-input-func-test.js
+++ b/test/ids-input/ids-input-func-test.js
@@ -4,13 +4,21 @@
 import IdsInput from '../../src/ids-input/ids-input';
 import IdsClearableMixin from '../../src/ids-mixins/ids-clearable-mixin';
 
+const processAnimFrame = () => new Promise((resolve) => {
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(resolve);
+  });
+});
+
 describe('IdsInput Component', () => {
   let input;
 
   beforeEach(async () => {
-    const elem = new IdsInput();
-    document.body.appendChild(elem);
-    input = document.querySelector('ids-input');
+    const template = document.createElement('template');
+    template.innerHTML = '<ids-input label="testing input"></ids-input>';
+    input = template.content.childNodes[0];
+    document.body.appendChild(input);
+    await processAnimFrame();
   });
 
   afterEach(async () => {
@@ -19,9 +27,6 @@ describe('IdsInput Component', () => {
 
   it('renders with no errors', () => {
     const errors = jest.spyOn(global.console, 'error');
-    const elem = new IdsInput();
-    document.body.appendChild(elem);
-    elem.remove();
     expect(document.querySelectorAll('ids-input').length).toEqual(1);
     expect(errors).not.toHaveBeenCalled();
   });
@@ -99,18 +104,20 @@ describe('IdsInput Component', () => {
   });
 
   it('should set label text', () => {
-    let label = input.labelEl.querySelector('ids-text');
-    label?.remove();
     input.label = 'test';
 
     document.body.innerHTML = '';
-    const elem = new IdsInput();
+
+    const template = document.createElement('template');
+    template.innerHTML = '<ids-input label="Hello World"></ids-input>';
+    const elem = template.content.childNodes[0];
+    document.body.appendChild(elem);
+
     document.body.appendChild(elem);
     input = document.querySelector('ids-input');
-    label = input.labelEl.querySelector('ids-text');
-    expect(input.labelEl.textContent.trim()).toBe('');
-    input.label = 'test';
-    expect(input.labelEl.textContent.trim()).toBe('test');
+    expect(input.labelEl.textContent.trim()).toBe('Hello World');
+    input.label = 'test2';
+    expect(input.labelEl.textContent.trim()).toBe('test2');
     input.label = null;
     expect(input.labelEl.textContent.trim()).toBe('');
   });

--- a/test/ids-input/ids-input-func-test.js
+++ b/test/ids-input/ids-input-func-test.js
@@ -143,6 +143,68 @@ describe('IdsInput Component', () => {
     expect(input.labelRequired).toEqual('true');
   });
 
+  it('should have an input with "aria-label" set when label-hidden ' +
+  'is flagged and a label exists, then toggles this by unsetting it', async () => {
+    input.labelHidden = true;
+    expect(input.labelHidden).toBeTruthy();
+    await processAnimFrame();
+
+    expect(input.shadowRoot.querySelector('label')).toBeFalsy();
+    expect(input.input.getAttribute('aria-label')?.length).toBeGreaterThan(0);
+
+    input.labelHidden = false;
+    expect(input.labelHidden).toBeFalsy();
+    await processAnimFrame();
+
+    expect(input.shadowRoot.querySelector('label')).toBeTruthy();
+    expect(input.input.hasAttribute('aria-label')).toBeFalsy();
+  });
+
+  it('renders label-hidden from a template with no issues', async () => {
+    const errors = jest.spyOn(global.console, 'error');
+
+    const template = document.createElement('template');
+    template.innerHTML = '<ids-input label="testing input" label-hidden></ids-input>';
+
+    input = template.content.childNodes[0];
+    document.body.appendChild(input);
+    await processAnimFrame();
+
+    expect(errors).not.toHaveBeenCalled();
+  });
+
+  it('should be able to assign an external label element via setLabelElement ' +
+  'setter', async () => {
+    input.label = undefined;
+    input.render();
+    await processAnimFrame();
+
+    const newLabelTemplate = document.createElement('template');
+    newLabelTemplate.innerHTML = '<label>random external label</label>';
+    const newLabel = newLabelTemplate.content.childNodes[0];
+    input.setLabelElement(newLabel);
+    await processAnimFrame();
+
+    expect(input.shadowRoot.querySelector('label')).toBeFalsy();
+  });
+
+  it('sets the label text of an external label element', async () => {
+    input.label = undefined;
+    input.render();
+    await processAnimFrame();
+
+    const newLabelTemplate = document.createElement('template');
+    newLabelTemplate.innerHTML = '<label>random external label</label>';
+    const newLabel = newLabelTemplate.content.childNodes[0];
+    input.setLabelElement(newLabel);
+    input.setLabelText('a new label');
+    await processAnimFrame();
+    expect(newLabel.innerHTML).toEqual('a new label');
+    input.setLabelText(undefined);
+    await processAnimFrame();
+    expect(newLabel.innerHTML).toEqual('');
+  });
+
   it('should set value', () => {
     expect(input.value).toEqual('');
     input.value = 'test';

--- a/test/ids-input/ids-input-func-test.js.snap
+++ b/test/ids-input/ids-input-func-test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsInput Component renders correctly 1`] = `"<ids-input type=\\"text\\"></ids-input>"`;
+exports[`IdsInput Component renders correctly 1`] = `"<ids-input label=\\"testing input\\" id=\\"ids-input-2\\" type=\\"text\\"></ids-input>"`;

--- a/test/ids-input/ids-input-validation-func-test.js
+++ b/test/ids-input/ids-input-validation-func-test.js
@@ -5,10 +5,19 @@ import IdsInput from '../../src/ids-input/ids-input';
 
 let elem = null;
 
+const processAnimFrame = () => new Promise((resolve) => {
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(resolve);
+  });
+});
+
 describe('IdsInput Component', () => {
   beforeEach(async () => {
-    elem = new IdsInput();
+    const template = document.createElement('template');
+    template.innerHTML = '<ids-input label="testing input"></ids-input>';
+    elem = template.content.childNodes[0];
     document.body.appendChild(elem);
+    await processAnimFrame();
   });
 
   afterEach(async () => {
@@ -16,10 +25,10 @@ describe('IdsInput Component', () => {
     elem = null;
   });
 
-  it('should add/remove required error', () => {
+  it('should add/remove required error', async () => {
     elem.validate = 'required';
     elem.template();
-    document.body.appendChild(elem);
+    await processAnimFrame();
 
     expect(elem.getAttribute('validate')).toEqual('required');
     expect(elem.validate).toEqual('required');
@@ -29,10 +38,10 @@ describe('IdsInput Component', () => {
 
     const msgEl = elem.shadowRoot.querySelector('.validation-message');
     expect(elem.input.getAttribute('aria-invalid')).toEqual('true');
-    expect(elem.input.getAttribute('aria-describedby')).toEqual('ids-input-id-error');
+    expect(elem.input.getAttribute('aria-describedby')).toEqual('ids-input-1-input-error');
     expect(msgEl).toBeTruthy();
     expect(msgEl.getAttribute('validation-id')).toEqual('required');
-    expect(msgEl.getAttribute('id')).toEqual('ids-input-id-error');
+    expect(msgEl.getAttribute('id')).toEqual('ids-input-1-input-error');
 
     elem.input.value = 'test';
     elem.checkValidation();
@@ -224,7 +233,6 @@ describe('IdsInput Component', () => {
   it('should remove all the messages from input', () => {
     elem.validate = 'required';
     elem.template();
-    document.body.appendChild(elem);
 
     expect(elem.getAttribute('validate')).toEqual('required');
     expect(elem.validate).toEqual('required');

--- a/test/ids-trigger-field/ids-trigger-field-func-test.js.snap
+++ b/test/ids-trigger-field/ids-trigger-field-func-test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsTriggerField Component renders correctly 1`] = `"<ids-trigger-field><ids-input triggerfield=\\"true\\"></ids-input><ids-trigger-button role=\\"button\\"></ids-trigger-button></ids-trigger-field>"`;
+exports[`IdsTriggerField Component renders correctly 1`] = `"<ids-trigger-field><ids-input id=\\"ids-input-2\\" triggerfield=\\"true\\"></ids-input><ids-trigger-button role=\\"button\\"></ids-trigger-button></ids-trigger-field>"`;
 
-exports[`IdsTriggerField Component renders correctly 2`] = `"<ids-trigger-field><ids-input triggerfield=\\"true\\"></ids-input><ids-trigger-button role=\\"button\\"></ids-trigger-button></ids-trigger-field>"`;
+exports[`IdsTriggerField Component renders correctly 2`] = `"<ids-trigger-field><ids-input id=\\"ids-input-2\\" triggerfield=\\"true\\"></ids-input><ids-trigger-button role=\\"button\\"></ids-trigger-button></ids-trigger-field>"`;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

Adding some flexibility to the `ids-input` component with regards to labels and `id` assignment; mainly for the sake of WC + axe and screen readers to work naturally together with the hassle of ShadowDOM (at least for now, in 2021 🤞...).

Changes for the sake of flexibility and WC accessibility quirks on `ids-input` in this PR: 

(1) no `label` attrib removes `<label>` elem from shadowDom

(2) `id` prop is set to be incremented/unique by default. Input will also receive `${id}-input`.
--  future facing since puppeteer tests can be written with `pierce/#unique-id` for the overall document or any sub document.
-- tames axe issues when you want to link inputs using hierarchical aria rules or `label for`
-- There is a gotcha that `this.id` had to be set in the `template` vs in `connectedCallback` as an exceptional rule before first render -- otherwise we have to be very defensive in when we do things with the attrib as I learned in the `ids-spinbox`. There might be a better way to handle this but it was just the conclusion of going in circles previously on the issue.

(3) added a `label-hidden` attrib: setting this adds `aria-label` to the inner `<input>`. This also satisfies screen readers and axe tools if we don't want the label to be explicitly on an input in an app (say it is self explanatory or for some group/etc, or with IdsSpinbox + ChromeVox)

(4) renamed `label-text` class to `ids-label-text` + added `setLabelElement` prop which allows external label to get required asterisk/validation styling. 

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Related to #39 and most of the changes help to satisfy making `ids-spinbox` accessible without axe issues (in addition to `ids-button` PR)

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull this branch (`139-ids-input-optional-label`) and visit http://localhost:4300 and view input changes.
- check the examples for input and see that there's no regressive changes.
- verify that no `id`s on the `ids-input` components nor the inner `input` components have collisions in overall document scope when inspecting the main demo page markup.
![image](https://user-images.githubusercontent.com/1799905/119564736-1ff77100-bd77-11eb-885e-0d5cea08863b.png)

- if the changes in PR aren't straightforward, another WIP branch which this is a blocker on is `139-ids-spinbox`. Pulling that and going to `http://localhost:4000/ids-spinbox` can show how it prevented Axe errors/simplified the label in a bit of a niche pattern with the WCs we haven't had to use yet.

**Included in this Pull Request**:
- [X] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
