### PR TITLE
waitFor: add selector param overload/minor refactors & apply to test

### DIFF
--- a/test/helpers/are-jest-fake-timers-enabled.js
+++ b/test/helpers/are-jest-fake-timers-enabled.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-underscore-dangle */
+
+/**
+ * @returns {boolean} whether jest timers are enabled
+ */
+export default function areJestFakeTimersEnabled() {
+  /* istanbul ignore else */
+  if (typeof jest !== 'undefined' && jest !== null) {
+    return (
+      setTimeout._isMockFunction === true
+      || Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
+    );
+  }
+  // istanbul ignore next
+  return false;
+}

--- a/test/ids-spinbox/ids-spinbox-func-test.js
+++ b/test/ids-spinbox/ids-spinbox-func-test.js
@@ -299,9 +299,7 @@ describe('IdsSpinbox Component', () => {
     await waitFor(() => expect(
       getIdsButtons().find((el) => el.hasAttribute('disabled'))
     ).not.toEqual(undefined));
-
     elem.removeAttribute('readonly');
-
     await waitFor(() => expect(
       getIdsButtons().find((el) => el.hasAttribute('disabled'))
     ).not.toEqual(undefined));
@@ -310,9 +308,7 @@ describe('IdsSpinbox Component', () => {
 
     elem.removeAttribute('disabled');
 
-    await waitFor(() => expect(
-      getIdsButtons().find((el) => el.hasAttribute('disabled'))
-    ).toEqual(undefined));
+    await waitFor('ids-button[disabled]', { container: elem.shadowRoot, hidden: true });
 
     expect(elem.disabled).toBeNull();
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Adds overloading of `waitFor` in Jest similar to `waitForSelector` in Puppeteer and adds a flag named `hidden` for the sake of possibly migrating; in Jest, the `hidden` flag implies the DOM element could not be found *or* it does not have display hidden, but did not want to chance this with this).

Just a heads up also that error messages are not yet ideal in this util, but the paradigm that was started off with/code in the implementation it was based on wasn't too idiomatic/simple for what it does and was trying to time box this issue since it's really just a utility to get around some edge cases.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #192 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- ensure the changes made from previous merge yesterday make sense
- functional tests pass

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
