### PR TITLE
451 - make menu tabbable using tab key only

### DIFF
--- a/src/components/ids-menu/ids-menu.js
+++ b/src/components/ids-menu/ids-menu.js
@@ -152,6 +152,11 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
   connectedCallback() {
     this.attachEventHandlers();
     this.attachKeyboardListeners();
+
+    // After repaint
+    requestAnimationFrame(() => {
+      this.makeTabbable(this.detectTabbable());
+    });
   }
 
   /**
@@ -492,6 +497,7 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
 
       // Don't count disabled items as "taking a step"
       if (!currentItem.disabled && !currentItem.hidden) {
+        this.makeTabbable(currentItem);
         steps -= 1;
       }
     }
@@ -502,6 +508,32 @@ class IdsMenu extends mix(IdsElement).with(IdsEventsMixin, IdsKeyboardMixin) {
     }
 
     return currentItem;
+  }
+
+  /**
+   * Gets the current item that should be used as the "tabbable" item
+   * (item that receives focus when the menu is "focused").
+   * @returns {HTMLElement | undefined} an element that currently has a usable tabIndex attribute
+   */
+  detectTabbable() {
+    let tabbableItem;
+    for (let i = 0; !tabbableItem && i < this.items.length; i++) {
+      if (this.items[i].tabIndex > -1) {
+        tabbableItem = this.items[i];
+      }
+    }
+    return tabbableItem;
+  }
+
+  /**
+   * @private
+   * @param {HTMLElement} elem an element residing within the menu that can accept
+   */
+  makeTabbable(elem = this.items[0]) {
+    this.items.forEach((item) => {
+      const nonTabbableTargetIndex = elem.isEqualNode(item) ? 0 : -1;
+      item.tabIndex = nonTabbableTargetIndex;
+    });
   }
 
   /**

--- a/test/ids-menu/ids-menu-func-test.js
+++ b/test/ids-menu/ids-menu-func-test.js
@@ -284,6 +284,53 @@ describe('IdsMenu Component', () => {
     expect(menu.focused).toEqual(item6);
   });
 
+  it('tab should not change navigation in the menu', () => {
+    const tabKeyEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+    const navigateUpEvent = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+    const navigateDownEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+
+    // Focus the first one
+    item1.focus();
+
+    expect(menu.focused).toEqual(item1);
+
+    // Tab should not change navigation in the menu
+    document.body.dispatchEvent(tabKeyEvent);
+    expect(menu.focused).toEqual(item1);
+
+    // Navigate down one item
+    menu.dispatchEvent(navigateDownEvent);
+
+    expect(menu.focused).toEqual(item2);
+
+    // Tab should not change navigation in the menu
+    document.body.dispatchEvent(tabKeyEvent);
+    document.body.dispatchEvent(tabKeyEvent);
+    expect(menu.focused).toEqual(item2);
+
+    // Only focused item should be tabbable
+    expect(item1.tabIndex).toEqual(-1);
+    expect(item2.tabIndex).toEqual(0);
+    expect(item3.tabIndex).toEqual(-1);
+    expect(item4.tabIndex).toEqual(-1);
+    expect(item5.tabIndex).toEqual(-1);
+    expect(item6.tabIndex).toEqual(-1);
+
+    // Navigate up two items (navigation will wrap to the bottom item)
+    menu.dispatchEvent(navigateUpEvent);
+    menu.dispatchEvent(navigateUpEvent);
+
+    expect(menu.focused).toEqual(item6);
+
+    // Only focused item should be tabbable
+    expect(item1.tabIndex).toEqual(-1);
+    expect(item2.tabIndex).toEqual(-1);
+    expect(item3.tabIndex).toEqual(-1);
+    expect(item4.tabIndex).toEqual(-1);
+    expect(item5.tabIndex).toEqual(-1);
+    expect(item6.tabIndex).toEqual(0);
+  });
+
   it('highlights a menu item on click', () => {
     item2.select();
     item1.click();


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Stop navigating the menu-items by using tab or shift + tab keyboard. Should be able to navigate using arrow keys.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes https://github.com/infor-design/enterprise-wc/issues/451

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Go to http://localhost:4300/ids-menu
- Tab through the page
- Should not be able to tab menu items

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
