### PR TITLE
Misc: Rename instances of events from past-to-present tense for consistency

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -90,7 +90,7 @@
   - Markup has changed to a custom element `<ids-tabs value=${selection}></ids-tabs>`
   - content within the tabs are specified as `<ids-tab value=${selection-value}>`Tab Label/Content`</ids-tab>`
 - `[Tags]` The Tag component has been changed to a web component.
-  - If using events events are now plain JS events. beforetagremoved, tagremoved, aftertagremoved
+  - If using events events are now plain JS events. beforetagremove, tagremove, aftertagremove
   - If using properties/settings these are now attributes: dismissible, color
   - Markup has changed to a custom element `<ids-tag color="error">Text</ids-tag>`
   - Can now be imported as a single JS file and used with encapsulated styles

--- a/src/ids-data-grid/ids-data-grid.d.ts
+++ b/src/ids-data-grid/ids-data-grid.d.ts
@@ -2,7 +2,7 @@
 // confirm our code is type safe, and to support TypeScript users.
 import { IdsElement } from '../ids-base';
 
-interface sorted extends Event {
+interface sort extends Event {
   detail: {
     elem: IdsDataGrid,
     sortColumn: {
@@ -12,7 +12,7 @@ interface sorted extends Event {
   }
 }
 
-interface activecellchanged extends Event {
+interface activecellchange extends Event {
   detail: {
     elem: IdsDataGrid,
     activeCell: {
@@ -54,9 +54,9 @@ export default class IdsDataGrid extends IdsElement {
   setSortColumn(id: string, ascending?: boolean): void;
 
   /** Fires before the tag is removed, you can return false in the response to veto. */
-  on(event: 'sorted', listener: (event: sorted) => void): this;
+  on(event: 'sort', listener: (event: sort) => void): this;
 
   /** Fires while the tag is removed */
   // eslint-disable-next-line no-use-before-define
-  on(event: 'activecellchanged', listener: (event: activecellchanged) => void): this;
+  on(event: 'activecellchange', listener: (event: activecellchange) => void): this;
 }

--- a/src/ids-data-grid/ids-data-grid.js
+++ b/src/ids-data-grid/ids-data-grid.js
@@ -325,7 +325,7 @@ class IdsDataGrid extends mix(IdsElement).with(
     this.datasource.sort(id, ascending, null);
     this.rerender();
     this.setSortState(id, ascending);
-    this.triggerEvent('sorted', this, { detail: { elem: this, sortColumn: this.sortColumn } });
+    this.triggerEvent('sort', this, { detail: { elem: this, sortColumn: this.sortColumn } });
   }
 
   /**
@@ -496,7 +496,7 @@ class IdsDataGrid extends mix(IdsElement).with(
     cellNode.setAttribute('tabindex', '0');
     cellNode.focus();
 
-    this.triggerEvent('activecellchanged', this, { detail: { elem: this, activeCell: this.activeCell } });
+    this.triggerEvent('activecellchange', this, { detail: { elem: this, activeCell: this.activeCell } });
     return this.activeCell;
   }
 }

--- a/src/ids-mixins/README.md
+++ b/src/ids-mixins/README.md
@@ -73,7 +73,7 @@ This mixin adds a clear button (x icon) to an input element ands bind click and 
 
 ## Ids Validation Mixin
 
-This mixin add functionality for validation to the component. This includes a add/remove message function api.  Also triggers the `validated` event when evaluated and passes an `isValid` argument for the current state.
+This mixin add functionality for validation to the component. This includes a add/remove message function api.  Also triggers the `` event when evaluated and passes an `isValid` argument for the current state.
 
 ## Ids Theme Mixin
 

--- a/src/ids-mixins/ids-validation-mixin.js
+++ b/src/ids-mixins/ids-validation-mixin.js
@@ -102,7 +102,7 @@ const IdsValidationMixin = (superclass) => class extends superclass {
         }
       });
       this.isTypeNotValid = null;
-      this.triggerEvent('validated', this, { detail: { elem: this, value: this.value, isValid } });
+      this.triggerEvent('validate', this, { detail: { elem: this, value: this.value, isValid } });
     }
   }
 

--- a/src/ids-tag/ids-tag.d.ts
+++ b/src/ids-tag/ids-tag.d.ts
@@ -33,11 +33,11 @@ export default class IdsTag extends IdsElement {
   version: 'new' | 'classic' | string;
 
   /** Fires before the tag is removed, you can return false in the response to veto. */
-  on(event: 'beforetagremoved', listener: (detail: IdsTagEventVetoable) => void): this;
+  on(event: 'beforetagremove', listener: (detail: IdsTagEventVetoable) => void): this;
 
   /** Fires while the tag is removed */
-  on(event: 'tagremoved', listener: (detail: IdsTagEventDetail) => void): this;
+  on(event: 'tagremove', listener: (detail: IdsTagEventDetail) => void): this;
 
   /** Fires after the tag is removed */
-  on(event: 'aftertagremoved', listener: (detail: IdsTagEventDetail) => void): this;
+  on(event: 'aftertagremove', listener: (detail: IdsTagEventDetail) => void): this;
 }

--- a/src/ids-tag/ids-tag.js
+++ b/src/ids-tag/ids-tag.js
@@ -226,15 +226,15 @@ class IdsTag extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin, IdsT
     const response = (veto) => {
       canDismiss = !!veto;
     };
-    this.triggerEvent('beforetagremoved', this, { detail: { elem: this, response } });
+    this.triggerEvent('beforetagremove', this, { detail: { elem: this, response } });
 
     if (!canDismiss) {
       return;
     }
 
-    this.triggerEvent('tagremoved', this, { detail: { elem: this } });
+    this.triggerEvent('tagremove', this, { detail: { elem: this } });
     this.remove();
-    this.triggerEvent('aftertagremoved', this, { detail: { elem: this } });
+    this.triggerEvent('aftertagremove', this, { detail: { elem: this } });
   }
 }
 

--- a/src/ids-trigger-field/ids-trigger-field.js
+++ b/src/ids-trigger-field/ids-trigger-field.js
@@ -179,7 +179,7 @@ class IdsTriggerField extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin
   handleEvents() {
     if (this.input) {
       const className = 'has-validation-message';
-      this.onEvent('validated', this.input, (e) => {
+      this.onEvent('validate', this.input, (e) => {
         if (e.detail?.isValid) {
           this.container?.classList?.remove(className);
         } else {

--- a/src/ids-virtual-scroll/ids-virtual-scroll.js
+++ b/src/ids-virtual-scroll/ids-virtual-scroll.js
@@ -105,7 +105,7 @@ class IdsVirtualScroll extends mix(IdsElement).with(IdsEventsMixin) {
     }
     /** @type {any} */
     const elem = this;
-    this.triggerEvent('afterrendered', elem, { detail: { elem: this, startIndex, endIndex } });
+    this.triggerEvent('afterrender', elem, { detail: { elem: this, startIndex, endIndex } });
   }
 
   /**

--- a/test/ids-data-grid/ids-data-grid-func-test.js
+++ b/test/ids-data-grid/ids-data-grid-func-test.js
@@ -261,7 +261,7 @@ describe('IdsDataGrid Component', () => {
       expect(x.detail.sortColumn.ascending).toEqual(true);
     });
 
-    dataGrid.addEventListener('sorted', mockCallback);
+    dataGrid.addEventListener('sort', mockCallback);
     dataGrid.setSortColumn('description', true);
 
     expect(mockCallback.mock.calls.length).toBe(1);
@@ -274,7 +274,7 @@ describe('IdsDataGrid Component', () => {
       expect(x.detail.sortColumn.ascending).toEqual(false);
     });
 
-    dataGrid.addEventListener('sorted', mockCallback);
+    dataGrid.addEventListener('sort', mockCallback);
     dataGrid.setSortColumn('description', false);
 
     expect(mockCallback.mock.calls.length).toBe(1);
@@ -287,7 +287,7 @@ describe('IdsDataGrid Component', () => {
       expect(x.detail.sortColumn.ascending).toEqual(true);
     });
 
-    dataGrid.addEventListener('sorted', mockCallback);
+    dataGrid.addEventListener('sort', mockCallback);
     dataGrid.setSortColumn('description');
 
     expect(mockCallback.mock.calls.length).toBe(1);
@@ -312,7 +312,7 @@ describe('IdsDataGrid Component', () => {
       expect(x.detail.sortColumn.ascending).toEqual(true);
     });
 
-    dataGrid.addEventListener('sorted', mockCallback);
+    dataGrid.addEventListener('sort', mockCallback);
     dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-header-cell')[1].click();
 
     expect(mockCallback.mock.calls.length).toBe(1);
@@ -323,7 +323,7 @@ describe('IdsDataGrid Component', () => {
     const mockCallback = jest.fn();
 
     dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-header-cell')[5].click();
-    dataGrid.addEventListener('sorted', mockCallback);
+    dataGrid.addEventListener('sort', mockCallback);
 
     expect(mockCallback.mock.calls.length).toBe(0);
     expect(errors).not.toHaveBeenCalled();
@@ -496,7 +496,7 @@ describe('IdsDataGrid Component', () => {
     expect(dataGrid.activeCell.row).toEqual(0);
   });
 
-  it('fires activecellchanged event', () => {
+  it('fires activecellchange event', () => {
     const mockCallback = jest.fn((x) => {
       expect(x.detail.elem).toBeTruthy();
       expect(x.detail.activeCell.row).toEqual(1);
@@ -504,17 +504,17 @@ describe('IdsDataGrid Component', () => {
       expect(x.detail.activeCell.node).toBeTruthy();
     });
 
-    dataGrid.addEventListener('activecellchanged', mockCallback);
+    dataGrid.addEventListener('activecellchange', mockCallback);
     const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
     dataGrid.dispatchEvent(event);
 
     expect(mockCallback.mock.calls.length).toBe(1);
   });
 
-  it('fires activecellchanged event on click', () => {
+  it('fires activecellchange event on click', () => {
     const mockCallback = jest.fn();
 
-    dataGrid.addEventListener('activecellchanged', mockCallback);
+    dataGrid.addEventListener('activecellchange', mockCallback);
     dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row')[3]
       .querySelectorAll('.ids-data-grid-cell')[3].click();
 

--- a/test/ids-tag/ids-tag-func-test.js
+++ b/test/ids-tag/ids-tag-func-test.js
@@ -119,9 +119,9 @@ describe('IdsTag Component', () => {
     expect(mockCallback.mock.calls.length).toBe(1);
   });
 
-  it('fires beforetagremoved on dismiss', () => {
+  it('fires beforetagremove on dismiss', () => {
     tag.dismissible = true;
-    tag.addEventListener('beforetagremoved', (e) => {
+    tag.addEventListener('beforetagremove', (e) => {
       e.detail.response(false);
     });
     tag.dismiss();
@@ -129,26 +129,26 @@ describe('IdsTag Component', () => {
     expect(document.body.contains(tag)).toEqual(true);
   });
 
-  it('fires tagremoved on dismiss', () => {
+  it('fires tagremove on dismiss', () => {
     const mockCallback = jest.fn((x) => {
       expect(x.detail.elem).toBeTruthy();
     });
 
     tag.dismissible = true;
-    tag.addEventListener('tagremoved', mockCallback);
+    tag.addEventListener('tagremove', mockCallback);
     tag.dismiss();
 
     expect(mockCallback.mock.calls.length).toBe(1);
     expect(document.body.contains(tag)).toEqual(false);
   });
 
-  it('fires aftertagremoved on dismiss', () => {
+  it('fires aftertagremove on dismiss', () => {
     const mockCallback = jest.fn((x) => {
       expect(x.detail.elem).toBeTruthy();
     });
 
     tag.dismissible = true;
-    tag.addEventListener('aftertagremoved', mockCallback);
+    tag.addEventListener('aftertagremove', mockCallback);
     tag.dismiss();
 
     expect(mockCallback.mock.calls.length).toBe(1);

--- a/test/ids-trigger-field/ids-trigger-field-func-test.js
+++ b/test/ids-trigger-field/ids-trigger-field-func-test.js
@@ -133,11 +133,11 @@ describe('IdsTriggerField Component', () => {
     const className = 'has-validation-message';
     expect(triggerField.container.classList).not.toContain(className);
     let input = triggerField.querySelector('ids-input');
-    let event = new CustomEvent('validated', { detail: { isValid: false } });
+    let event = new CustomEvent('validate', { detail: { isValid: false } });
     input.dispatchEvent(event);
     expect(triggerField.container.classList).toContain(className);
     input = triggerField.querySelector('ids-input');
-    event = new CustomEvent('validated', { detail: { isValid: true } });
+    event = new CustomEvent('validate', { detail: { isValid: true } });
     input.dispatchEvent(event);
     expect(triggerField.container.classList).not.toContain(className);
   });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Since the HTMLDOM events use present tense e.g. `change` `click`, etc, we decided after a team conversation to make events consistently present tense e.g. `activecellchange` vs `activecellchanged`.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #213 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- tests should pass

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
N/A
<!-- After submitting your PR, please check back to make sure checks on the PR -->
