### PR TITLE
ids-element: memo style objects for performance improvement per-render

### DIFF
--- a/test/helpers/css-style-sheet-mock.js
+++ b/test/helpers/css-style-sheet-mock.js
@@ -1,0 +1,3 @@
+window.CSSStyleSheet = function CSSStyleSheet() { //eslint-disable-line
+  return { cssRules: [], replaceSync: () => '' };
+};

--- a/test/ids-base/ids-base-func-test.js
+++ b/test/ids-base/ids-base-func-test.js
@@ -1,9 +1,10 @@
 /**
  * @jest-environment jsdom
  */
+import '../helpers/css-style-sheet-mock';
+import styleMock from '../helpers/style-mock';
 import IdsTag from '../../src/ids-tag/ids-tag';
 import { IdsElement } from '../../src/ids-base/ids-element';
-import styleMock from '../helpers/style-mock';
 
 describe('IdsBase Tests', () => {
   afterEach(async () => {
@@ -12,10 +13,6 @@ describe('IdsBase Tests', () => {
 
   it('can fall back to appending styles (mocked)', () => {
     const elem = new IdsTag();
-
-    window.CSSStyleSheet = function CSSStyleSheet() { //eslint-disable-line
-      return { cssRules: [], replaceSync: () => '' };
-    };
 
     elem.shadowRoot.adoptedStyleSheets = () => {};
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Currently on IDSElement, we are recreating styles on every render via `this.appendStyles`. There are only about 53 different namespaces for components registered and they are not using the same resources even though they are the same components that share the same styles so could spare to cut it down a bit with a simple memoization obj.

This is not the most perfect/thorough optimization since constructed stylesheets currently include a lot of content per-component and we go through setAttribute reflecting as well which takes a bulk of first render and there's other things after doing perf tests tonight, but very low hanging fruit on this one.

Found that on the demo page with changes, 
- 95.7% of renders could avoid creating a stylesheet/adopted stylesheet instance were avoided
- average for each component of just the demo page styles 1x went from ~0.573ms to ~0.033ms or 19-20x for 1st initial render/page-load of the components with no interactions (scale would gradually increase in favor of optimization as well). 

These numbers aren't crazy in scope (saves about ~0.5s on our demo page render on my PC in that test) but gives room for things to feel smoother per-render on average since there's only 16.6ms to work with for 60fps and time to first paint is one of the most important metrics on SEO.

(Note: haven't ran tests locally just pushing so PR can be up here for tomorrow AM in case coverage is not there now in ids-element)

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
- Related to #140 which is not confined to this issue and this was known for a while, just finally getting to this tonight since was browsing ids-element earlier and remembered to do that.

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

(1) On our demo app at http://localhost:4300, if you pull branch `component-stylesheets-optimization-perf-a` it saves cache hits/misses in `window.cacheHits`/`cacheMisses` and if logging in console after app loads (before there is interaction; as interactions will just increase cache hits thereafter here): 

```
window.cacheHits => 1204
window.cacheMisses => 54 ​
% of cache hits => ~95.7%
```

(2) for the performance check, check out the spreadsheet at:
https://docs.google.com/spreadsheets/d/1zbB23xci4Eh-qIjhLhR_FrD41-rl_mIsWIobHZyJaNs/edit?usp=sharing

Feel free to try to reproduce in the spreadsheet by first copying and then:

- pulling `component-stylesheets-pre-optimization-log` and copying console, stripping with find/replace in text editor and pasting into column `A` of `main`. Then notice the value on `B:1`.

- pulling `component-stylesheets-optimization-perf-b` and copying `console.time` logs; stripping with find/replace in text editor and pasting into column `A` of `optimized-branch-${your-browser}`. 
- Notice the value on `B:1` is much lower (this represents the average of all values in A which are per-component `appendStyles` runtime in ms).
- Component styles should render fine and tests and coverage should pass

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->