### PR TITLE
376 - Automatically add alternate color variant to button components …

### DIFF
--- a/demos/ids-search-field/example.html
+++ b/demos/ids-search-field/example.html
@@ -13,25 +13,28 @@
     <ids-search-field disabled label="Disabled Search Bar" value="Anti-virus Software"></ids-search-field>
   </ids-layout-grid-cell>
 </ids-layout-grid>
+
 <ids-layout-grid cols="3" gap="xl">
   <ids-layout-grid-cell>
     <ids-search-field readonly label="Read-only Search Bar" value="Cellphone"></ids-search-field>
   </ids-layout-grid-cell>
   <ids-layout-grid-cell>
-      <form>
-        <ids-search-field label="Search Wrapped in a Form tag" value="Cellphone"></ids-search-field>
-      </form>
+    <form>
+      <ids-search-field label="Search Wrapped in a Form tag" value="Cellphone"></ids-search-field>
+    </form>
   </ids-layout-grid-cell>
   <ids-layout-grid-cell>
-        <ids-search-field color-variant="alternate" label="Alternate Color Search Bar" value="Cellphone"></ids-search-field>
+    <ids-search-field color-variant="alternate" label="Alternate Color Search Bar" value="Cellphone"></ids-search-field>
+  </ids-layout-grid-cell>
 </ids-layout-grid>
+
 <ids-layout-grid cols="1">
   <ids-layout-grid-cell>
     <ids-text font-size="12" type="h1">Inside a Header:</ids-text>
     <ids-header>
       <ids-toolbar>
         <ids-toolbar-section>
-          <ids-button icon="menu" role="button" color-variant="alternate">
+          <ids-button icon="menu" role="button">
             <span slot="text" class="audible">Application Menu Trigger</span>
           </ids-button>
         </ids-toolbar-section>
@@ -40,11 +43,10 @@
           <ids-text font-size="14" color-variant="alternate">With some extra information below</ids-text>
         </ids-toolbar-section>
         <ids-toolbar-section type="search" align="end">
-          <ids-search-field color-variant="alternate" label=""></ids-search-field>
+          <ids-search-field label=""></ids-search-field>
         </ids-toolbar-section>
-        <ids-theme-switcher mode="light" version="new" color-variant="alternate"></ids-theme-switcher>
+        <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
       </ids-toolbar>
     </ids-header>
-
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/src/components/ids-button/ids-button.js
+++ b/src/components/ids-button/ids-button.js
@@ -13,7 +13,8 @@ import {
   IdsColorVariantMixin,
   IdsLocaleMixin,
   IdsThemeMixin,
-  IdsTooltipMixin
+  IdsTooltipMixin,
+  IdsHeaderMixin
 } from '../../mixins';
 
 import { renderLoop, IdsRenderLoopItem } from '../ids-render-loop';
@@ -89,7 +90,8 @@ class IdsButton extends mix(IdsElement).with(
     IdsColorVariantMixin,
     IdsLocaleMixin,
     IdsThemeMixin,
-    IdsTooltipMixin
+    IdsTooltipMixin,
+    IdsHeaderMixin
   ) {
   constructor() {
     super();

--- a/src/components/ids-search-field/ids-search-field.js
+++ b/src/components/ids-search-field/ids-search-field.js
@@ -10,7 +10,8 @@ import {
   IdsEventsMixin,
   IdsThemeMixin,
   IdsKeyboardMixin,
-  IdsColorVariantMixin
+  IdsColorVariantMixin,
+  IdsHeaderMixin
 } from '../../mixins';
 
 import { IdsStringUtils } from '../../utils';
@@ -26,7 +27,8 @@ const appliedMixins = [
   IdsEventsMixin,
   IdsKeyboardMixin,
   IdsThemeMixin,
-  IdsColorVariantMixin
+  IdsColorVariantMixin,
+  IdsHeaderMixin
 ];
 
 const DEFAULT_LABEL = 'Search';

--- a/src/mixins/ids-header-mixin/ids-header-mixin.d.ts
+++ b/src/mixins/ids-header-mixin/ids-header-mixin.d.ts
@@ -1,0 +1,4 @@
+export class IdsHeaderMixin {
+  /** Alternate color variant for buttons in header */
+  colorVariant: string;
+}

--- a/src/mixins/ids-header-mixin/ids-header-mixin.js
+++ b/src/mixins/ids-header-mixin/ids-header-mixin.js
@@ -1,0 +1,39 @@
+import { attributes } from '../../core/ids-attributes';
+
+const IdsHeaderMixin = (superclass) => class extends superclass {
+  constructor() {
+    super();
+  }
+
+  static get attributes() {
+    return [...super.attributes, attributes.COLOR_VARIANT];
+  }
+
+  /**
+   * @returns {void}
+   */
+  connectedCallback() {
+    super.connectedCallback?.();
+
+    // Check if it has ids-header web component in parent list
+    // If exists, add color-variant `alternate` for the color variant in the header 
+    let parent = this;
+    while (true) {
+      if (parent?.name === 'ids-header' || parent?.localName === 'ids-header') {
+        this.colorVariant = 'alternate';
+        break;
+      }
+
+      if (parent?.nodeType !== 11) {
+        if (parent.localName === 'body') {
+          break;
+        }
+        parent = parent.parentNode;
+      } else {
+        parent = parent.host;
+      }
+    }
+  }
+};
+
+export default IdsHeaderMixin;

--- a/src/mixins/ids-header-mixin/index.js
+++ b/src/mixins/ids-header-mixin/index.js
@@ -1,0 +1,1 @@
+export { default as IdsHeaderMixin } from './ids-header-mixin';

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -15,3 +15,4 @@ export { default as IdsThemeMixin } from './ids-theme-mixin/ids-theme-mixin';
 export { default as IdsTooltipMixin } from './ids-tooltip-mixin/ids-tooltip-mixin';
 export { default as IdsValidationMixin } from './ids-validation-mixin/ids-validation-mixin';
 export { default as IdsXssMixin } from './ids-xss-mixin/ids-xss-mixin';
+export { default as IdsHeaderMixin } from './ids-header-mixin/ids-header-mixin';


### PR DESCRIPTION
…in header

**Explain the details for making this change. What existing problem does the pull request solve?**
Before, we manually added `color-variant='alternate'` to the components in `ids-header`
Added new mixin for header so that color-variant can be added automatically for the buttons in `ids-header`

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-wc/issues/376

**Steps necessary to review your pull request (required)**:
Go to http://localhost:4300/ids-search-field
Check if menu, search-clearable button, search-input has alternate color variant

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
