### PR TITLE
224- fix dirty-tracker indicator

### DIFF
--- a/app/ids-input/example.html
+++ b/app/ids-input/example.html
@@ -17,7 +17,7 @@
     <ids-input type="text" label="Email Address" placeholder="Company@address.com" validate="email required"></ids-input>
     <ids-input type="text" label="Disabled" disabled="true" value="Field not editable"></ids-input>
     <ids-input type="text" label="Readonly" readonly="true" value="02006"></ids-input>
-    <ids-input type="text" label="Dirty Tracking" dirty-tracker="true" placeholder="Dirty Tracking"></ids-input>
+    <ids-input type="text" label="Dirty Tracking" dirty-tracker="true" placeholder="Dirty Tracking" value="02006"></ids-input>
     <ids-input type="text" label="Clearable" placeholder="Clearable text Field" clearable="true"></ids-input>
     <ids-input type="text" label="Autoselect" value="Text select on focus" autoselect="true"></ids-input>
   </ids-layout-grid-cell>

--- a/src/ids-color-picker/ids-color-picker.js
+++ b/src/ids-color-picker/ids-color-picker.js
@@ -81,7 +81,7 @@ class IdsColorPicker extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMix
             <ids-input tabindex="-1" class="color-input" type="color" disabled="${this.disabled}"></ids-input>
             <ids-text audible="true">Pick Custom Color</ids-text>
           </label>
-          <ids-input size="sm" dirty-tracker="true" disabled="${this.disabled}" class="${this.label === '' ? 'color-input-value-no-label' : 'color-input-value'}" label="${this.label}"></ids-input>
+          <ids-input value="${this.value.toLowerCase()}" size="sm" dirty-tracker="true" disabled="${this.disabled}" class="${this.label === '' ? 'color-input-value-no-label' : 'color-input-value'}" label="${this.label}"></ids-input>
           <ids-trigger-button id="${id}-button" title="${id}">
             <ids-text audible="true">color picker trigger</ids-text>
             <ids-icon class="ids-dropdown" icon="dropdown" size="medium"></ids-icon>
@@ -104,7 +104,7 @@ class IdsColorPicker extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMix
   }
 
   get value() {
-    return this.getAttribute('value') || '#B94E4E';
+    return this.getAttribute('value') || '#b94e4e';
   }
 
   /**
@@ -181,7 +181,7 @@ class IdsColorPicker extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMix
 
         if (target.hasAttribute('hex')) {
           this.#updateColorCheck(target);
-          this.setAttribute('value', target.getAttribute('hex'));
+          this.setAttribute('value', target.getAttribute('hex').toLowerCase());
           this.#openCloseColorpicker();
         }
       });
@@ -192,7 +192,7 @@ class IdsColorPicker extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMix
             this.#openCloseColorpicker();
           }
           if (keyup.target.hasAttribute('hex')) {
-            this.setAttribute('value', keyup.target.getAttribute('hex'));
+            this.setAttribute('value', keyup.target.getAttribute('hex').toLowerCase());
             this.#openCloseColorpicker();
             this.#updateColorCheck(keyup.target);
           }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

- I applied `.toLowerCase()` to all hex color codes--this is why the dirty-tracker indicator is not working correctly for `ids-color-picker` component, because it was comparing a lower-cased value to an all-caps value (it is initially entered as all caps in the attribute, but gets lower-cased in the process of being set). 
- I was not able to reproduce the issue saying that initial values also triggered the dirty-tracker indicator on the `ids-input` component. I believe the issue was just due to inconsistent casing for the `ids-color picker`, so this should solve the ticket.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->

- Closes #224


**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- `npm run start:watch`

- http://localhost:4300/ids-color-picker
- change the color hex code by typing it in or clicking on the color swatch
- the dirty-tracking indicator (yellow triangular flag in top left) should only appear when values differ from the initial value from when page first loaded

Initial value here is `#b94e4e`
<img width="298" alt="Screen Shot 2021-07-19 at 4 17 13 PM" src="https://user-images.githubusercontent.com/22609861/126239312-dccb667c-5f25-4de5-b6b8-2a0b4de944d9.png">
<img width="262" alt="Screen Shot 2021-07-19 at 4 17 32 PM" src="https://user-images.githubusercontent.com/22609861/126239313-89dcf55d-4016-47c4-b9c7-cd46e14b806f.png">

- http://localhost:4300/ids-input
- change line 20 in `app/ids-input/example.html` to `<ids-input value="test" type="text" label="Dirty Tracking" dirty-tracker="true" placeholder="Dirty Tracking"></ids-input>`
- the dirty-tracking indicator already works as it should (dirty-tracking indicator only appears when value differs from initial value "test")

<img width="337" alt="Screen Shot 2021-07-19 at 4 18 31 PM" src="https://user-images.githubusercontent.com/22609861/126239400-1603dded-068a-4930-8fd9-da6ca3f4cc69.png">
<img width="353" alt="Screen Shot 2021-07-19 at 4 18 37 PM" src="https://user-images.githubusercontent.com/22609861/126239402-8655a749-8dba-413f-89c9-f0ac93e13072.png">


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
