### PR TITLE
398: Device Specs Util: Update from deprecated API

### DIFF
--- a/src/utils/ids-device-env-specs-utils/ids-device-env-specs-utils.js
+++ b/src/utils/ids-device-env-specs-utils/ids-device-env-specs-utils.js
@@ -11,11 +11,12 @@ export function getSpecs() {
   let browser = navigator.appName;
   let appVersion = ` ${parseFloat(navigator.appVersion)}`;
   const majorVersion = parseInt(navigator.appVersion, 10);
+  const platform = navigator.userAgentData?.platform;
   let nameOffset;
   let verOffset;
   let ix;
   const isIPad = () => !!(navigator.userAgent.match(/(iPad)/)
-    || (navigator.platform === 'MacIntel' && typeof navigator.standalone !== 'undefined'));
+    || (platform === 'macOS' && typeof navigator.standalone !== 'undefined'));
   const browserLanguage = navigator.appName === 'Microsoft Internet Explorer'
     ? navigator.userLanguage
     : navigator.language;
@@ -147,7 +148,7 @@ export function getSpecs() {
     os,
     currentOSVersion: osVersion,
     idsVersion: packageJson.version,
-    platform: navigator.platform,
+    platform,
     browserLanguage
   };
 }

--- a/test/core/ids-device-env-specs-utils-func-test.js
+++ b/test/core/ids-device-env-specs-utils-func-test.js
@@ -6,6 +6,12 @@ import { IdsDeviceEnvUtils } from '../../src/utils';
 describe('IdsDeviceEnvUtils Tests', () => {
   let specs;
 
+  beforeAll(() => {
+    Object.defineProperty(window.navigator, 'userAgentData', {
+      value: { platform: 'macOS' },
+    });
+  });
+
   beforeEach(async () => {
     specs = IdsDeviceEnvUtils.getSpecs();
   });
@@ -33,13 +39,13 @@ describe('IdsDeviceEnvUtils Tests', () => {
 
   it('should detect browser and device specs', () => {
     const userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
-    const platformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+    const platformGetterDeprecated = jest.spyOn(window.navigator, 'platform', 'get');
     const appVersionGetter = jest.spyOn(window.navigator, 'appVersion', 'get');
     const appNameGetter = jest.spyOn(window.navigator, 'appName', 'get');
 
     userAgentGetter.mockReturnValue('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36');
     appVersionGetter.mockReturnValue('5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36');
-    platformGetter.mockReturnValue('MacIntel');
+    platformGetterDeprecated.mockReturnValue('MacIntel');
 
     specs = IdsDeviceEnvUtils.getSpecs();
 
@@ -48,14 +54,13 @@ describe('IdsDeviceEnvUtils Tests', () => {
     expect(specs.browserMajorVersion).toEqual('5');
     expect(specs.isMobile).toBeFalsy();
     expect(specs.os).toEqual('Mac OS X');
-    expect(specs.platform).toEqual('MacIntel');
+    expect(specs.platform).toEqual('macOS');
     expect(specs.currentOSVersion).toEqual('10.15.7');
     expect(specs.cookiesEnabled).toBeTruthy();
     expect(specs.browserLanguage).toEqual('en-US');
 
     userAgentGetter.mockReturnValue('Mozilla/5.0 iPad OS 10 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15');
     appVersionGetter.mockReturnValue('5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15');
-    platformGetter.mockReturnValue('MacIntel');
 
     specs = IdsDeviceEnvUtils.getSpecs();
 
@@ -64,7 +69,7 @@ describe('IdsDeviceEnvUtils Tests', () => {
     expect(specs.browserMajorVersion).toEqual('5');
     expect(specs.isMobile).toBeTruthy();
     expect(specs.os).toEqual('IOS');
-    expect(specs.platform).toEqual('MacIntel');
+    expect(specs.platform).toEqual('macOS');
     expect(specs.currentOSVersion).toEqual('14.1');
     expect(specs.cookiesEnabled).toBeTruthy();
     expect(specs.browserLanguage).toEqual('en-US');
@@ -133,5 +138,6 @@ describe('IdsDeviceEnvUtils Tests', () => {
     specs = IdsDeviceEnvUtils.getSpecs();
 
     expect(specs.browserLanguage).toBe(undefined);
+    expect(platformGetterDeprecated).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
This PR replaces the deprecated `navigator.platform` with `navigator.userAgentData.platform`.  However, see https://github.com/infor-design/enterprise-wc/issues/398#issuecomment-956476324 on the issue-ticket as to why this change may be insufficient.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes https://github.com/infor-design/enterprise-wc/issues/398

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Go to http://localhost:4300/ids-about
- Try in mac/ff/chrome

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
