### PR TITLE
Chore: Fix the about dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ demo-dist
 coverage
 test/**/diff
 tmp
+app
 
 # OS Setting Files
 .DS_Store

--- a/src/components/ids-about/ids-about.js
+++ b/src/components/ids-about/ids-about.js
@@ -15,7 +15,7 @@ import {
   IdsDeviceEnvUtils
 } from '../../utils';
 
-import { IdsLocaleMixin, IdsEventsMixin } from '../../mixins';
+import { IdsLocaleMixin } from '../../mixins';
 
 import styles from './ids-about.scss';
 
@@ -26,11 +26,10 @@ import styles from './ids-about.scss';
  * @part popup - the popup outer element
  * @part overlay - the inner overlay element
  * @mixes IdsLocaleMixin
- * @mixes IdsEventsMixin
  */
 @customElement('ids-about')
 @scss(styles)
-class IdsAbout extends mix(IdsModal).with(IdsEventsMixin, IdsLocaleMixin) {
+class IdsAbout extends mix(IdsModal).with(IdsLocaleMixin) {
   constructor() {
     super();
   }

--- a/src/mixins/ids-events-mixin/ids-events-mixin.js
+++ b/src/mixins/ids-events-mixin/ids-events-mixin.js
@@ -123,7 +123,8 @@ const IdsEventsMixin = (superclass) => class extends IdsRenderLoopMixin(supercla
    * @returns {boolean} true if the event works
    */
   triggerVetoableEvent(eventType) {
-    if (!this.vetoableEventTypes.includes(eventType)) {
+    if (this.vetoableEventTypes.length > 0
+      && !this.vetoableEventTypes.includes(eventType)) {
       return false;
     }
 

--- a/test/ids-about/ids-about-func-test.js.snap
+++ b/test/ids-about/ids-about-func-test.js.snap
@@ -14,7 +14,7 @@ exports[`IdsAbout Component (using properties) should render 1`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 2`] = `
-"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" language=\\"en\\" locale=\\"en-US\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\"><ids-text slot=\\"device\\" type=\\"p\\" language=\\"en\\" locale=\\"en-US\\"><span>Operating System :  -</span><br>
+"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" language=\\"en\\" locale=\\"en-US\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\"><ids-text slot=\\"device\\" type=\\"p\\" language=\\"en\\" locale=\\"en-US\\"><span>Operating System :  -</span><br>
         <span>Platform : </span><br>
         <span>Mobile : false</span><br>
         <span>Locale : en-US</span><br>
@@ -27,7 +27,7 @@ exports[`IdsAbout Component (using properties) should render 2`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 3`] = `
-"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" language=\\"en\\" locale=\\"en-US\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\"><ids-text slot=\\"device\\" type=\\"p\\" language=\\"en\\" locale=\\"en-US\\"><span>Operating System :  -</span><br>
+"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" language=\\"en\\" locale=\\"en-US\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\" style=\\"z-index: 1020;\\"><ids-text slot=\\"device\\" type=\\"p\\" language=\\"en\\" locale=\\"en-US\\"><span>Operating System :  -</span><br>
         <span>Platform : </span><br>
         <span>Mobile : false</span><br>
         <span>Locale : en-US</span><br>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Some recent merges broke the about dialog from opening. The problem was that IdsEventsMixin was added in the about component even tho its already added in IdsModal. This blew away the vetoable events array.

In addition added a check on empty array in the case we want something thats non-vetoable. And added an ignore as the app folder keeps coming back

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-about
- click open and it should open
- check coverage dips (on ci)
- check tests/percy (on ci)
