### PR TITLE
443 - Set validate attribute dynamically

### DIFF
--- a/src/components/ids-lookup/ids-lookup.js
+++ b/src/components/ids-lookup/ids-lookup.js
@@ -329,12 +329,16 @@ class IdsLookup extends mix(IdsElement).with(
   set validate(value) {
     if (value) {
       this.setAttribute(attributes.VALIDATE, value.toString());
-      this.input.setAttribute(attributes.VALIDATE, value.toString());
       this.triggerField.setAttribute(attributes.VALIDATE, value.toString());
+      this.triggerField.setAttribute(attributes.VALIDATION_EVENTS, this.validationEvents);
+      this.triggerField.handleValidation();
+      this.input.setLabelElement(this.triggerField.shadowRoot?.querySelector('[slot="ids-trigger-field-label"]'));
     } else {
       this.removeAttribute(attributes.VALIDATE);
-      this.input.removeAttribute(attributes.VALIDATE);
       this.triggerField.removeAttribute(attributes.VALIDATE);
+      this.triggerField.removeAttribute(attributes.VALIDATION_EVENTS);
+      this.triggerField.handleValidation();
+      this.input.setLabelElement(undefined);
     }
   }
 

--- a/test/ids-lookup/ids-lookup-func-test.js
+++ b/test/ids-lookup/ids-lookup-func-test.js
@@ -302,6 +302,25 @@ describe('IdsLookup Component', () => {
     expect(lookup.validationEvents).toEqual('change blur');
   });
 
+  it('adding validation dynamically', async () => {
+    lookup = createFromTemplate(lookup, `<ids-lookup id="lookup-5" label="Dynamic Validation"></ids-lookup>`);
+    await waitFor(() => expect(lookup.shadowRoot.querySelector('ids-trigger-field')).toBeTruthy());
+
+    document.querySelector('ids-lookup').validate = 'required';
+    const triggerElem = lookup.shadowRoot.querySelector('ids-trigger-field');
+    const inputElem = lookup.shadowRoot.querySelector('ids-input');
+    expect(triggerElem.getAttribute('validate')).toEqual('required');
+    expect(triggerElem.getAttribute('validation-events')).toEqual('change blur');
+    expect(inputElem.labelEl).not.toEqual(undefined);
+
+    document.querySelector('ids-lookup').validate = '';
+    expect(triggerElem.getAttribute('validate')).toEqual(null);
+    expect(triggerElem.getAttribute('validation-events')).toEqual(null);
+    expect(inputElem.labelEl).not.toEqual(undefined);
+
+    expect(lookup.getAttribute('validate')).toEqual(null);
+  });
+
   it('supports validation', async () => {
     lookup = createFromTemplate(lookup, `<ids-lookup id="lookup-5" label="Dropdown with Icons" validate="true">
      </ids-lookup>`);

--- a/test/ids-lookup/ids-lookup-func-test.js
+++ b/test/ids-lookup/ids-lookup-func-test.js
@@ -302,7 +302,7 @@ describe('IdsLookup Component', () => {
     expect(lookup.validationEvents).toEqual('change blur');
   });
 
-  it('adding validation dynamically', async () => {
+  it('supports changing validation dynamically', async () => {
     lookup = createFromTemplate(lookup, `<ids-lookup id="lookup-5" label="Dynamic Validation"></ids-lookup>`);
     await waitFor(() => expect(lookup.shadowRoot.querySelector('ids-trigger-field')).toBeTruthy());
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Make it enable to set `validate` property dynamically.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes https://github.com/infor-design/enterprise-wc/issues/443

**Steps necessary to review your pull request (required)**:

- Go to http://localhost:4300/ids-lookup
- Type in the console to toggle validation
```
document.querySelector('ids-lookup').validate = 'required'
'required'
document.querySelector('ids-lookup').validate = ''
```
Then `validate` attribute should be working correctly.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
