### PR TITLE
webpack: share runtime for normalized modules & update the source-map-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16679,6 +16679,28 @@
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true
     },
+    "source-map-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.0.tgz",
+      "integrity": "sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.2",
+        "source-map-js": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "sass": "^1.36.0",
     "sass-loader": "^12.1.0",
     "sass-to-string": "^1.5.1",
+    "source-map-loader": "^3.0.0",
     "style-loader": "^3.2.1",
     "stylelint": "^13.13.1",
     "stylelint-config-sass-guidelines": "^8.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = {
         test: /\.js(\?.*)?$/i
       }),
     ],
+    runtimeChunk: 'single'
   },
   output: {
     library: '[name]-lib.js',
@@ -178,6 +179,11 @@ module.exports = {
           // Compiles Sass to CSS
           'sass-loader',
         ]
+      },
+      {
+        test: /\.js$/,
+        enforce: 'pre',
+        use: ['source-map-loader'],
       },
     ]
   },


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
(1) changes a parameter to share the runtime across app entry-points as the nature of our library is one global set of instances (#290). 

Fixes a few hidden quirks about using `instanceof` or `Ids{Component}.prototype` consistency in mixins/callbacks and saves a tiny bit of RAM/time executing JS on-load.

(2) adds `source-map-loader` to debug some types of problems a bit quicker.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Fixes #290 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull this branch
- run `npm i`
- close browser or run in incognito/hard refresh

- open Chrome Dev Tools => Source Tab => Ctrl + P  and search an ids component
![image](https://user-images.githubusercontent.com/1799905/128127530-d7f5964c-ed46-4854-9f39-54550bd5dc20.png)
- should see the compiled source map vs the webpack dist
- breakpoints work (but one caveat: since the code is source-mapped on first load, going another level now does not work oddly. But the source-maps seem to be correct/loaded by default now)

- visit http://localhost:4000/ids-pager
- open Chrome Dev Tools => Sources Tab => Ctrl + P and search for `ids-theme-mixin`
- put a breakpoint by clicking line number 8 and refresh page
- theme mixin module should run the line declaring 1x instead of repeat for each/every component in the app
(does call super class so may need to add parens as that's how I was testing to be sure; alternate method to debug is just old fashioned console.log above the `IdsThemeMixin` declaration)
![image](https://user-images.githubusercontent.com/1799905/128127800-2289d790-1245-476f-9187-9f7ccf83401c.png)


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
N/A
<!-- After submitting your PR, please check back to make sure checks on the PR -->
