### PR TITLE
Chore: Change HTMLHint to not require all tags to be closed

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -11,7 +11,7 @@
   "title-require": true,
   "head-script-disabled": false,
   "alt-require": true,
-  "tag-self-close": true,
+  "tag-self-close": false,
   "attr-value-not-empty": false,
   "attr-unsafe-chars": true,
   "space-tab-mixed-disabled": "true",


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Our `.htmlhintrc` is configured to require all standalone tags to self close.  This caused a problem in some templates when [linting on #411](https://github.com/infor-design/enterprise-wc/runs/4105759483?check_suite_focus=true#step:8:137) that have `<meta>` tags that standalone and are not closed at the end, [which is valid HTML](https://stackoverflow.com/a/19510239/4024149).  The meta tags in that sample needed to not be closed in order to fix a weird parsing bug.

This PR just changes the configuration not to require all standalone tags to be closed.

**Related github/jira issue (required)**:
- Related to #411 (this PR is required to merge that one)

**Steps necessary to review your pull request (required)**:
Make sure all linting passes on this PR before merging
