### PR TITLE
467 - Add ability to filter on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:app:prod": "webpack --config ./webpack.config.demos.js --mode production",
     "build:verbose": "npx webpack --config ./webpack.config.demos.js --progress profile",
     "start": "webpack serve --live-reload --open --config ./webpack.config.demos.js",
-    "start:filter": "npm --components=data-grid run start",
+    "start:filter": "npm --component=data-grid run start",
     "start:watch": "nodemon --watch webpack.config.demos.js --exec \"npx webpack serve --config ./webpack.config.demos.js\"",
     "lint": "npx eslint src test demos && npx stylelint src/**/**/*.scss --config .stylelintrc.json && npm run mdlint && npx htmlhint 'demos/**/*.html' && npm run typecheck",
     "mdlint": "npx remark . -f",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:app:prod": "webpack --config ./webpack.config.demos.js --mode production",
     "build:verbose": "npx webpack --config ./webpack.config.demos.js --progress profile",
     "start": "webpack serve --live-reload --open --config ./webpack.config.demos.js",
+    "start:filter": "npm --components=data-grid run start",
     "start:watch": "nodemon --watch webpack.config.demos.js --exec \"npx webpack serve --config ./webpack.config.demos.js\"",
     "lint": "npx eslint src test demos && npx stylelint src/**/**/*.scss --config .stylelintrc.json && npm run mdlint && npx htmlhint 'demos/**/*.html' && npm run typecheck",
     "mdlint": "npx remark . -f",

--- a/webpack.config.demos.js
+++ b/webpack.config.demos.js
@@ -14,15 +14,15 @@ const fileUpload = require('express-fileupload');
 
 const isProduction = process.argv[process.argv.indexOf('--mode') + 1] === 'production';
 process.env.NODE_ENV = isProduction ? 'production' : 'development';
-const filterComponents = process.env.npm_config_components || '';
+const filterComponent = process.env.npm_config_component || '';
 
 module.exports = {
-  entry: glob.sync(`./demos/*${filterComponents}*/*.js`).reduce((acc, filePath) => {
+  entry: glob.sync(`./demos/*${filterComponent}*/*.js`).reduce((acc, filePath) => {
     let entry = filePath.replace(`/${path.basename(filePath)}`, '');
     entry = (entry === './demos' ? 'index' : entry.replace('./demos/', ''));
 
     // If filtering add a few "required" entries
-    if (filterComponents) {
+    if (filterComponent) {
       acc['ids-container/ids-container'] = './demos/ids-container/index.js';
       acc['ids-text/ids-text'] = './demos/ids-text/index.js';
       acc['ids-icon/ids-icon'] = './demos/ids-icon/index.js';
@@ -262,7 +262,7 @@ if (!isProduction) {
 }
 
 // Dynamically add all html examples
-glob.sync(`./demos/*${filterComponents}*/*.html`).reduce((acc, filePath) => {
+glob.sync(`./demos/*${filterComponent}*/*.html`).reduce((acc, filePath) => {
   const folderName = path.dirname(filePath).replace('./demos/', '');
   const folderAndFile = filePath.replace('./demos/', '');
   let title = `${folderName.split('-').map((word) =>

--- a/webpack.config.demos.js
+++ b/webpack.config.demos.js
@@ -14,11 +14,20 @@ const fileUpload = require('express-fileupload');
 
 const isProduction = process.argv[process.argv.indexOf('--mode') + 1] === 'production';
 process.env.NODE_ENV = isProduction ? 'production' : 'development';
+const filterComponents = process.env.npm_config_components || '';
 
 module.exports = {
-  entry: glob.sync('./demos/**/**.js').reduce((acc, filePath) => {
+  entry: glob.sync(`./demos/*${filterComponents}*/*.js`).reduce((acc, filePath) => {
     let entry = filePath.replace(`/${path.basename(filePath)}`, '');
     entry = (entry === './demos' ? 'index' : entry.replace('./demos/', ''));
+
+    // If filtering add a few "required" entries
+    if (filterComponents) {
+      acc['ids-container/ids-container'] = './demos/ids-container/index.js';
+      acc['ids-text/ids-text'] = './demos/ids-text/index.js';
+      acc['ids-icon/ids-icon'] = './demos/ids-icon/index.js';
+      acc['ids-layout-grid/ids-layout-grid'] = './demos/ids-layout-grid/index.js';
+    }
 
     if (path.basename(filePath) === 'index.js') {
       acc[entry === 'index' ? entry : `${entry}/${entry}`] = filePath;

--- a/webpack.config.demos.js
+++ b/webpack.config.demos.js
@@ -262,7 +262,7 @@ if (!isProduction) {
 }
 
 // Dynamically add all html examples
-glob.sync('./demos/**/*.html').reduce((acc, filePath) => {
+glob.sync(`./demos/*${filterComponents}*/*.html`).reduce((acc, filePath) => {
   const folderName = path.dirname(filePath).replace('./demos/', '');
   const folderAndFile = filePath.replace('./demos/', '');
   let title = `${folderName.split('-').map((word) =>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Adds the ability to filter whats being watched so the startup is faster and the reload is faster. Note that the command in the package.json is just an example how to run the command.

**Related github/jira issue (required)**:
Fixes #467

**Steps necessary to review your pull request (required)**:
- `npm run start` -> should work like normal
- try `npm --component=data-grid run start` -> only loads datagrid (and a few things like text/icon ect)
- open http://localhost:4300/ids-data-grid to confirm
- save something in ids-datagrid-js.js and watch the console (should be under 8 seconds or so now)
-  note that http://localhost:4300 will not work..
- try `npm --component=[anycomponent sub string] run start` -> only loads datagrid (and a few things like text/icon ect)
