### PR TITLE
252- change the default button text color to slate-60

### DIFF
--- a/src/ids-button/ids-button-base.scss
+++ b/src/ids-button/ids-button-base.scss
@@ -46,8 +46,8 @@
   @include px-28();
   @include rounded-default();
   @include text-16();
+  @include text-slate-60();
 
-  color: var(--ids-color-font-base);
   overflow: hidden;
   padding-bottom: 6px;
   padding-top: 6px;

--- a/src/ids-button/ids-button.scss
+++ b/src/ids-button/ids-button.scss
@@ -121,6 +121,7 @@
 .btn-swipe-action-left,
 .btn-swipe-action-right {
   @include bg-slate-30();
+  @include text-slate-100();
 
   border-radius: 0;
   display: block;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
- Changed the default button text color to slate-60 in `ids-button-base.scss`

**Related github/jira issue (required)**:

- Closes #252

**Steps necessary to review your pull request (required)**:
- `npm run start` and go to http://localhost:4300/ids-button
- NOTE: Tertiary and Default button are the same--font color has now been changed to #606066 (slate-60)

<img width="1264" alt="Screen Shot 2021-07-15 at 9 57 29 AM" src="https://user-images.githubusercontent.com/22609861/125827532-c01927fe-05b3-48f0-9e5c-49c87b755135.png">

- NOTE TO SELF: 
- color palette documentation: https://main-enterprise.demo.design.infor.com/components/colors/example-index.html
- design tokens (check here for variables used in the `enterprise-wc` repo--this was handy bc I didn't know what `--ids-color-font-base` referred to in `ids-button-base.scss`)
https://github.com/infor-design/design-system/blob/main/design-tokens/theme-new/theme.json
- in the `enterprise-wc` repo, can check `node_modules/ids-identity/dist/theme-new/tokens/web/theme-new-mixins.scss` which has shorthand for CSS (similar to TailwindCSS)--prefer to use `@include text-slate-60();` over `color: var(--ids-color-palette-slate-60)`
