### PR TITLE
345 - IdsTabs Improvements

### DIFF
--- a/demos/ids-tabs/example.html
+++ b/demos/ids-tabs/example.html
@@ -7,7 +7,7 @@
     <ids-tab value="contracts">Contracts</ids-tab>
     <ids-tab value="opportunities">Opportunities</ids-tab>
     <ids-tab value="attachments">Attachments</ids-tab>
-    <ids-tab value="notes">Notes</ids-tab>
+    <ids-tab value="notes" selected>Notes</ids-tab>
   </ids-tabs>
   <div class="ids-tabs-content">
     <ids-tab-content value="contracts">

--- a/demos/ids-tabs/example.html
+++ b/demos/ids-tabs/example.html
@@ -7,7 +7,7 @@
     <ids-tab value="contracts">Contracts</ids-tab>
     <ids-tab value="opportunities">Opportunities</ids-tab>
     <ids-tab value="attachments">Attachments</ids-tab>
-    <ids-tab value="notes" selected>Notes</ids-tab>
+    <ids-tab value="notes">Notes</ids-tab>
   </ids-tabs>
   <div class="ids-tabs-content">
     <ids-tab-content value="contracts">

--- a/demos/ids-tabs/header-tabs.html
+++ b/demos/ids-tabs/header-tabs.html
@@ -42,7 +42,7 @@
         <ids-tabs value="b">
           <ids-tab value="a">A</ids-tab>
           <ids-tab value="b">B</ids-tab>
-          <ids-tab value="c" selected>C</ids-tab>
+          <ids-tab value="c">C</ids-tab>
           <ids-tab value="d">D</ids-tab>
         </ids-tabs>
         <div class="ids-tabs-content">

--- a/demos/ids-tabs/header-tabs.html
+++ b/demos/ids-tabs/header-tabs.html
@@ -44,7 +44,7 @@
         <ids-tabs value="b">
           <ids-tab value="a">A</ids-tab>
           <ids-tab value="b">B</ids-tab>
-          <ids-tab value="c">C</ids-tab>
+          <ids-tab value="c" selected>C</ids-tab>
           <ids-tab value="d">D</ids-tab>
         </ids-tabs>
         <div class="ids-tabs-content">

--- a/demos/ids-tabs/header-tabs.html
+++ b/demos/ids-tabs/header-tabs.html
@@ -37,9 +37,7 @@
       </div>
     </ids-tab-content>
     <ids-tab-content value="attachments">
-      <ids-text type="h2">attachments</ids-text>
-    </ids-tab-content>
-    <ids-tab-content value="attachments">
+      <ids-text type="h2" font-size="20" font-weight="bold">Attachments</ids-text>
       <ids-tabs-context>
         <ids-tabs value="b">
           <ids-tab value="a">A</ids-tab>

--- a/demos/ids-tabs/header-tabs.html
+++ b/demos/ids-tabs/header-tabs.html
@@ -1,4 +1,5 @@
 {{> ../layouts/head-no-padding.html }}
+
 <ids-text font-size="12" type="h1" audible="true">Ids Tabs (Header Tabs)</ids-text>
 <ids-tabs-context>
   <ids-header>
@@ -36,6 +37,9 @@
       </div>
     </ids-tab-content>
     <ids-tab-content value="attachments">
+      <ids-text type="h2">attachments</ids-text>
+    </ids-tab-content>
+    <ids-tab-content value="attachments">
       <ids-tabs-context>
         <ids-tabs value="b">
           <ids-tab value="a">A</ids-tab>
@@ -69,12 +73,6 @@
         </div>
       </ids-tabs-context>
     </ids-tab-content>
-    <ids-tab-content value="attachments">
-      <pre>=====================</pre>
-    </ids-tab-content>
-    <ids-tab-content value="attachments">
-      Additional Attachments Here
-    </ids-tab-content>
     <ids-tab-content value="notes">
       <ids-text font-size="18">
         If debugging is the process of removing bugs, then programming must be the process of
@@ -83,3 +81,5 @@
     </ids-tab-content>
   </div>
 </ids-tabs-context>
+
+{{> ../layouts/footer.html }}

--- a/demos/layouts/head-no-padding.html
+++ b/demos/layouts/head-no-padding.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{{ htmlWebpackPlugin.options.title }}</title>
-  <meta http-equiv="Content-Security-Policy"
-  content="
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="
     script-src 'self';
     style-src 'self' https://fonts.googleapis.com 'nonce-0a59a005';
     font-src 'self' data: https://fonts.gstatic.com;
-  "/>
+  ">
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&amp;display=swap" rel="stylesheet" />
+  <title>{{ htmlWebpackPlugin.options.title }}</title>
 </head>
 <body>
   <ids-container role="main" hidden>

--- a/src/components/ids-tabs/TODO.md
+++ b/src/components/ids-tabs/TODO.md
@@ -4,12 +4,10 @@
 
 Tentative for Phase 1 but certain things e.g. overflows may need to  get done in Phase 2 since they are not directly functional depending on time.
 
-- [] hashes
 - [] ids-tab-divider: accessibility + axe tests
 - [] detect overflows
 - [] edge case: when user removes an option (either via through React/Angular template or JS) that was selected, provide warning
 - [] test: for keyboard events
 - [] test: figure out how to get coveralls + Jest to detect certain parts of code
 - [] test: figure out why ids-tab.selected = false doesn't trigger in Jest
-- fix an issue with double firing of change
-- some JSDoc
+- [x] fix an issue with double firing of change

--- a/src/components/ids-tabs/ids-tab-content.js
+++ b/src/components/ids-tabs/ids-tab-content.js
@@ -37,19 +37,15 @@ class IdsTabContent extends mix(IdsElement).with(
 
   /** @returns {Array} The attributes we handle as getters/setters */
   static get attributes() {
-    return [attributes.VALUE, attributes.ACTIVE];
+    return [
+      ...super.attributes,
+      attributes.VALUE,
+      attributes.ACTIVE
+    ];
   }
 
   template() {
     return `<slot></slot>`;
-  }
-
-  connectedCallback() {
-    super.connectedCallback?.();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback?.();
   }
 
   /** @type {string} Value representing associated tab */

--- a/src/components/ids-tabs/ids-tab.js
+++ b/src/components/ids-tabs/ids-tab.js
@@ -9,7 +9,8 @@ import {
 // Import Mixins
 import {
   IdsColorVariantMixin,
-  IdsEventsMixin
+  IdsEventsMixin,
+  IdsOrientationMixin,
 } from '../../mixins';
 
 // Import Dependencies
@@ -33,7 +34,7 @@ const { stringToBool, buildClassAttrib } = stringUtils;
  */
 @customElement('ids-tab')
 @scss(styles)
-class IdsTab extends mix(IdsElement).with(IdsColorVariantMixin, IdsEventsMixin) {
+class IdsTab extends mix(IdsElement).with(IdsColorVariantMixin, IdsEventsMixin, IdsOrientationMixin) {
   /** store the previous "selected" value to prevent double firing events */
   #prevSelected = false;
 
@@ -49,7 +50,6 @@ class IdsTab extends mix(IdsElement).with(IdsColorVariantMixin, IdsEventsMixin) 
     return [
       ...super.attributes,
       attributes.COUNT,
-      attributes.ORIENTATION,
       attributes.SELECTED,
       attributes.VALUE
     ];
@@ -226,28 +226,6 @@ class IdsTab extends mix(IdsElement).with(IdsColorVariantMixin, IdsEventsMixin) 
     if (this.getAttribute(attributes.COUNT) !== value) {
       this.setAttribute(attributes.COUNT, value);
     }
-  }
-
-  /** @param {'horizontal' | 'vertical'} value The direction which tabs will be laid out in */
-  set orientation(value) {
-    switch (value) {
-    case 'vertical': {
-      this.setAttribute(attributes.ORIENTATION, 'vertical');
-      this.container.classList.add('vertical');
-      break;
-    }
-    case 'horizontal':
-    default: {
-      this.setAttribute(attributes.ORIENTATION, 'horizontal');
-      this.container.classList.remove('vertical');
-      break;
-    }
-    }
-  }
-
-  /** @returns {'horizontal' | 'vertical'} value The direction which tabs will be laid out in. */
-  get orientation() {
-    return this.getAttribute(attributes.ORIENTATION);
   }
 
   /**

--- a/src/components/ids-tabs/ids-tab.js
+++ b/src/components/ids-tabs/ids-tab.js
@@ -7,7 +7,10 @@ import {
 } from '../../core/ids-element';
 
 // Import Mixins
-import { IdsEventsMixin } from '../../mixins';
+import {
+  IdsColorVariantMixin,
+  IdsEventsMixin
+} from '../../mixins';
 
 // Import Dependencies
 import IdsText from '../ids-text';
@@ -30,7 +33,7 @@ const { stringToBool, buildClassAttrib } = stringUtils;
  */
 @customElement('ids-tab')
 @scss(styles)
-class IdsTab extends mix(IdsElement).with(IdsEventsMixin) {
+class IdsTab extends mix(IdsElement).with(IdsColorVariantMixin, IdsEventsMixin) {
   /** store the previous "selected" value to prevent double firing events */
   #prevSelected = false;
 
@@ -40,17 +43,23 @@ class IdsTab extends mix(IdsElement).with(IdsEventsMixin) {
 
   /**
    * Return the attributes we handle as getters/setters
-   * @returns {Array} The attributes in an array
+   * @returns {Array<string>} The attributes in an array
    */
   static get attributes() {
     return [
-      attributes.COLOR_VARIANT,
+      ...super.attributes,
       attributes.COUNT,
       attributes.ORIENTATION,
       attributes.SELECTED,
       attributes.VALUE
     ];
   }
+
+  /**
+   * Inherited from `IdsColorVariantMixin`
+   * @returns {Array<string>} List of available color variants for this component
+   */
+  colorVariants = ['alternate'];
 
   /**
    * Create the Template for the contents
@@ -172,35 +181,6 @@ class IdsTab extends mix(IdsElement).with(IdsEventsMixin) {
    */
   get selected() {
     return this.hasAttribute(attributes.SELECTED);
-  }
-
-  /**
-   * @param {'alternate'|undefined} variant A value which represents a currently
-   * selected tab; at any time, should match one of the child ids-tab `value`
-   * attributes set for a valid selection.
-   */
-  set colorVariant(variant) {
-    switch (variant) {
-    case 'alternate': {
-      this.setAttribute(attributes.COLOR_VARIANT, 'alternate');
-      this.container.classList.add('color-variant-alternate');
-      break;
-    }
-    default: {
-      this.removeAttribute(attributes.COLOR_VARIANT);
-      this.container.classList.remove('color-variant-alternate');
-      break;
-    }
-    }
-  }
-
-  /**
-   * @returns {'alternate'|undefined} A value which represents a currently
-   * selected tab; at any time, should match one of the child ids-tab `value`
-   * attributes set for a valid selection.
-   */
-  get colorVariant() {
-    return this.getAttribute(attributes.COLOR_VARIANT);
   }
 
   /** @param {string} value The value which becomes selected by ids-tabs component */

--- a/src/components/ids-tabs/ids-tab.js
+++ b/src/components/ids-tabs/ids-tab.js
@@ -129,6 +129,8 @@ class IdsTab extends mix(IdsElement).with(IdsColorVariantMixin, IdsEventsMixin, 
   }
 
   connectedCallback() {
+    super.connectedCallback?.();
+
     this.#prevSelected = false;
     this.setAttribute('role', 'tab');
     this.setAttribute('aria-selected', `${Boolean(this.selected)}`);
@@ -136,6 +138,10 @@ class IdsTab extends mix(IdsElement).with(IdsColorVariantMixin, IdsEventsMixin, 
     this.setAttribute('aria-label', this.#getReadableAriaLabel());
     this.selected = this.hasAttribute(attributes.SELECTED);
 
+    this.#attachEventHandlers();
+  }
+
+  #attachEventHandlers() {
     this.onEvent('click', this, () => {
       if (!this.hasAttribute(attributes.SELECTED)) {
         this.setAttribute(attributes.SELECTED, '');

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -50,7 +50,7 @@
     @include border-white();
   }
 
-  &.selected.vertical:focus::before {
+  &.selected.orientation-vertical:focus::before {
     position: absolute;
     top: 1px;
     left: 1px;
@@ -98,11 +98,11 @@
     }
   }
 
-  &:not(.vertical):not(.count) {
+  &:not(.orientation-vertical):not(.count) {
     @include pt-8;
   }
 
-  &:not(.vertical) {
+  &:not(.orientation-vertical) {
     @include rounded-default();
     @include pb-8();
 
@@ -111,7 +111,7 @@
     border-bottom-right-radius: 0;
   }
 
-  &.vertical {
+  &.orientation-vertical {
     @include pl-24();
 
     display: flex;
@@ -143,11 +143,11 @@
     @include font-bold();
   }
 
-  &:not(.vertical)::after,
+  &:not(.orientation-vertical)::after,
   /* cannot read css var for color in :after
    * without shadowDOM scope so need .selection-underline div
    * as workaround */
-  &:not(.vertical) .selection-underline {
+  &:not(.orientation-vertical) .selection-underline {
     position: absolute;
     bottom: 0;
     height: 3px;
@@ -158,13 +158,13 @@
     content: '';
   }
 
-  &:not(.vertical):not(.color-variant-alternate)::after,
-  &:not(.vertical):not(.color-variant-alternate) .selection-underline {
+  &:not(.orientation-vertical):not(.color-variant-alternate)::after,
+  &:not(.orientation-vertical):not(.color-variant-alternate) .selection-underline {
     @include bg-azure-60();
   }
 
-  &.color-variant-alternate:not(.vertical)::after,
-  &.color-variant-alternate:not(.vertical) .selection-underline {
+  &.color-variant-alternate:not(.orientation-vertical)::after,
+  &.color-variant-alternate:not(.orientation-vertical) .selection-underline {
     @include bg-white();
   }
 }

--- a/src/components/ids-tabs/ids-tabs-context.js
+++ b/src/components/ids-tabs/ids-tabs-context.js
@@ -7,30 +7,11 @@ import {
 } from '../../core';
 
 import {
-  IdsAttributeProviderMixin,
   IdsEventsMixin
 } from '../../mixins';
 
 import IdsTabContent from './ids-tab-content';
 import styles from './ids-tabs.scss';
-
-/**
- * list of entries for attributes provided by
- * the ids-tabs-context and how they map,
- * as well as which are listened on for updates
- * in the children
- */
-const attributeProviderDefs = {
-  attributesProvided: [{
-    attribute: attributes.VALUE,
-    component: IdsTabContent,
-    targetAttribute: attributes.ACTIVE,
-    valueTransformer: ({ value, element }) => element.getAttribute(attributes.VALUE) === value
-  }],
-  attributesListenedFor: [],
-  exitTags: ['IDS-TABS', 'IDS-TAB-CONTENT', 'IDS-TABS-CONTEXT'],
-  maxDepth: 8
-};
 
 /**
  * IDS Tabs Context Component
@@ -44,8 +25,7 @@ const attributeProviderDefs = {
 @customElement('ids-tabs-context')
 @scss(styles)
 class IdsTabsContext extends mix(IdsElement).with(
-    IdsEventsMixin,
-    IdsAttributeProviderMixin(attributeProviderDefs)
+    IdsEventsMixin
   ) {
   constructor() {
     super();
@@ -68,25 +48,34 @@ class IdsTabsContext extends mix(IdsElement).with(
 
     this.onEvent('tabselect', this, (e) => {
       e.stopPropagation();
-      if (this.getAttribute(attributes.VALUE) !== e.target.value) {
-        this.setAttribute(attributes.VALUE, e.target.value);
-      }
+      this.value = e.target.value;
     });
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback?.();
   }
 
   /** @param {string} value The value representing a currently selected tab */
   set value(value) {
-    if (this.getAttribute(attributes.VALUE) !== value) {
+    const currentValue = this.getAttribute(attributes.VALUE);
+    if (currentValue !== value) {
       this.setAttribute(attributes.VALUE, value);
+      this.#changeContentPane(currentValue, value);
     }
   }
 
   get value() {
     return this.getAttribute(attributes.VALUE);
+  }
+
+  /**
+   * Switches the "Active" content pane associated with this Tabs Context
+   * @param {string} currentValue the value of the current pane, used to make it inactive
+   * @param {string} newValue the value of the new pane, used to make it active
+   */
+  #changeContentPane(currentValue, newValue) {
+    const contentPanes = [...this.querySelectorAll('ids-tab-content')];
+    const currentPane = contentPanes.find((el) => el.value === currentValue);
+    const targetPane = contentPanes.find((el) => el.value === newValue);
+    if (currentPane) currentPane.active = false;
+    if (targetPane) targetPane.active = true;
   }
 }
 

--- a/src/components/ids-tabs/ids-tabs.d.ts
+++ b/src/components/ids-tabs/ids-tabs.d.ts
@@ -8,7 +8,7 @@ export default class IdsTabs extends IdsElement {
   colorVariant? : 'alternate';
 
   /** The direction the tabs will be laid out in; defaults to `horizontal`. */
-   orientation? : 'horizontal' | 'vertical';
+  orientation? : 'horizontal' | 'vertical';
 
   /**
    * A value which represents a currently selected tab; at any time,

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -272,11 +272,19 @@ class IdsTabs extends mix(IdsElement).with(
       this.children[this.children.length - 1].focus();
     });
 
-    this.listen('Enter', this, () => {
+    this.listen('Enter', this, (e) => {
+      const tab = e.target.closest('ids-tab');
+      if (tab) {
+        this.value = tab.value;
+      }
+
+
+      /*
       const focusedTabIndex = this.getFocusedTabIndex();
       if (focusedTabIndex >= 0 && focusedTabIndex < this.children.length) {
         this.setAttribute(attributes.VALUE, this.getTabIndexValue(focusedTabIndex));
       }
+      */
     });
   }
 

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -84,7 +84,7 @@ class IdsTabs extends mix(IdsElement).with(
     this.setAttribute('role', 'tablist');
 
     if (!this.hasAttribute(attributes.COLOR_VARIANT)) {
-      this.#checkAndSetColorVariant();
+      this.#adjustColorVariant();
     }
 
     this.onEvent('tabselect', this, (e) => {
@@ -146,10 +146,10 @@ class IdsTabs extends mix(IdsElement).with(
   #tabValueSet = new Set();
 
   /**
-   * checks if we are in a header tab and adjusts color-variant
-   * accordingly
+   * Traverses parent nodes and scans for parent IdsHeader components.
+   * If an IdsHeader is found, adjusts this component's ColorVariant accordingly.
    */
-  #checkAndSetColorVariant() {
+  #adjustColorVariant() {
     let isHeaderDescendent = false;
     let currentElement = this.host || this.parentNode;
 

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -71,22 +71,29 @@ class IdsTabs extends mix(IdsElement).with(
     this.setAttribute('role', 'tablist');
 
     this.#detectParentColorVariant();
-    this.#refreshSelectionState();
+    this.#refreshSelectionState(null, this.getAttribute('value'));
     this.#attachEventHandlers();
   }
+
+  #value = '';
 
   /**
    * @param {string} value A value which represents a currently selected tab
    */
   set value(value) {
-    const currentValue = this.value;
-    if (currentValue !== value) {
+    const currentValue = this.#value;
+    const isValidValue = this.hasTab(value);
+
+    if (isValidValue && currentValue !== value) {
+      this.#value = value;
       this.setAttribute(attributes.VALUE, value);
       this.#refreshSelectionState(currentValue, value);
       this.triggerEvent('change', this, {
         bubbles: false,
         detail: { elem: this, value }
       });
+    } else {
+      this.setAttribute(attributes.VALUE, this.value);
     }
   }
 
@@ -94,7 +101,16 @@ class IdsTabs extends mix(IdsElement).with(
    * @returns {string} The value representing a currently selected tab
    */
   get value() {
-    return this.getAttribute(attributes.VALUE);
+    return this.#value;
+  }
+
+  /**
+   * Reference to the currently-selected tab, if applicable
+   * @param {string} value the tab value to scan
+   * @returns {boolean} true if this tab list contains a tab with the provided value
+   */
+  hasTab(value) {
+    return this.querySelector(`ids-tab[value="${value}"]`) !== null;
   }
 
   /**

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -10,6 +10,7 @@ import {
   IdsKeyboardMixin,
   IdsEventsMixin,
   IdsThemeMixin,
+  IdsColorVariantMixin,
   IdsAttributeProviderMixin
 } from '../../mixins';
 
@@ -42,6 +43,7 @@ const attributeProviderDefs = {
 @scss(styles)
 class IdsTabs extends mix(IdsElement).with(
     IdsAttributeProviderMixin(attributeProviderDefs),
+    IdsColorVariantMixin,
     IdsEventsMixin,
     IdsKeyboardMixin,
     IdsThemeMixin
@@ -56,11 +58,17 @@ class IdsTabs extends mix(IdsElement).with(
    */
   static get attributes() {
     return [
-      attributes.COLOR_VARIANT,
+      ...super.attributes,
       attributes.ORIENTATION,
       attributes.VALUE
     ];
   }
+
+  /**
+   * Inherited from `IdsColorVariantMixin`
+   * @returns {Array<string>} List of available color variants for this component
+   */
+  colorVariants = ['alternate'];
 
   template() {
     return '<slot></slot>';
@@ -82,10 +90,6 @@ class IdsTabs extends mix(IdsElement).with(
 
     // set initial selection state
     this.#updateSelectionState();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback?.();
   }
 
   /**
@@ -340,31 +344,6 @@ class IdsTabs extends mix(IdsElement).with(
         this.triggerEvent('tabselect', this.children[0], { bubbles: true });
       });
     }
-  }
-
-  /**
-   * @param {'alternate'|undefined} variant A theming variant to the ids-tabs which
-   * also applies to each ids-tab
-   */
-  set colorVariant(variant) {
-    switch (variant) {
-    case 'alternate': {
-      this.setAttribute(attributes.COLOR_VARIANT, 'alternate');
-      break;
-    }
-    default: {
-      this.removeAttribute(attributes.COLOR_VARIANT);
-      break;
-    }
-    }
-  }
-
-  /**
-   * @returns {'alternate'|undefined} A theming variant for the ids-tabs which also
-   * applies to each ids-tab
-   */
-  get colorVariant() {
-    return this.getAttribute(attributes.COLOR_VARIANT);
   }
 }
 

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -11,6 +11,7 @@ import {
   IdsEventsMixin,
   IdsThemeMixin,
   IdsColorVariantMixin,
+  IdsOrientationMixin,
   IdsAttributeProviderMixin
 } from '../../mixins';
 
@@ -27,6 +28,10 @@ import styles from './ids-tabs.scss';
 const attributeProviderDefs = {
   attributesProvided: [{
     attribute: attributes.COLOR_VARIANT,
+    component: IdsTab
+  },
+  {
+    attribute: attributes.ORIENTATION,
     component: IdsTab
   }]
 };
@@ -46,6 +51,7 @@ class IdsTabs extends mix(IdsElement).with(
     IdsColorVariantMixin,
     IdsEventsMixin,
     IdsKeyboardMixin,
+    IdsOrientationMixin,
     IdsThemeMixin
   ) {
   constructor() {
@@ -59,7 +65,6 @@ class IdsTabs extends mix(IdsElement).with(
   static get attributes() {
     return [
       ...super.attributes,
-      attributes.ORIENTATION,
       attributes.VALUE
     ];
   }
@@ -98,41 +103,6 @@ class IdsTabs extends mix(IdsElement).with(
    */
   rendered() {
     this.#updateCallbacks();
-  }
-
-  /**
-   * @param {'horizontal' | 'vertical'} value The direction the tabs will be laid out in.
-   */
-  set orientation(value) {
-    const currentValue = this.orientation;
-    if (currentValue !== value) {
-      switch (value) {
-      case 'vertical': {
-        this.setAttribute(attributes.ORIENTATION, 'vertical');
-
-        for (let i = 0; i < this.children.length; i++) {
-          this.children[i].setAttribute('orientation', 'vertical');
-        }
-        break;
-      }
-      case 'horizontal':
-      default: {
-        this.setAttribute(attributes.ORIENTATION, 'horizontal');
-
-        for (let i = 0; i < this.children.length; i++) {
-          this.children[i].setAttribute('orientation', 'horizontal');
-        }
-        break;
-      }
-      }
-    }
-  }
-
-  /**
-   * @returns {string} The direction the tabs will be laid out in.
-   */
-  get orientation() {
-    return this.getAttribute(attributes.ORIENTATION);
   }
 
   /**

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -100,24 +100,27 @@ class IdsTabs extends mix(IdsElement).with(
    * @param {'horizontal' | 'vertical'} value The direction the tabs will be laid out in.
    */
   set orientation(value) {
-    switch (value) {
-    case 'vertical': {
-      this.setAttribute(attributes.ORIENTATION, 'vertical');
+    const currentValue = this.orientation;
+    if (currentValue !== value) {
+      switch (value) {
+      case 'vertical': {
+        this.setAttribute(attributes.ORIENTATION, 'vertical');
 
-      for (let i = 0; i < this.children.length; i++) {
-        this.children[i].setAttribute('orientation', 'vertical');
+        for (let i = 0; i < this.children.length; i++) {
+          this.children[i].setAttribute('orientation', 'vertical');
+        }
+        break;
       }
-      break;
-    }
-    case 'horizontal':
-    default: {
-      this.setAttribute(attributes.ORIENTATION, 'horizontal');
+      case 'horizontal':
+      default: {
+        this.setAttribute(attributes.ORIENTATION, 'horizontal');
 
-      for (let i = 0; i < this.children.length; i++) {
-        this.children[i].setAttribute('orientation', 'horizontal');
+        for (let i = 0; i < this.children.length; i++) {
+          this.children[i].setAttribute('orientation', 'horizontal');
+        }
+        break;
       }
-      break;
-    }
+      }
     }
   }
 
@@ -132,16 +135,15 @@ class IdsTabs extends mix(IdsElement).with(
    * @param {string} value A value which represents a currently selected tab
    */
   set value(value) {
-    if (this.getAttribute(attributes.VALUE) !== value) {
+    const currentValue = this.value;
+    if (currentValue !== value) {
       this.setAttribute(attributes.VALUE, value);
+      this.#updateSelectionState();
+      this.triggerEvent('change', this, {
+        bubbles: false,
+        detail: { elem: this, value }
+      });
     }
-
-    this.#updateSelectionState();
-
-    this.triggerEvent('change', this, {
-      bubbles: false,
-      detail: { elem: this, value }
-    });
   }
 
   /**
@@ -202,7 +204,7 @@ class IdsTabs extends mix(IdsElement).with(
     }
 
     if (isHeaderDescendent) {
-      this.setAttribute(attributes.COLOR_VARIANT, 'alternate');
+      this.colorVariant = 'alternate';
     }
   }
 

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -11,30 +11,12 @@ import {
   IdsEventsMixin,
   IdsThemeMixin,
   IdsColorVariantMixin,
-  IdsOrientationMixin,
-  IdsAttributeProviderMixin
+  IdsOrientationMixin
 } from '../../mixins';
 
 import IdsHeader from '../ids-header';
 import IdsTab from './ids-tab';
 import styles from './ids-tabs.scss';
-
-/**
- * list of entries for attributes provided by
- * the ids-tabs-context and how they map,
- * as well as which are listened on for updates
- * in the children
- */
-const attributeProviderDefs = {
-  attributesProvided: [{
-    attribute: attributes.COLOR_VARIANT,
-    component: IdsTab
-  },
-  {
-    attribute: attributes.ORIENTATION,
-    component: IdsTab
-  }]
-};
 
 /**
  * IDS Tabs Component
@@ -47,7 +29,6 @@ const attributeProviderDefs = {
 @customElement('ids-tabs')
 @scss(styles)
 class IdsTabs extends mix(IdsElement).with(
-    IdsAttributeProviderMixin(attributeProviderDefs),
     IdsColorVariantMixin,
     IdsEventsMixin,
     IdsKeyboardMixin,
@@ -75,10 +56,16 @@ class IdsTabs extends mix(IdsElement).with(
    */
   colorVariants = ['alternate'];
 
+  /**
+   * @returns {string} template for Tab List
+   */
   template() {
     return '<slot></slot>';
   }
 
+  /**
+   * WebComponent's `connectedCallback` implementation
+   */
   connectedCallback() {
     super.connectedCallback?.();
     this.setAttribute('role', 'tablist');
@@ -113,6 +100,7 @@ class IdsTabs extends mix(IdsElement).with(
   /**
    * Traverses parent nodes and scans for parent IdsHeader components.
    * If an IdsHeader is found, adjusts this component's ColorVariant accordingly.
+   * @returns {void}
    */
   #detectParentColorVariant() {
     let isHeaderDescendent = false;
@@ -140,6 +128,7 @@ class IdsTabs extends mix(IdsElement).with(
   /**
    * When a child value or this component value changes,
    * called to rebind onclick callbacks to each child
+   * @returns {void}
    */
   #attachEventHandlers() {
     // Reusable handlers
@@ -232,21 +221,43 @@ class IdsTabs extends mix(IdsElement).with(
       return;
     }
 
-    const tabsArray = [...this.children];
-    const previouslySelectedTab = tabsArray.find((el) => el.value === currentValue);
+    const tabs = [...this.children];
+    const previouslySelectedTab = tabs.find((el) => el.value === currentValue);
 
     if (!newValue) {
-      newValue = tabsArray.find((el) => el.selected)?.value;
+      newValue = tabs.find((el) => el.selected)?.value;
       if (!newValue) {
-        newValue = tabsArray[0].value;
+        newValue = tabs[0].value;
       }
     }
-    const newSelectedTab = tabsArray.find((el) => el.value === newValue);
+    const newSelectedTab = tabs.find((el) => el.value === newValue);
 
     if (previouslySelectedTab !== newSelectedTab) {
       if (previouslySelectedTab) previouslySelectedTab.selected = false;
       if (newSelectedTab) newSelectedTab.selected = true;
     }
+  }
+
+  /**
+   * Listen for changes to color variant, which updates each child tab.
+   * @returns {void}
+   */
+  onColorVariantRefresh() {
+    const tabs = [...this.querySelectorAll('ids-tab')];
+    tabs.forEach((tab) => {
+      tab.colorVariant = this.colorVariant;
+    });
+  }
+
+  /**
+   * Listen for changes to orientation, which updates each child tab.
+   * @returns {void}
+   */
+  onOrientationRefresh() {
+    const tabs = [...this.querySelectorAll('ids-tab')];
+    tabs.forEach((tab) => {
+      tab.orientation = this.orientation;
+    });
   }
 }
 

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -93,7 +93,6 @@ class IdsTabs extends mix(IdsElement).with(
       }
     });
 
-    // set initial selection state
     this.#updateSelectionState();
   }
 
@@ -112,7 +111,7 @@ class IdsTabs extends mix(IdsElement).with(
     const currentValue = this.value;
     if (currentValue !== value) {
       this.setAttribute(attributes.VALUE, value);
-      this.#updateSelectionState();
+      this.#updateSelectionState(currentValue, value);
       this.triggerEvent('change', this, {
         bubbles: false,
         detail: { elem: this, value }
@@ -239,37 +238,29 @@ class IdsTabs extends mix(IdsElement).with(
 
   /**
    * Sets the ids-tab selection states based on the current value
+   * @param {string} currentValue the current tab value
+   * @param {string} newValue the new tab value
+   * @returns {void}
    */
-  #updateSelectionState() {
+  #updateSelectionState(currentValue, newValue) {
     if (!this.children.length) {
       return;
     }
 
-    // determine which child tab value was set, then highlight the item
-    let hadTabSelection = false;
+    const tabsArray = [...this.children];
+    const previouslySelectedTab = tabsArray.find((el) => el.value === currentValue);
 
-    for (let i = 0; i < this.children.length; i++) {
-      const tabValue = this.children[i].getAttribute(attributes.VALUE);
-      const isTabSelected = Boolean(this.value === tabValue);
-
-      if (this.children[i].selected !== isTabSelected) {
-        this.children[i].selected = isTabSelected;
-      }
-
-      if (!hadTabSelection && Boolean(this.children[i].selected)) {
-        hadTabSelection = true;
+    if (!newValue) {
+      newValue = tabsArray.find((el) => el.selected)?.value;
+      if (!newValue) {
+        newValue = tabsArray[0].value;
       }
     }
+    const newSelectedTab = tabsArray.find((el) => el.value === newValue);
 
-    // if no selection found, flag the first child;
-    // this will possibly send a callback up to context for
-    // other listeners and trigger a value change
-
-    if (!hadTabSelection) {
-      window.requestAnimationFrame(() => {
-        this.children[0].selected = true;
-        this.triggerEvent('tabselect', this.children[0], { bubbles: true });
-      });
+    if (previouslySelectedTab !== newSelectedTab) {
+      if (previouslySelectedTab) previouslySelectedTab.selected = false;
+      if (newSelectedTab) newSelectedTab.selected = true;
     }
   }
 }

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -87,21 +87,8 @@ class IdsTabs extends mix(IdsElement).with(
       this.#adjustColorVariant();
     }
 
-    this.onEvent('tabselect', this, (e) => {
-      if (e.target.value !== this.value) {
-        this.setAttribute(attributes.VALUE, e.target.value);
-      }
-    });
-
     this.#updateSelectionState();
-  }
-
-  /**
-   * Binds associated callbacks and cleans
-   * old handlers when template refreshes
-   */
-  rendered() {
-    this.#updateCallbacks();
+    this.#handleEvents();
   }
 
   /**
@@ -157,7 +144,7 @@ class IdsTabs extends mix(IdsElement).with(
    * When a child value or this component value changes,
    * called to rebind onclick callbacks to each child
    */
-  #updateCallbacks() {
+  #handleEvents() {
     // Reusable handlers
     const nextTabHandler = (e) => {
       this.nextTab(e.target.closest('ids-tab')).focus();
@@ -192,6 +179,7 @@ class IdsTabs extends mix(IdsElement).with(
     // Add Events/Key listeners for Tab Selection via click/keyboard
     this.onEvent('click.tabs', this, selectTabHandler);
     this.listen('Enter', this, selectTabHandler);
+    this.onEvent('tabselect', this, selectTabHandler);
   }
 
   /**
@@ -204,7 +192,7 @@ class IdsTabs extends mix(IdsElement).with(
 
     // If next sibling isn't a tab or is disabled, try this method again on the found sibling
     if (nextTab && (nextTab.tagName !== 'IDS-TAB' || nextTab.disabled)) {
-      return nextTab(nextTab);
+      return this.nextTab(nextTab);
     }
 
     // If null, reset back to the first tab (cycling behavior)
@@ -225,7 +213,7 @@ class IdsTabs extends mix(IdsElement).with(
 
     // If previous sibling isn't a tab or is disabled, try this method again on the found sibling
     if (prevTab && (prevTab.tagName !== 'IDS-TAB' || prevTab.disabled)) {
-      return prevTab(prevTab);
+      return this.prevTab(prevTab);
     }
 
     // If null, reset back to the last tab (cycling behavior)

--- a/src/components/ids-tabs/ids-tabs.js
+++ b/src/components/ids-tabs/ids-tabs.js
@@ -83,12 +83,9 @@ class IdsTabs extends mix(IdsElement).with(
     super.connectedCallback?.();
     this.setAttribute('role', 'tablist');
 
-    if (!this.hasAttribute(attributes.COLOR_VARIANT)) {
-      this.#adjustColorVariant();
-    }
-
-    this.#updateSelectionState();
-    this.#handleEvents();
+    this.#detectParentColorVariant();
+    this.#refreshSelectionState();
+    this.#attachEventHandlers();
   }
 
   /**
@@ -98,7 +95,7 @@ class IdsTabs extends mix(IdsElement).with(
     const currentValue = this.value;
     if (currentValue !== value) {
       this.setAttribute(attributes.VALUE, value);
-      this.#updateSelectionState(currentValue, value);
+      this.#refreshSelectionState(currentValue, value);
       this.triggerEvent('change', this, {
         bubbles: false,
         detail: { elem: this, value }
@@ -117,7 +114,7 @@ class IdsTabs extends mix(IdsElement).with(
    * Traverses parent nodes and scans for parent IdsHeader components.
    * If an IdsHeader is found, adjusts this component's ColorVariant accordingly.
    */
-  #adjustColorVariant() {
+  #detectParentColorVariant() {
     let isHeaderDescendent = false;
     let currentElement = this.host || this.parentNode;
 
@@ -144,7 +141,7 @@ class IdsTabs extends mix(IdsElement).with(
    * When a child value or this component value changes,
    * called to rebind onclick callbacks to each child
    */
-  #handleEvents() {
+  #attachEventHandlers() {
     // Reusable handlers
     const nextTabHandler = (e) => {
       this.nextTab(e.target.closest('ids-tab')).focus();
@@ -230,7 +227,7 @@ class IdsTabs extends mix(IdsElement).with(
    * @param {string} newValue the new tab value
    * @returns {void}
    */
-  #updateSelectionState(currentValue, newValue) {
+  #refreshSelectionState(currentValue, newValue) {
     if (!this.children.length) {
       return;
     }

--- a/src/components/ids-tabs/ids-tabs.scss
+++ b/src/components/ids-tabs/ids-tabs.scss
@@ -26,5 +26,5 @@
 :host(ids-tabs:not([orientation='vertical']):not([color-variant='alternate'])),
 .ids-tabs-container:not([orientation='vertical']):not([color-variant='alternate']) {
   @include border-b-1;
-  @include border-graphite-60;
+  @include border-graphite-30;
 }

--- a/src/mixins/ids-color-variant-mixin/ids-color-variant-mixin.d.ts
+++ b/src/mixins/ids-color-variant-mixin/ids-color-variant-mixin.d.ts
@@ -6,5 +6,5 @@ export class IdsColorVariantMixin {
   colorVariant: string;
 
   /** refreshes the Color Variant's state applied to the IdsElement container */
-  refreshColorVariant(): void;
+  onColorVariantRefresh?(): void;
 }

--- a/src/mixins/ids-color-variant-mixin/ids-color-variant-mixin.js
+++ b/src/mixins/ids-color-variant-mixin/ids-color-variant-mixin.js
@@ -1,6 +1,5 @@
 import { attributes } from '../../core';
-// Import Utils
-import { IdsStringUtils, IdsXssUtils } from '../../utils';
+import { IdsXssUtils } from '../../utils';
 
 /**
  * A mixin that will provide the container element of an IDS Component with a class

--- a/src/mixins/ids-color-variant-mixin/ids-color-variant-mixin.js
+++ b/src/mixins/ids-color-variant-mixin/ids-color-variant-mixin.js
@@ -53,21 +53,22 @@ const IdsColorVariantMixin = (superclass) => class extends superclass {
    * @param {string|null} val the name of the color variant to be applied
    */
   set colorVariant(val) {
-    let safeVal = null;
+    let safeValue = null;
     if (typeof val === 'string') {
-      safeVal = IdsXssUtils.stripTags(val, '');
+      safeValue = IdsXssUtils.stripTags(val, '');
     }
 
-    if (this.colorVariants.includes(safeVal)) {
-      this.setAttribute(attributes.COLOR_VARIANT, `${safeVal}`);
-    } else {
-      this.removeAttribute(attributes.COLOR_VARIANT);
-      safeVal = null;
-    }
+    const currentValue = this.state.colorVariant;
+    if (currentValue !== safeValue) {
+      if (this.colorVariants.includes(safeValue)) {
+        this.setAttribute(attributes.COLOR_VARIANT, `${safeValue}`);
+      } else {
+        this.removeAttribute(attributes.COLOR_VARIANT);
+        safeValue = null;
+      }
 
-    if (this.state.colorVariant !== safeVal) {
-      this.state.colorVariant = safeVal;
-      this.#refreshColorVariant(safeVal);
+      this.state.colorVariant = safeValue;
+      this.#refreshColorVariant(currentValue, safeValue);
     }
   }
 
@@ -75,22 +76,15 @@ const IdsColorVariantMixin = (superclass) => class extends superclass {
    * Refreshes the component's color variant state, driven by
    * a CSS class on the WebComponent's `container` element
    *
-   * @param {string} variantName the variant name to "add" to the style
+   * @param {string} oldVariantName the variant name to "remove" from the style
+   * @param {string} newVariantName the variant name to "add" to the style
    * @returns {void}
    */
-  #refreshColorVariant(variantName) {
-    const variantClass = `color-variant-${variantName}`;
+  #refreshColorVariant(oldVariantName, newVariantName) {
     const cl = this.container.classList;
 
-    // remove any color-variant classes
-    cl.forEach((x) => {
-      if (x.includes('color-variant')) cl.remove(x);
-    });
-
-    // add the color-variant class
-    if (variantName !== null) {
-      cl.add(variantClass);
-    }
+    if (oldVariantName) cl.remove(`color-variant-${oldVariantName}`);
+    if (newVariantName) cl.add(`color-variant-${newVariantName}`);
 
     // Fire optional callback
     if (typeof this.onColorVariantRefresh === 'function') {

--- a/src/mixins/ids-orientation-mixin/ids-orientation-mixin.d.ts
+++ b/src/mixins/ids-orientation-mixin/ids-orientation-mixin.d.ts
@@ -1,0 +1,10 @@
+export class IdsOrientationMixin {
+  /** list of available orientations for this component */
+  orientations: Array<string>;
+
+  /** the current orientation */
+  orientation: string;
+
+  /** refreshes the orientation's state applied to the IdsElement container */
+  onOrientationRefresh?(): void;
+}

--- a/src/mixins/ids-orientation-mixin/ids-orientation-mixin.js
+++ b/src/mixins/ids-orientation-mixin/ids-orientation-mixin.js
@@ -1,0 +1,99 @@
+import { attributes } from '../../core';
+import { IdsXssUtils } from '../../utils';
+
+/**
+ * @param {any} superclass Accepts a superclass and creates a new subclass from it
+ * @returns {any} The extended object
+ */
+const IdsOrientationMixin = (superclass) => class extends superclass {
+  constructor() {
+    super();
+
+    if (!this.state) {
+      this.state = {};
+    }
+    this.state.orientation = null;
+
+    // Overrides the IdsElement `render` method to also include an update
+    // to color variant styling after it runs, keeping the visual state in-sync.
+    this.render = () => {
+      super.render();
+      this.#refreshOrientation();
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback?.();
+    this.orientation = this.getAttribute(attributes.ORIENTATION);
+  }
+
+  static get attributes() {
+    return [
+      ...super.attributes,
+      attributes.ORIENTATION
+    ];
+  }
+
+  /**
+   * @returns {Array<string>} List of available orientation for this component
+   */
+  orientations = ['horizontal', 'vertical'];
+
+  /**
+   * @returns {string|null} the name of the orientation currently applied
+   */
+  get orientation() {
+    return this.state?.orientation;
+  }
+
+  /**
+   * @param {string|null} val the name of the orientation to be applied
+   */
+  set orientation(val) {
+    let safeVal = null;
+    if (typeof val === 'string') {
+      safeVal = IdsXssUtils.stripTags(val, '');
+    }
+
+    if (this.orientations.includes(safeVal)) {
+      this.setAttribute(attributes.ORIENTATION, `${safeVal}`);
+    } else {
+      this.removeAttribute(attributes.ORIENTATION);
+      safeVal = null;
+    }
+
+    if (this.state.orientation !== safeVal) {
+      this.state.orientation = safeVal;
+      this.#refreshOrientation(safeVal);
+    }
+  }
+
+  /**
+   * Refreshes the component's orientation state, driven by
+   * a CSS class on the WebComponent's `container` element
+   *
+   * @param {string} variantName the orientation variant name to "add" to the style
+   * @returns {void}
+   */
+  #refreshOrientation(variantName) {
+    const variantClass = `orientation-${variantName}`;
+    const cl = this.container.classList;
+
+    // remove any orientation classes
+    cl.forEach((x) => {
+      if (x.includes('orientation')) cl.remove(x);
+    });
+
+    // add the orientation class
+    if (variantName !== null) {
+      cl.add(variantClass);
+    }
+
+    // Fire optional callback
+    if (typeof this.onOrientationRefresh === 'function') {
+      this.onOrientationRefresh();
+    }
+  }
+};
+
+export default IdsOrientationMixin;

--- a/src/mixins/ids-orientation-mixin/ids-orientation-mixin.js
+++ b/src/mixins/ids-orientation-mixin/ids-orientation-mixin.js
@@ -50,21 +50,22 @@ const IdsOrientationMixin = (superclass) => class extends superclass {
    * @param {string|null} val the name of the orientation to be applied
    */
   set orientation(val) {
-    let safeVal = null;
+    let safeValue = null;
     if (typeof val === 'string') {
-      safeVal = IdsXssUtils.stripTags(val, '');
+      safeValue = IdsXssUtils.stripTags(val, '');
     }
 
-    if (this.orientations.includes(safeVal)) {
-      this.setAttribute(attributes.ORIENTATION, `${safeVal}`);
-    } else {
-      this.removeAttribute(attributes.ORIENTATION);
-      safeVal = null;
-    }
+    const currentValue = this.state.orientation;
+    if (currentValue !== safeValue) {
+      if (this.orientations.includes(safeValue)) {
+        this.setAttribute(attributes.ORIENTATION, `${safeValue}`);
+      } else {
+        this.removeAttribute(attributes.ORIENTATION);
+        safeValue = null;
+      }
 
-    if (this.state.orientation !== safeVal) {
-      this.state.orientation = safeVal;
-      this.#refreshOrientation(safeVal);
+      this.state.orientation = safeValue;
+      this.#refreshOrientation(currentValue, safeValue);
     }
   }
 
@@ -72,22 +73,15 @@ const IdsOrientationMixin = (superclass) => class extends superclass {
    * Refreshes the component's orientation state, driven by
    * a CSS class on the WebComponent's `container` element
    *
-   * @param {string} variantName the orientation variant name to "add" to the style
+   * @param {string} oldVariantName the orientation variant name to "remove" from the style
+   * @param {string} newVariantName the orientation variant name to "add" to the style
    * @returns {void}
    */
-  #refreshOrientation(variantName) {
-    const variantClass = `orientation-${variantName}`;
+  #refreshOrientation(oldVariantName, newVariantName) {
     const cl = this.container.classList;
 
-    // remove any orientation classes
-    cl.forEach((x) => {
-      if (x.includes('orientation')) cl.remove(x);
-    });
-
-    // add the orientation class
-    if (variantName !== null) {
-      cl.add(variantClass);
-    }
+    if (oldVariantName) cl.remove(`orientation-${oldVariantName}`);
+    if (newVariantName) cl.add(`orientation-${newVariantName}`);
 
     // Fire optional callback
     if (typeof this.onOrientationRefresh === 'function') {

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -8,6 +8,7 @@ export { default as IdsHitboxMixin } from './ids-hitbox-mixin/ids-hitbox-mixin';
 export { default as IdsKeyboardMixin } from './ids-keyboard-mixin/ids-keyboard-mixin';
 export { default as IdsLocaleMixin } from './ids-locale-mixin/ids-locale-mixin';
 export { default as IdsMaskMixin } from './ids-mask-mixin/ids-mask-mixin';
+export { default as IdsOrientationMixin } from './ids-orientation-mixin/ids-orientation-mixin';
 export { default as IdsPopupInteractionsMixin } from './ids-popup-interactions-mixin/ids-popup-interactions-mixin';
 export { default as IdsPopupOpenEventsMixin } from './ids-popup-open-events-mixin/ids-popup-open-events-mixin';
 export { default as IdsThemeMixin } from './ids-theme-mixin/ids-theme-mixin';

--- a/test/ids-tabs/ids-tabs-e2e-test.js
+++ b/test/ids-tabs/ids-tabs-e2e-test.js
@@ -35,10 +35,9 @@ describe('Ids Tabs e2e Tests', () => {
     await page.keyboard.press('ArrowRight');
     await page.keyboard.press('ArrowRight');
     await page.keyboard.press('ArrowRight');
-    await page.keyboard.press('ArrowLeft');
     await page.keyboard.press('Enter');
     innerHTML = await page.evaluate('document.activeElement.innerHTML');
-    await expect(innerHTML).toEqual('Attachments');
+    await expect(innerHTML).toEqual('Opportunities');
   });
 
   it('can use home/end keys to focus', async () => {

--- a/test/ids-tabs/ids-tabs-func-test.js
+++ b/test/ids-tabs/ids-tabs-func-test.js
@@ -16,7 +16,7 @@ const processAnimFrame = () => new Promise((resolve) => {
 });
 
 const DEFAULT_TABS_HTML = (
-  `<ids-tabs value="hello">
+  `<ids-tabs>
     <ids-tab value="hello">Hello</ids-tab>
     <ids-tab value="world">World</ids-tab>
     <ids-tab value="can">Can</ids-tab>
@@ -129,6 +129,8 @@ describe('IdsTabs Tests', () => {
   it('renders correctly', async () => {
     elem = await createFromTemplate(elem, DEFAULT_TABS_HTML);
 
+    await processAnimFrame();
+
     expect(elem.outerHTML).toMatchSnapshot();
   });
 
@@ -143,6 +145,7 @@ describe('IdsTabs Tests', () => {
         <ids-tab count="12">Ginger Ales</ids-tab>
       </ids-tabs>`
     );
+    await processAnimFrame();
     expect(elem.outerHTML).toMatchSnapshot();
     expect(errors).not.toHaveBeenCalled();
   });
@@ -159,6 +162,8 @@ describe('IdsTabs Tests', () => {
        <ids-tab count="12">Ginger Ales</ids-tab>
       </ids-tabs>`
     );
+    await processAnimFrame();
+
     expect(elem.outerHTML).toMatchSnapshot();
     expect(errors).not.toHaveBeenCalled();
     expect(elem.querySelector('ids-tab-divider').getAttribute('role')).toEqual('presentation');
@@ -191,8 +196,7 @@ describe('IdsTabs Tests', () => {
     expect(elem.outerHTML).toMatchSnapshot();
   });
 
-  it('sets "selected" state of a new tab directly, and does not '
-  + 'become in an invalid tabs state', async () => {
+  it('sets "selected" state of a new tab directly, and does not become in an invalid tabs state', async () => {
     elem = await createFromTemplate(elem, DEFAULT_TABS_HTML);
 
     elem.children[1].selected = true;
@@ -202,28 +206,13 @@ describe('IdsTabs Tests', () => {
     // expect(hasValidTabs).toEqual(true);
   });
 
-  it('unsets "selected" state of a selected tab false, and triggers '
-  + 'an error with an invalid tabs state', async () => {
+  it('unsets "selected" state of a selected tab false, and triggers an error with an invalid tabs state', async () => {
     elem = await createFromTemplate(elem, DEFAULT_TABS_HTML);
     elem.children[0].selected = false;
     await processAnimFrame();
     const hasValidTabs = areTabSelectionAttribsValid(elem);
 
     expect(hasValidTabs).toEqual(false);
-  });
-
-  it('sets tabs to an invalid value, and is reset to the first tab value available', async () => {
-    const errors = jest.spyOn(global.console, 'error');
-    elem = await createFromTemplate(elem, DEFAULT_TABS_HTML);
-    await processAnimFrame();
-
-    elem.value = 'random_value';
-    await processAnimFrame();
-
-    const hasValidTabs = areTabSelectionAttribsValid(elem);
-
-    expect(hasValidTabs).toEqual(true);
-    expect(errors).not.toHaveBeenCalled();
   });
 
   it('changes content within a text node to fire a slotchange with no errors', async () => {
@@ -239,8 +228,7 @@ describe('IdsTabs Tests', () => {
     expect(elem.outerHTML).toMatchSnapshot();
   });
 
-  it('changes value of ids-tab, and the "selected" attrib of every '
-  + 'ids-tab listed is predictable', async () => {
+  it('changes value of ids-tab, and the "selected" attrib of every ids-tab listed is predictable', async () => {
     elem = await createFromTemplate(elem, DEFAULT_TABS_HTML);
     await processAnimFrame();
 
@@ -260,8 +248,7 @@ describe('IdsTabs Tests', () => {
     elem.value = 'world';
   });
 
-  it('assigns an invalid count to a tab with counts, and triggers '
-  + 'an error', async () => {
+  it('assigns an invalid count to a tab with counts, and triggers an error', async () => {
     const errors = jest.spyOn(global.console, 'error');
 
     await expect(createFromTemplate(
@@ -388,6 +375,5 @@ describe('IdsTabs Tests', () => {
     expect(elem.querySelector('ids-tab').getAttribute('aria-label')).toEqual('Hello');
     elem = await createFromTemplate(elem, `<ids-tabs></ids-tabs>`);
     expect(elem.querySelector('ids-tab')).toBeFalsy();
-    expect(elem.getFocusedTabIndex()).toEqual(-1);
   });
 });

--- a/test/ids-tabs/ids-tabs-func-test.js.snap
+++ b/test/ids-tabs/ids-tabs-func-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IdsTabs Tests changes content within a text node to fire a slotchange with no errors 1`] = `
-"<ids-tabs value=\\"hello\\" role=\\"tablist\\">
+"<ids-tabs role=\\"tablist\\">
     <ids-tab value=\\"hello\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"Its Over 9000\\">Its Over 9000</ids-tab>
     <ids-tab value=\\"world\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"World\\">World</ids-tab>
     <ids-tab value=\\"can\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"Can\\">Can</ids-tab>
@@ -10,7 +10,7 @@ exports[`IdsTabs Tests changes content within a text node to fire a slotchange w
 `;
 
 exports[`IdsTabs Tests removes a tab after rendering and does not break 1`] = `
-"<ids-tabs value=\\"hello\\" role=\\"tablist\\">
+"<ids-tabs role=\\"tablist\\">
     <ids-tab value=\\"hello\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"Hello\\">Hello</ids-tab>
     <ids-tab value=\\"world\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"World\\">World</ids-tab>
     <ids-tab value=\\"can\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"Can\\">Can</ids-tab>
@@ -19,7 +19,7 @@ exports[`IdsTabs Tests removes a tab after rendering and does not break 1`] = `
 `;
 
 exports[`IdsTabs Tests renders correctly 1`] = `
-"<ids-tabs value=\\"hello\\" role=\\"tablist\\">
+"<ids-tabs role=\\"tablist\\">
     <ids-tab value=\\"hello\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"Hello\\">Hello</ids-tab>
     <ids-tab value=\\"world\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"World\\">World</ids-tab>
     <ids-tab value=\\"can\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"Can\\">Can</ids-tab>
@@ -31,10 +31,10 @@ exports[`IdsTabs Tests renders tab dividers on counts, and has no errors 1`] = `
 "<ids-tabs role=\\"tablist\\">
         <ids-tab count=\\"20\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"20
        Pizzas\\">Pizzas</ids-tab>
-        <ids-tab count=\\"18\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"18
+        <ids-tab count=\\"18\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"18
        Diet Cokes\\">Diet Cokes</ids-tab>
         <ids-tab-divider role=\\"presentation\\"></ids-tab-divider>
-       <ids-tab count=\\"12\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"12
+       <ids-tab count=\\"12\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"12
        Ginger Ales\\">Ginger Ales</ids-tab>
       </ids-tabs>"
 `;
@@ -43,9 +43,9 @@ exports[`IdsTabs Tests renders with counts, and has no errors 1`] = `
 "<ids-tabs role=\\"tablist\\">
         <ids-tab count=\\"20\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"20
        Pizzas\\">Pizzas</ids-tab>
-        <ids-tab count=\\"18\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"18
+        <ids-tab count=\\"18\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"18
        Diet Cokes\\">Diet Cokes</ids-tab>
-        <ids-tab count=\\"12\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"12
+        <ids-tab count=\\"12\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"12
        Ginger Ales\\">Ginger Ales</ids-tab>
       </ids-tabs>"
 `;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR refactors parts of the IdsTabs component to simplify its design:
- Got rid of stored internal references to child tabs, reducing the need to remove/reapply event handlers
- Reworked keyboard navigation to not depend on said references
- Reworked events not to use indexes for referencing tabs but `e.target` (again to reduce looping for detection)
- Fixed setter logic in many places to prevent double-setting from occuring, removed `#prevSelected` since its unneeded after this.
- Fixed bugs related to setting junk values referencing non-existent tab content (setters should ignore these)
- Broke out logic for Orientation into its own `IdsOrientationMixin` (could be used elsewhere)
- Updated tests/types/docs to match

No visual states or interactions should change with this PR, and it should behave pretty much the same as before, aside from the bug fixes.

**Related github/jira issue (required)**:
Closes #345

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4300/ids-tabs
- By default the "Contracts" tab should be selected
- Clicking the tabs should change the tab clicked to "selected", and should deselect the previously selected tab.
- After clicking a tab, use the left/right arrow keys to navigate.  It should be possible to cycle focus in both directions, and focus should loop between first/last tabs.
- Pressing "Enter" should select a keyboard-focused tab.
- Pressing "Home"/"End" keys should set focus to the first/last tabs respectively.
- Open a dev tools console.  Inspect the `<ids-tabs>` element and change its value attribute to match one of the `<ids-tab-content>` pane's value attributes.  The selected tab should be updated in the DOM.
- Open http://localhost:4300/ids-tabs/vertical.html.  Try the same keyboard tests, but use the up/down arrows.
- Check counts on http://localhost:4300/ids-tabs/counts.html
- Check the color variant and nested tabs on http://localhost:4300/ids-tabs/header-tabs.html

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
