### PR TITLE
302 - add Ids progress chart themes (need to merge 276 first)

### DIFF
--- a/app/ids-progress-chart/example.html
+++ b/app/ids-progress-chart/example.html
@@ -4,55 +4,44 @@
 
 <ids-layout-grid cols="3" gap="xl">
   <ids-layout-grid-cell>
-    <ids-progress-chart color="#606066" label-progress="90%" progress="90" label="dark"></ids-progress-chart>
-    <ids-progress-chart label="error" color="error" label-progress="33%" progress="33">
-      <ids-icon slot="icon" icon="error" size="medium"></ids-icon>
-    </ids-progress-chart>
+    <ids-progress-chart label-progress="90%" progress="90" label="dark"></ids-progress-chart>
+    <ids-progress-chart icon="error" label="error" color="error" label-progress="33%" progress="33"></ids-progress-chart>
     <ids-progress-chart color="success" label-progress="10 min" progress="10" label-total="1 hr" total="60" label="good"></ids-progress-chart>
     <ids-progress-chart color="base" label-progress="10 cm" progress="10" label-total="25 cm" total="25" label="primary"></ids-progress-chart>
     <ids-progress-chart color="#D66221"  progress="10" label-total="100" total="100" label="#D66221"></ids-progress-chart>
     <ids-progress-chart label="empty"></ids-progress-chart>
-    <ids-progress-chart color="warning"  progress="10" label-total="100" total="100" label="alert">
-      <ids-icon slot="icon" icon="alert" size="small"></ids-icon>
+    <ids-progress-chart icon="error" color="warning"  progress="10" label-total="100" total="100" label="alert">
     </ids-progress-chart>
-    <ids-progress-chart color="caution"  progress="10" label-total="100" total="100" label="alert-yellow">
-      <ids-icon slot="icon" icon="alert" size="small"></ids-icon>
+    <ids-progress-chart icon="alert" color="caution"  progress="10" label-total="100" total="100" label="alert-yellow">
     </ids-progress-chart>
   </ids-layout-grid-cell>
 
   <ids-layout-grid-cell>
-    <ids-progress-chart size="small" color="#606066"  progress="10"  total="100" label="dark"></ids-progress-chart>
-    <ids-progress-chart  size="small" color="error"  progress="10"  total="100" label="error">
-      <ids-icon slot="icon" icon="error" size="small"></ids-icon>
+    <ids-progress-chart size="small" progress="10"  total="100" label="dark"></ids-progress-chart>
+    <ids-progress-chart  icon="error" size="small" color="error"  progress="10"  total="100" label="error">
     </ids-progress-chart>
     <ids-progress-chart size="small" color="success"  progress="10"  total="100" label="good">
     </ids-progress-chart>
     <ids-progress-chart size="small" color="base"  progress="10"  total="100" label="primary"></ids-progress-chart>
     <ids-progress-chart size="small" color="#D66221"  progress="10"  total="100" label="#D66221"></ids-progress-chart>
     <ids-progress-chart size="small" label="empty"></ids-progress-chart>
-    <ids-progress-chart size="small" color="warning"  progress="10"  total="100" label="alert">
-      <ids-icon slot="icon" size="small" icon="alert"></ids-icon>
+    <ids-progress-chart icon="alert" size="small" color="warning"  progress="10"  total="100" label="alert">
     </ids-progress-chart>
-    <ids-progress-chart size="small" color="caution"  progress="10"  total="100" label="alert-yellow">
-      <ids-icon slot="icon" size="small" icon="alert"></ids-icon>
+    <ids-progress-chart icon="alert" size="small" color="caution"  progress="10"  total="100" label="alert-yellow">
     </ids-progress-chart>
   </ids-layout-grid-cell>
   
   <ids-layout-grid-cell>
-    <ids-progress-chart size="small" color="#606066" label-progress="13h" progress="13" label-total="13h" total="13" label="dark"></ids-progress-chart>
-    <ids-progress-chart size="small" color="error" label-progress="13h" progress="13" label-total="26h" total="26" label="error">
-      <ids-icon slot="icon" icon="error" size="small"></ids-icon>
+    <ids-progress-chart size="small" label-progress="13h" progress="13" label-total="13h" total="13" label="dark"></ids-progress-chart>
+    <ids-progress-chart icon="error" size="small" color="error" label-progress="13h" progress="13" label-total="26h" total="26" label="error">
+      <!-- <ids-icon slot="icon" icon="error" size="small"></ids-icon> -->
     </ids-progress-chart>
     <ids-progress-chart size="small" color="success" label-progress="13h" progress="13" label-total="5h" total="5" label="good"></ids-progress-chart>
     <ids-progress-chart size="small" color="base" label-progress="13h" progress="13" label-total="14h" total="14" label="primary"></ids-progress-chart>
     <ids-progress-chart size="small" color="#D66221" label-progress="13h" progress="13" label-total="15h" total="15" label="#D66221"></ids-progress-chart>
     <ids-progress-chart size="small" label="empty"></ids-progress-chart>
-    <ids-progress-chart size="small" color="warning" label-progress="13h" progress="13" label-total="16h" total="16" label="alert">
-      <ids-icon slot="icon" size="small" icon="alert"></ids-icon>
-    </ids-progress-chart>
-    <ids-progress-chart size="small" color="caution" label-progress="13h" progress="13" label-total="20h" total="20" label="alert-yellow">
-      <ids-icon slot="icon" size="small" icon="alert"></ids-icon>
-    </ids-progress-chart>
+    <ids-progress-chart icon="alert" size="small" color="warning" label-progress="13h" progress="13" label-total="16h" total="16" label="alert"></ids-progress-chart>
+    <ids-progress-chart icon="alert" size="small" color="caution" label-progress="13h" progress="13" label-total="20h" total="20" label="alert-yellow"></ids-progress-chart>
   </ids-layout-grid-cell>
 
 </ids-layout-grid>

--- a/app/ids-progress-chart/example.html
+++ b/app/ids-progress-chart/example.html
@@ -10,32 +10,24 @@
     <ids-progress-chart color="base" label-progress="10 cm" progress="10" label-total="25 cm" total="25" label="primary"></ids-progress-chart>
     <ids-progress-chart color="#D66221"  progress="10" label-total="100" total="100" label="#D66221"></ids-progress-chart>
     <ids-progress-chart label="empty"></ids-progress-chart>
-    <ids-progress-chart icon="error" color="warning"  progress="10" label-total="100" total="100" label="alert">
-    </ids-progress-chart>
-    <ids-progress-chart icon="alert" color="caution"  progress="10" label-total="100" total="100" label="alert-yellow">
-    </ids-progress-chart>
+    <ids-progress-chart icon="error" color="warning"  progress="10" label-total="100" total="100" label="alert"></ids-progress-chart>
+    <ids-progress-chart icon="alert" color="caution"  progress="10" label-total="100" total="100" label="alert-yellow"></ids-progress-chart>
   </ids-layout-grid-cell>
 
   <ids-layout-grid-cell>
     <ids-progress-chart size="small" progress="10"  total="100" label="dark"></ids-progress-chart>
-    <ids-progress-chart  icon="error" size="small" color="error"  progress="10"  total="100" label="error">
-    </ids-progress-chart>
-    <ids-progress-chart size="small" color="success"  progress="10"  total="100" label="good">
-    </ids-progress-chart>
+    <ids-progress-chart icon="error" size="small" color="error"  progress="10"  total="100" label="error"></ids-progress-chart>
+    <ids-progress-chart size="small" color="success"  progress="10"  total="100" label="good"></ids-progress-chart>
     <ids-progress-chart size="small" color="base"  progress="10"  total="100" label="primary"></ids-progress-chart>
     <ids-progress-chart size="small" color="#D66221"  progress="10"  total="100" label="#D66221"></ids-progress-chart>
     <ids-progress-chart size="small" label="empty"></ids-progress-chart>
-    <ids-progress-chart icon="alert" size="small" color="warning"  progress="10"  total="100" label="alert">
-    </ids-progress-chart>
-    <ids-progress-chart icon="alert" size="small" color="caution"  progress="10"  total="100" label="alert-yellow">
-    </ids-progress-chart>
+    <ids-progress-chart icon="alert" size="small" color="warning"  progress="10"  total="100" label="alert"></ids-progress-chart>
+    <ids-progress-chart icon="alert" size="small" color="caution"  progress="10"  total="100" label="alert-yellow"></ids-progress-chart>
   </ids-layout-grid-cell>
   
   <ids-layout-grid-cell>
     <ids-progress-chart size="small" label-progress="13h" progress="13" label-total="13h" total="13" label="dark"></ids-progress-chart>
-    <ids-progress-chart icon="error" size="small" color="error" label-progress="13h" progress="13" label-total="26h" total="26" label="error">
-      <!-- <ids-icon slot="icon" icon="error" size="small"></ids-icon> -->
-    </ids-progress-chart>
+    <ids-progress-chart icon="error" size="small" color="error" label-progress="13h" progress="13" label-total="26h" total="26" label="error"></ids-progress-chart>
     <ids-progress-chart size="small" color="success" label-progress="13h" progress="13" label-total="5h" total="5" label="good"></ids-progress-chart>
     <ids-progress-chart size="small" color="base" label-progress="13h" progress="13" label-total="14h" total="14" label="primary"></ids-progress-chart>
     <ids-progress-chart size="small" color="#D66221" label-progress="13h" progress="13" label-total="15h" total="15" label="#D66221"></ids-progress-chart>

--- a/app/ids-progress-chart/readme-examples.html
+++ b/app/ids-progress-chart/readme-examples.html
@@ -36,14 +36,13 @@
 
   <ids-layout-grid-cell>
     <ids-text font-size="12" type="h1">Icon Example: </ids-text>
-    <ids-progress-chart label="Error with icon" color="error" progress="50" label-progress="50%">
-      <ids-icon slot="icon" icon="error" size="small"></ids-icon>
-    </ids-progress-chart>
+    <ids-progress-chart icon="error" label="Error with icon" color="error" progress="50" label-progress="50%"></ids-progress-chart>
   </ids-layout-grid-cell>
 
   <ids-layout-grid-cell>
     <ids-text font-size="12" type="h1">Size Example: </ids-text>
     <ids-progress-chart label="Compact" size="small" progress="50"></ids-progress-chart>
+    <ids-progress-chart icon="alert" label="Compact w/ icon" size="small" progress="50"></ids-progress-chart>
   </ids-layout-grid-cell>
 
   <ids-layout-grid-cell>

--- a/doc/CHECKLIST.md
+++ b/doc/CHECKLIST.md
@@ -117,7 +117,7 @@ Will get a checkbox at minimum viable product. The rest of the details are cover
  - [ ] Spinbox (ids-spin-box)
  - [ ] Splitter (ids-splitter)
  - [ ] Stepchart (ids-step-chart)
- - [x] SummaryField (ids-summary-field)
+ - [x] Summaryfield (ids-summary-field)
  - [ ] Swaplist (ids-swap-list)
  - [ ] Switch (ids-switch)
  - [ ] Tabs (ids-tabs)

--- a/doc/CHECKLIST.md
+++ b/doc/CHECKLIST.md
@@ -117,6 +117,7 @@ Will get a checkbox at minimum viable product. The rest of the details are cover
  - [ ] Spinbox (ids-spin-box)
  - [ ] Splitter (ids-splitter)
  - [ ] Stepchart (ids-step-chart)
+ - [x] SummaryField (ids-summary-field)
  - [ ] Swaplist (ids-swap-list)
  - [ ] Switch (ids-switch)
  - [ ] Tabs (ids-tabs)

--- a/src/ids-icon/ids-icon.js
+++ b/src/ids-icon/ids-icon.js
@@ -215,14 +215,18 @@ class IdsIcon extends mix(IdsElement).with(IdsEventsMixin, IdsLocaleMixin) {
 
   /**
    * Return the icon name
-   * @returns {string} the path data
+   * @returns {string} the icon
    */
   get icon() { return this.getAttribute(attributes.ICON) || ''; }
 
+  /**
+   * Sets the icon svg path to render
+   * @param {string} value The value must be a valid key in the path-data.json
+   */
   set icon(value) {
     const svgElem = this.shadowRoot?.querySelector('svg');
     if (value && this.iconData()) {
-      svgElem.styles.display = '';
+      svgElem.style.display = '';
       this.setAttribute(attributes.ICON, value);
       svgElem.innerHTML = this.iconData();
     } else {
@@ -233,7 +237,7 @@ class IdsIcon extends mix(IdsElement).with(IdsEventsMixin, IdsLocaleMixin) {
 
   /**
    * Return the size. May be large, normal/medium or small
-   * @returns {string} the path data
+   * @returns {string} the size
    */
   get size() { return this.getAttribute(attributes.SIZE) || 'normal'; }
 

--- a/src/ids-icon/ids-icon.js
+++ b/src/ids-icon/ids-icon.js
@@ -75,9 +75,9 @@ class IdsIcon extends mix(IdsElement).with(IdsEventsMixin, IdsLocaleMixin) {
     this.onEvent('languagechange.icon', this, async (e) => {
       await this.locale.setLanguage(e.detail.language.name);
       if (this.isFlipped(this.icon)) {
-        this.container.classList.add('flipped');
+        this.shadowRoot.querySelector('svg').classList.add('flipped');
       } else {
-        this.container.classList.remove('flipped');
+        this.shadowRoot.querySelector('svg').classList.remove('flipped');
       }
     });
   }
@@ -225,7 +225,7 @@ class IdsIcon extends mix(IdsElement).with(IdsEventsMixin, IdsLocaleMixin) {
    */
   set icon(value) {
     const svgElem = this.shadowRoot?.querySelector('svg');
-    if (value && this.iconData()) {
+    if (value && pathData[value]) {
       svgElem.style.display = '';
       this.setAttribute(attributes.ICON, value);
       svgElem.innerHTML = this.iconData();

--- a/src/ids-icon/ids-icon.js
+++ b/src/ids-icon/ids-icon.js
@@ -221,12 +221,13 @@ class IdsIcon extends mix(IdsElement).with(IdsEventsMixin, IdsLocaleMixin) {
 
   set icon(value) {
     const svgElem = this.shadowRoot?.querySelector('svg');
-    if (value && svgElem) {
+    if (value && this.iconData()) {
+      svgElem.styles.display = '';
       this.setAttribute(attributes.ICON, value);
       svgElem.innerHTML = this.iconData();
     } else {
       this.removeAttribute(attributes.ICON);
-      svgElem?.remove();
+      svgElem.style.display = 'none';
     }
   }
 

--- a/src/ids-progress-chart/README.md
+++ b/src/ids-progress-chart/README.md
@@ -73,20 +73,24 @@ These are the few scenarios where it will color the progress label as well
 
 ### Adding icons
 
-You can insert `ids-icon` components to include in the label heading
+You can include icons in the label heading
 
 ```html
-<ids-progress-chart label="Error with icon" color="error" progress="50">
-  <ids-icon icon="error" size="small"></ids-icon>
-</ids-progress-chart>
+<ids-progress-chart icon="error" label="Error with icon" color="error" progress="50"></ids-progress-chart>
 ```
 
 ### Adjust the size
 
-There are 2 sizes, `small` and `large`
+There are 2 sizes, `small` and `normal`
 
 ```html
 <ids-progress-chart label="Compact" size="small" progress="50"></ids-progress-chart>
+```
+
+Icons adjust accordingly to the size of the chart
+
+```html
+<ids-progress-chart icon="alert" label="Compact w/ icon" size="small" progress="50"></ids-progress-chart>
 ```
 
 ## Settings (Attributes)
@@ -94,8 +98,9 @@ There are 2 sizes, `small` and `large`
 - `progress` { string | number } set the progress value attribute
 - `total` { string | number } set the total progress value attribute
 - `color` { string } set the color of the progress bar
-- `size` { 'small' | 'large' } set the size of the progress bar
+- `size` { 'small' | 'normal' } set the size of the progress bar
 - `label` { string } set the title label
+- `icon` { string } set the icon type
 - `label-progress` { string } set the progress value label
 - `label-total` { string } set the total progress value label
 

--- a/src/ids-progress-chart/ids-progress-chart.d.ts
+++ b/src/ids-progress-chart/ids-progress-chart.d.ts
@@ -14,7 +14,7 @@ export default class IdsNotificationBanner extends IdsElement {
   progressLabel: string;
 
   /** Sets the size of the chart */
-  size: 'small' | 'large';
+  size: 'small' | 'normal';
 
   /** Sets the progress goal of the chart */
   total: string;

--- a/src/ids-progress-chart/ids-progress-chart.js
+++ b/src/ids-progress-chart/ids-progress-chart.js
@@ -17,8 +17,7 @@ import styles from './ids-progress-chart.scss';
 // Defaults
 const DEFAULT_PROGRESS = 0;
 const DEFAULT_TOTAL = 100;
-const DEFAULT_COLOR = '#606066';
-const DEFAULT_SIZE = 'large';
+const DEFAULT_SIZE = 'normal';
 
 /**
  * IDS Progress Chart Component
@@ -50,7 +49,7 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
       attributes.LABEL_PROGRESS,
       attributes.LABEL_TOTAL,
       attributes.PROGRESS,
-      attributes.SIZE, // small or large
+      attributes.SIZE, // small or normal
       attributes.TOTAL,
     ];
   }
@@ -60,11 +59,12 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
    * @returns {string} The template
    */
   template() {
+    console.log(this.icon)
     return `
     <div class="ids-progress-chart" part="chart">
       <div class="labels">
         <ids-text class="label-main">${this.label ?? ''}</ids-text>
-        <slot name="icon"></slot>
+        <ids-icon class="icon" icon="${this.icon ?? ''}"></ids-icon>
         <ids-text class="label-progress">${this.progressLabel ?? ''}</ids-text>
         <div class="label-end">
           <ids-text class="label-total">${this.totalLabel ?? ''}</ids-text>
@@ -78,12 +78,19 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
     </div>`;
   }
 
+  set icon(value) {
+    this.setAttribute('icon', value);
+    this.container.querySelector('ids-icon').setAttribute('icon', value);
+  }
+
+  get icon() { return this.getAttribute('icon'); }
+
   /**
    * Set the color of the bar
    * @param {string} value The color value, this can be a hex code with the #
    */
   set color(value) {
-    this.setAttribute(attributes.COLOR, value || DEFAULT_COLOR);
+    this.setAttribute(attributes.COLOR, value);
     this.#updateColor();
   }
 
@@ -109,10 +116,10 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
           progressLabel.style.color = prop;
         }
 
-        const slot = this.container.querySelector('slot');
+        const icon = this.container.querySelector('ids-icon');
         /* istanbul ignore else */
-        if (slot) {
-          slot.style.color = prop;
+        if (icon) {
+          icon.style.color = prop;
         }
       }
     } else if (this.color.substr(0, 1) !== '#') {
@@ -159,6 +166,7 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
   #updateSize() {
     const bar = this.container.querySelector('.bar');
     bar.style.minHeight = this.size === 'small' ? '10px' : '28px';
+    bar.style.borderRadius = this.size === 'small' ? '0px' : '2px';
   }
 
   /**

--- a/src/ids-progress-chart/ids-progress-chart.js
+++ b/src/ids-progress-chart/ids-progress-chart.js
@@ -252,6 +252,8 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
   set size(value) {
     const prop = value === 'small' ? value : DEFAULT_SIZE;
     this.setAttribute(attributes.SIZE, prop);
+    const icon = this.container.querySelector('.icon');
+    icon.setAttribute('size', prop)
     this.#updateSize();
   }
 

--- a/src/ids-progress-chart/ids-progress-chart.js
+++ b/src/ids-progress-chart/ids-progress-chart.js
@@ -17,7 +17,7 @@ import styles from './ids-progress-chart.scss';
 // Defaults
 const DEFAULT_PROGRESS = 0;
 const DEFAULT_TOTAL = 100;
-const DEFAULT_COLOR = '#25af65';
+const DEFAULT_COLOR = '#606066';
 const DEFAULT_SIZE = 'large';
 
 /**

--- a/src/ids-progress-chart/ids-progress-chart.js
+++ b/src/ids-progress-chart/ids-progress-chart.js
@@ -64,7 +64,7 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
     <div class="ids-progress-chart" part="chart">
       <div class="labels">
         <ids-text class="label-main">${this.label ?? ''}</ids-text>
-        <ids-icon class="icon" icon="${this.icon ?? ''}"></ids-icon>
+        <ids-icon class="icon" icon="${this.icon ?? ''}" size="${this.size ?? DEFAULT_SIZE}"></ids-icon>
         <ids-text class="label-progress">${this.progressLabel ?? ''}</ids-text>
         <div class="label-end">
           <ids-text class="label-total">${this.totalLabel ?? ''}</ids-text>
@@ -80,7 +80,7 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
 
   set icon(value) {
     this.setAttribute(attributes.ICON, value);
-    this.container.querySelector('ids-icon').setAttribute('icon', value);
+    this.container.querySelector('ids-icon').setAttribute(attributes.ICON, value);
   }
 
   get icon() { return this.getAttribute(attributes.ICON); }
@@ -233,7 +233,7 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
   get totalLabel() { return this.getAttribute(attributes.LABEL_TOTAL); }
 
   /**
-   * Set the size of the progress bar (small, or large (default)
+   * Set the size of the progress bar (small, or normal (default)
    * @param {string} value The size of the progress bar
    */
   set size(value) {
@@ -245,10 +245,6 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
   get size() { return this.getAttribute(attributes.SIZE); }
 
   #handleEvents() {
-    this.onEvent('slotchange', this.container.querySelector('slot'), () => {
-      this.#updateColor();
-    });
-
     return this;
   }
 }

--- a/src/ids-progress-chart/ids-progress-chart.js
+++ b/src/ids-progress-chart/ids-progress-chart.js
@@ -253,7 +253,7 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
     const prop = value === 'small' ? value : DEFAULT_SIZE;
     this.setAttribute(attributes.SIZE, prop);
     const icon = this.container.querySelector('.icon');
-    icon.setAttribute('size', prop)
+    icon.setAttribute('size', prop);
     this.#updateSize();
   }
 

--- a/src/ids-progress-chart/ids-progress-chart.js
+++ b/src/ids-progress-chart/ids-progress-chart.js
@@ -78,9 +78,22 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
     </div>`;
   }
 
+  /**
+   * Sets the icon inside the label
+   * @param {string} value The icon name
+   */
   set icon(value) {
-    this.setAttribute(attributes.ICON, value);
-    this.container.querySelector('ids-icon').setAttribute(attributes.ICON, value);
+    const icon = this.container.querySelector('.icon');
+    if (value) {
+      icon.style.display = '';
+      icon.style.margin = '0 4px';
+      this.setAttribute(attributes.ICON, value);
+      icon.setAttribute(attributes.ICON, value);
+    } else {
+      icon.style.display = 'none';
+      this.setAttribute(attributes.ICON, '');
+      icon.setAttribute(attributes.ICON, '');
+    }
   }
 
   get icon() { return this.getAttribute(attributes.ICON); }

--- a/src/ids-progress-chart/ids-progress-chart.js
+++ b/src/ids-progress-chart/ids-progress-chart.js
@@ -45,6 +45,7 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
   static get attributes() {
     return [
       attributes.COLOR,
+      attributes.ICON,
       attributes.LABEL,
       attributes.LABEL_PROGRESS,
       attributes.LABEL_TOTAL,
@@ -59,7 +60,6 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
    * @returns {string} The template
    */
   template() {
-    console.log(this.icon)
     return `
     <div class="ids-progress-chart" part="chart">
       <div class="labels">
@@ -79,11 +79,11 @@ class IdsProgressChart extends mix(IdsElement).with(IdsEventsMixin, IdsThemeMixi
   }
 
   set icon(value) {
-    this.setAttribute('icon', value);
+    this.setAttribute(attributes.ICON, value);
     this.container.querySelector('ids-icon').setAttribute('icon', value);
   }
 
-  get icon() { return this.getAttribute('icon'); }
+  get icon() { return this.getAttribute(attributes.ICON); }
 
   /**
    * Set the color of the bar

--- a/src/ids-progress-chart/ids-progress-chart.scss
+++ b/src/ids-progress-chart/ids-progress-chart.scss
@@ -11,6 +11,7 @@
   .labels {
     @include text-graphite-50();
 
+    font-size: 16px;
     display: inline-flex;
     flex-direction: row;
     position: relative;
@@ -30,17 +31,16 @@
       }
     }
 
-
     .label-progress {
       display: inline-flex;
       margin: 0 4px;
+
       &::part(text) {
         color: currentColor;
         font-family: inherit;
         font-size: inherit;
       }
     }
-
 
     .label-end {
       display: flex;
@@ -53,24 +53,23 @@
 
     .label-total {
       position: absolute;
+
       &::part(text) {
         color: currentColor;
         font-family: inherit;
         font-size: inherit;
       }
     }
-
   }
 
   .bar {
     border-radius: 2px;
+    min-height: 28px;
     min-width: 66px;
     display: flex;
     position: relative;
 
     .bar-total {
-      // @include bg-slate-30();
-
       border-radius: inherit;
       display: flex;
       top: 0;
@@ -78,10 +77,8 @@
       width: 100%;
       height: inherit;
     }
-    
+
     .bar-progress {
-      // @include bg-slate-60();
-      
       border-radius: inherit;
       display: flex;
       top: 0;
@@ -89,81 +86,61 @@
       height: inherit;
     }
   }
+}
 
-  
-  &[version='new'] {
-    ids-icon {
-      margin: 3px 4px 0 4px;
+.ids-progress-chart[version='new'] {
+  &[mode='light'] {
+    .bar {
+      .bar-total {
+        @include bg-slate-30();
+      }
+
+      .bar-progress {
+        @include bg-slate-60();
+      }
     }
 
     .labels {
-      font-size: 16px;
+      @include text-slate-60();
     }
+  }
 
+  &[mode='dark'] {
     .bar {
-      min-height: 28px;
+      .bar-total {
+        @include bg-slate-50();
+      }
+
+      .bar-progress {
+        @include bg-azure-60();
+      }
     }
 
-    &[mode='light'] {
-      .bar {
-        .bar-total {
-          @include bg-slate-30();
-        }
-  
-        .bar-progress {
-          @include bg-slate-60();
-        }
-      }
-      .labels {
-        @include text-slate-60();
-      }
+    .labels {
+      @include text-slate-30();
     }
-  
-    &[mode='dark'] {
-      .bar {
-        .bar-total {
-          @include bg-slate-50();
-        }
-  
-        .bar-progress {
-          @include bg-azure-60();
-        }
-      }
-      .labels {
-        @include text-slate-30();
-      }
-    }
-  
-    &[mode='contrast'] {
-      .bar {
-        .bar-total {
-          @include bg-slate-40();
-        }
-  
-        .bar-progress {
-          @include bg-azure-90();
-        }
-      }
-      .labels {
-        @include text-slate-90();
-      }
-    }
-  } 
+  }
 
+  &[mode='contrast'] {
+    .bar {
+      .bar-total {
+        @include bg-slate-40();
+      }
+
+      .bar-progress {
+        @include bg-azure-90();
+      }
+    }
+
+    .labels {
+      @include text-slate-90();
+    }
+  }
 }
 
 .ids-progress-chart[version='classic'] {
   ids-icon {
-    margin: 0px;
-  }
-
-  .labels {
-    font-family: helvetica;
-    font-size: 12px;
-  }
-
-  .bar {
-    min-height: 26px;
+    margin: 0;
   }
 
   &[mode='light'] {
@@ -176,6 +153,7 @@
         background-color: #5c5c5c;
       }
     }
+
     .labels {
       color: #5c5c5c;
     }
@@ -188,9 +166,10 @@
       }
 
       .bar-progress {
-        background-color: #368ac0
+        background-color: #368ac0;
       }
     }
+
     .labels {
       color: #abaeb7;
     }
@@ -206,8 +185,9 @@
         background-color: #383838;
       }
     }
+
     .labels {
-      color: #383838
+      color: #383838;
     }
   }
 }

--- a/src/ids-progress-chart/ids-progress-chart.scss
+++ b/src/ids-progress-chart/ids-progress-chart.scss
@@ -9,9 +9,6 @@
   margin: 0 0 8px 0;
 
   .labels {
-    // @include text-slate-60();
-    font-family: helvetica, arial, sans-serif;
-    font-size: 12px;
     @include text-graphite-50();
 
     display: inline-flex;
@@ -25,20 +22,25 @@
     .label-main {
       display: inline-flex;
       margin: 0 4px 0 0;
+
+      &::part(text) {
+        color: currentColor;
+        font-family: inherit;
+        font-size: inherit;
+      }
     }
 
-    .label-main::part(text) {
-      color: currentColor;
-    }
 
     .label-progress {
       display: inline-flex;
       margin: 0 4px;
+      &::part(text) {
+        color: currentColor;
+        font-family: inherit;
+        font-size: inherit;
+      }
     }
 
-    .label-progress::part(text) {
-      color: currentColor;
-    }
 
     .label-end {
       display: flex;
@@ -51,16 +53,17 @@
 
     .label-total {
       position: absolute;
+      &::part(text) {
+        color: currentColor;
+        font-family: inherit;
+        font-size: inherit;
+      }
     }
 
-    .label-total::part(text) {
-      color: currentColor;
-    }
   }
 
   .bar {
     border-radius: 2px;
-    min-height: 28px;
     min-width: 66px;
     display: flex;
     position: relative;
@@ -87,64 +90,124 @@
     }
   }
 
-  ::slotted(ids-icon) {
-    margin: 3px 4px 0 4px;
+  
+  &[version='new'] {
+    ids-icon {
+      margin: 3px 4px 0 4px;
+    }
+
+    .labels {
+      font-size: 16px;
+    }
+
+    .bar {
+      min-height: 28px;
+    }
+
+    &[mode='light'] {
+      .bar {
+        .bar-total {
+          @include bg-slate-30();
+        }
+  
+        .bar-progress {
+          @include bg-slate-60();
+        }
+      }
+      .labels {
+        @include text-slate-60();
+      }
+    }
+  
+    &[mode='dark'] {
+      .bar {
+        .bar-total {
+          @include bg-slate-50();
+        }
+  
+        .bar-progress {
+          @include bg-azure-60();
+        }
+      }
+      .labels {
+        @include text-slate-30();
+      }
+    }
+  
+    &[mode='contrast'] {
+      .bar {
+        .bar-total {
+          @include bg-slate-40();
+        }
+  
+        .bar-progress {
+          @include bg-azure-90();
+        }
+      }
+      .labels {
+        @include text-slate-90();
+      }
+    }
+  } 
+
+}
+
+.ids-progress-chart[version='classic'] {
+  ids-icon {
+    margin: 0px;
   }
 
+  .labels {
+    font-family: helvetica;
+    font-size: 12px;
+  }
+
+  .bar {
+    min-height: 26px;
+  }
 
   &[mode='light'] {
     .bar {
       .bar-total {
-        @include bg-slate-30();
+        background-color: #bdbdbd;
       }
 
       .bar-progress {
-        // @include bg-slate-60();
-        background-color: orange;
+        background-color: #5c5c5c;
       }
     }
     .labels {
-      @include text-slate-60();
+      color: #5c5c5c;
     }
   }
 
   &[mode='dark'] {
     .bar {
       .bar-total {
-        @include bg-slate-50();
+        background-color: #50535a;
       }
 
       .bar-progress {
-        @include bg-white();
-        // background-color: orange !important;
+        background-color: #368ac0
       }
     }
     .labels {
-      @include text-slate-30();
+      color: #abaeb7;
     }
   }
 
   &[mode='contrast'] {
     .bar {
       .bar-total {
-        @include bg-slate-40();
+        background-color: #737373;
       }
 
       .bar-progress {
-        @include bg-azure-90();
+        background-color: #383838;
       }
     }
     .labels {
-      @include text-slate-90();
+      color: #383838
     }
-  }
-
-}
-
-.ids-progress-chart[mode='light'][version='classic'] {
-  .labels {
-    font-family: helvetica;
-    font-size: 12px;
-    @include text-graphite-50();
   }
 }

--- a/src/ids-progress-chart/ids-progress-chart.scss
+++ b/src/ids-progress-chart/ids-progress-chart.scss
@@ -9,7 +9,10 @@
   margin: 0 0 8px 0;
 
   .labels {
-    @include text-slate-60();
+    // @include text-slate-60();
+    font-family: helvetica, arial, sans-serif;
+    font-size: 12px;
+    @include text-graphite-50();
 
     display: inline-flex;
     flex-direction: row;
@@ -63,25 +66,85 @@
     position: relative;
 
     .bar-total {
-      @include bg-slate-30();
+      // @include bg-slate-30();
 
+      border-radius: inherit;
       display: flex;
       top: 0;
       left: 0;
       width: 100%;
       height: inherit;
     }
-
+    
     .bar-progress {
+      // @include bg-slate-60();
+      
+      border-radius: inherit;
       display: flex;
       top: 0;
       left: 0;
       height: inherit;
-      background-color: #25af65;
     }
   }
 
   ::slotted(ids-icon) {
     margin: 3px 4px 0 4px;
+  }
+
+
+  &[mode='light'] {
+    .bar {
+      .bar-total {
+        @include bg-slate-30();
+      }
+
+      .bar-progress {
+        // @include bg-slate-60();
+        background-color: orange;
+      }
+    }
+    .labels {
+      @include text-slate-60();
+    }
+  }
+
+  &[mode='dark'] {
+    .bar {
+      .bar-total {
+        @include bg-slate-50();
+      }
+
+      .bar-progress {
+        @include bg-white();
+        // background-color: orange !important;
+      }
+    }
+    .labels {
+      @include text-slate-30();
+    }
+  }
+
+  &[mode='contrast'] {
+    .bar {
+      .bar-total {
+        @include bg-slate-40();
+      }
+
+      .bar-progress {
+        @include bg-azure-90();
+      }
+    }
+    .labels {
+      @include text-slate-90();
+    }
+  }
+
+}
+
+.ids-progress-chart[mode='light'][version='classic'] {
+  .labels {
+    font-family: helvetica;
+    font-size: 12px;
+    @include text-graphite-50();
   }
 }

--- a/test/ids-icon/ids-icon-func-test.js
+++ b/test/ids-icon/ids-icon-func-test.js
@@ -97,7 +97,7 @@ describe('IdsIcon Component', () => {
     document.body.appendChild(container);
     icon.language = 'ar';
     expect(icon.isFlipped('previous-page')).toBeTruthy();
-    expect(icon.template()).toContain('class="flipped"'); // Class list doesnt work on SVG?
+    expect(icon.template()).toContain('class="flipped"');
   });
 
   it('can change language from the container', () => {

--- a/test/ids-progress-chart/ids-progress-chart-func-test.js
+++ b/test/ids-progress-chart/ids-progress-chart-func-test.js
@@ -42,11 +42,25 @@ describe('IdsProgressChart Component', () => {
     expect(elem.outerHTML).toMatchSnapshot();
   });
 
-  it('sets color correctly', () => {
-    // empty input sets color to default (#25af65)
-    chart.color = '';
-    expect(chart.container.querySelector('.bar-progress').style.backgroundColor).toBe('rgb(37, 175, 101)');
+  it('sets icon correctly', () => {
+    const icon = chart.container.querySelector('.icon');
 
+    chart.icon = 'alert';
+    expect(chart.icon).toBe('alert');
+    expect(icon.getAttribute('icon')).toBe('alert');
+    expect(icon.style.display).toBe('')
+    
+    chart.size = 'small';
+    expect(icon.getAttribute('size')).toBe('small');
+
+    chart.icon = '';
+    expect(chart.icon).toBe('');
+    expect(icon.getAttribute('icon')).toBe('');
+    expect(icon.style.display).toBe('none')
+
+  });
+
+  it('sets color correctly', () => {
     chart.color = '#25af65';
     expect(chart.color).toBe('#25af65');
 
@@ -64,16 +78,6 @@ describe('IdsProgressChart Component', () => {
 
     chart.color = 'amethyst-50';
     expect(chart.color).toBe('amethyst-50');
-  });
-
-  it('adds icon and label', () => {
-    chart.color = 'error';
-    chart.progressLabel = '2%';
-    chart.totalLabel = '100%';
-    expect(chart.container.querySelector('.label-progress').innerHTML).toBe('2%');
-    expect(chart.container.querySelector('.label-total').innerHTML).toBe('100%');
-    chart.container.querySelector('slot').insertAdjacentHTML('beforeend', `<ids-icon slot="icon" size="small" icon="alert"></ids-icon>`);
-    expect(chart.container.querySelector('ids-icon').getAttribute('slot')).toBe('icon');
   });
 
   it('sets labels correctly', () => {
@@ -152,11 +156,11 @@ describe('IdsProgressChart Component', () => {
     chart.size = 'small';
     expect(chart.size).toBe('small');
 
-    // invalid inputs set attribute to default (large)
+    // invalid inputs set attribute to default (normal)
     chart.size = '';
-    expect(chart.size).toBe('large');
+    expect(chart.size).toBe('normal');
 
     chart.size = '25';
-    expect(chart.size).toBe('large');
+    expect(chart.size).toBe('normal');
   });
 });

--- a/test/ids-progress-chart/ids-progress-chart-func-test.js
+++ b/test/ids-progress-chart/ids-progress-chart-func-test.js
@@ -48,16 +48,15 @@ describe('IdsProgressChart Component', () => {
     chart.icon = 'alert';
     expect(chart.icon).toBe('alert');
     expect(icon.getAttribute('icon')).toBe('alert');
-    expect(icon.style.display).toBe('')
-    
+    expect(icon.style.display).toBe('');
+
     chart.size = 'small';
     expect(icon.getAttribute('size')).toBe('small');
 
     chart.icon = '';
     expect(chart.icon).toBe('');
     expect(icon.getAttribute('icon')).toBe('');
-    expect(icon.style.display).toBe('none')
-
+    expect(icon.style.display).toBe('none');
   });
 
   it('sets color correctly', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
- added colors for respective themes, class/new:light/dark/contrast
- refactored slots to ids-icon element which can be set by icon attribute
- adjust icon size based on chart size

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
- Closes #302 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- `npm run start:watch`
- http://localhost:4300/ids-progress-chart
- click through the themes
- can also set/change/remove icons through DOM functions

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
