### PR TITLE
Chore: Change ESLint rules to not require explicit array return values

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,8 @@ module.exports = {
       exports: 'never',
       functions: 'never'
     }],
+    // allow inconsistent return values (allows empty return values on array functions, etc)
+    'consistent-return': ['off'],
     // bit masks used for idiomatic MouseEvents.buttons detection w/ mousewheel down
     'no-bitwise': 0,
     // we aren't doing special math with binary/hex radix numbers often,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,10 @@ module.exports = {
     'jsdoc/no-multi-asterisks': 0,
     // Allow a few custom jsdoc tags
     'jsdoc/check-tag-names': ['error', { definedTags: ['jest-environment', 'inherits', 'part'] }],
+    // Allow array methods to not require an explicit return value (for no return values in `.filter()`, `.map()`, etc)
+    'array-callback-return': ['off', {
+      allowImplicit: true
+    }],
     // require trailing commas in multiline object literals
     'comma-dangle': ['off', {
       arrays: 'never',


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
After some review on #495 we ran into a case where `Array.prototype.filter()` could be used more efficiently if we didn't have to return a value from its callback, but our lint rules required explicit AND consistent return values.  Disabling the lint rules in question would enable this type of behavior from methods like `.filter()`: https://github.com/infor-design/enterprise-wc/pull/495/files#diff-81ac9bd7caf95d8fd2e65d0ee5b73edeaa08ec399807a932293fd68fa26c27a3R148

This PR turns these rules off.  We should discuss the impact this has before merging and make sure everyone contributing is aware.  

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
Make sure tests pass