### PR TITLE
471 - Fix ids-treemap loading in firefox

### DIFF
--- a/src/components/ids-treemap/ids-treemap.js
+++ b/src/components/ids-treemap/ids-treemap.js
@@ -433,10 +433,10 @@ export default class IdsTreeMap extends Base {
           }
         }
 
-        requestAnimationFrame(() => resizeObserver.observe(this.container));
+        requestAnimationFrame(() => resizeObserver.observe(this));
       });
 
-      resizeObserver.observe(this.container);
+      resizeObserver.observe(this);
     });
   }
 }

--- a/test/ids-treemap/ids-treemap-e2e-test.js
+++ b/test/ids-treemap/ids-treemap-e2e-test.js
@@ -19,15 +19,15 @@ describe('Ids Treemap e2e Tests', () => {
     await page.setViewport({ width: 589, height: 9999, deviceScaleFactor: 1 });
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
     await page.waitForTimeout(400);
-    let containerWidth = await page.evaluate(`document.querySelector("ids-treemap").container.offsetWidth`);
     let treemapWidth = await page.evaluate(`document.querySelector("ids-treemap").width`);
+    let containerWidth = await page.evaluate(`document.querySelector("ids-treemap").container.offsetWidth`);
     expect(treemapWidth).toEqual(containerWidth);
 
     await page.setViewport({ width: 989, height: 9999, deviceScaleFactor: 1 });
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
     await page.waitForTimeout(400);
-    containerWidth = await page.evaluate(`document.querySelector("ids-treemap").container.offsetWidth`);
     treemapWidth = await page.evaluate(`document.querySelector("ids-treemap").width`);
+    containerWidth = await page.evaluate(`document.querySelector("ids-treemap").container.offsetWidth`);
     expect(treemapWidth).toEqual(containerWidth);
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
ids-treemap works as expected in Chrome and Safari, however is not rendering in Firefox. It was an issue of ResizeObserver in firefox so moved the watcher to the parent element.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-wc/issues/471

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-treemap (in FF/Safari/Chrome)
- resize the page -> should work
