### PR TITLE
ids-text: fix right-click crashing Chrome

### DIFF
--- a/src/ids-text/ids-text.js
+++ b/src/ids-text/ids-text.js
@@ -45,19 +45,18 @@ class IdsText extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin, IdsToo
    */
   static get attributes() {
     return [
-      attributes.TYPE,
-      attributes.FONT_SIZE,
       attributes.AUDIBLE,
+      attributes.COLOR,
       attributes.DISABLED,
       attributes.DISPLAY,
       attributes.ERROR,
-      attributes.MODE,
-      attributes.VERSION,
-      attributes.LABEL,
+      attributes.FONT_SIZE,
       attributes.FONT_WEIGHT,
-      attributes.AUDIBLE,
+      attributes.LABEL,
+      attributes.MODE,
       attributes.OVERFLOW,
-      attributes.COLOR
+      attributes.TYPE,
+      attributes.VERSION
     ];
   }
 
@@ -82,7 +81,7 @@ class IdsText extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixin, IdsToo
       mode="${this.mode}"
       version="${this.version}"
       part="text"
-    ><slot></slot>
+    >${this.innerHTML}
     </${tag}>`;
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixes an issue with IdsText where when it is arranged in certain patterns and right clicking on the non-whitespace characters, would crash Chrome browsers. 

Since IDSText is meant to simply be a content tag type with styling and a user defined slot, a workaround for now was to render `innerHTML` vs a `slot` in the shadowDOM directly.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
N/A, was a known issue but we did not have a tracker for it yet. Fixed while working on `ids-draggable` since it was affecting efficient debuggability with something.

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- visit the local demo app @ http://localhost:4300 in Chrome latest (important; otherwise worked on FF)
- right click on the "ICON" or "ONLY" text specifically -- not on whitespace characters on the header for "ICON ONLY BUTTONS"
- Chrome should no longer crash and visit an "Aw Snap" and "Error code: 5" page
![image](https://user-images.githubusercontent.com/1799905/125868846-c291497e-fdc7-48b9-80c8-4e0d2ef1c182.png)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
