### PR TITLE
565 - Fix some IdsPopup animation/placement bugs

### DIFF
--- a/src/assets/css/ids-popup/test-sandbox.css
+++ b/src/assets/css/ids-popup/test-sandbox.css
@@ -4,14 +4,24 @@ body {
   margin: 0;
 }
 
-div[role='main'] {
-  position: relative;
-}
-
 .demo-popup {
   padding: 50px;
+  text-align: center;
 }
 
+/*
+For the purposes of the sandbox page, remove IdsThemeSwitcher from document flow.
+DO NOT DO THIS in normal application setups.
+*/
+ids-theme-switcher {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+/*
+Contains the controls for the sandbox
+*/
 .fixed-bottom {
   bottom: 0;
   left: 0;
@@ -39,7 +49,7 @@ div[role='main'] {
 }
 
 #second-target,
-#third-target {
+#test-container-target {
   position: absolute;
 }
 
@@ -51,9 +61,4 @@ div[role='main'] {
   left: 10%;
   right: 60%;
   padding: 10px;
-}
-
-.demo-popup {
-  padding: 20px;
-  white-space: nowrap;
 }

--- a/src/assets/css/ids-popup/test-sandbox.css
+++ b/src/assets/css/ids-popup/test-sandbox.css
@@ -1,3 +1,9 @@
+html,
+body {
+  height: 100vh;
+  margin: 0;
+}
+
 div[role='main'] {
   position: relative;
 }

--- a/src/components/ids-date-picker/ids-date-picker.js
+++ b/src/components/ids-date-picker/ids-date-picker.js
@@ -286,12 +286,12 @@ class IdsDatePicker extends Base {
       this.addOpenEvents();
       this.#attachMonthView();
 
-      this.#popup.visible = true;
       this.#popup.alignTarget = this.isCalendarToolbar ? this.container : this.#triggerField;
       this.#popup.arrowTarget = this.#triggerButton;
       this.#popup.align = 'bottom, left';
       this.#popup.arrow = 'bottom';
       this.#popup.y = 16;
+      this.#popup.visible = true;
 
       this.container.classList.add('is-open');
     } else {

--- a/src/components/ids-dropdown/demos/index.html
+++ b/src/components/ids-dropdown/demos/index.html
@@ -92,7 +92,7 @@
 
         <ids-dropdown id="dropdown-4" label="Required Dropdown" value="opt1" validate="required">
           <ids-list-box>
-            <ids-list-box-option value="blank" id="blank"></ids-list-box-option>
+            <ids-list-box-option value="blank" id="blank" aria-label="Blank"></ids-list-box-option>
             <ids-list-box-option value="opt1" id="opt1-d4">Option One</ids-list-box-option>
             <ids-list-box-option value="opt2" id="opt2-d4">Option Two</ids-list-box-option>
             <ids-list-box-option value="opt3" id="opt3-d4">Option Three</ids-list-box-option>

--- a/src/components/ids-dropdown/ids-dropdown.js
+++ b/src/components/ids-dropdown/ids-dropdown.js
@@ -118,13 +118,13 @@ export default class IdsDropdown extends Base {
       'aria-expanded': 'false',
       'aria-autocomplete': 'list',
       'aria-haspopup': 'listbox',
-      'aria-label': this.locale?.translate('PressDown'),
+      'aria-description': this.locale?.translate('PressDown'),
       'aria-controls': this.listBox?.getAttribute('id') || `ids-list-box-${this.id}`
     };
 
     if (this.listBox) {
       this.listBox.setAttribute('id', `ids-list-box-${this.id}`);
-      this.listBox.setAttribute('aria-labelledby', this.id);
+      this.listBox.setAttribute('aria-label', `Listbox`);
     }
     Object.keys(attrs).forEach((key) => this.setAttribute(key, attrs[key]));
     return this;
@@ -135,7 +135,7 @@ export default class IdsDropdown extends Base {
 
     // Add aria for the open state
     const selected = this.selectedOption;
-    this.listBox.setAttribute('tabindex', '0');
+    this.listBox?.setAttribute('tabindex', '0');
     this.listBox?.setAttribute('aria-activedescendant', selected?.id || this.selectedIndex);
     if (selected) {
       selected.setAttribute('tabindex', '0');
@@ -145,7 +145,7 @@ export default class IdsDropdown extends Base {
 
   #setAriaOnMenuClose() {
     this.setAttribute('aria-expanded', 'false');
-    this.listBox.removeAttribute('tabindex');
+    this.listBox?.removeAttribute('tabindex');
 
     const selected = this.selected;
     if (selected) {

--- a/src/components/ids-dropdown/ids-dropdown.js
+++ b/src/components/ids-dropdown/ids-dropdown.js
@@ -53,7 +53,9 @@ export default class IdsDropdown extends Base {
       .#addAria()
       .#attachEventHandlers()
       .#attachKeyboardListeners();
+
     super.connectedCallback();
+    this.#configurePopup();
   }
 
   /**
@@ -324,6 +326,14 @@ export default class IdsDropdown extends Base {
     }
   }
 
+  #configurePopup() {
+    this.popup.alignTarget = this.fieldContainer;
+    this.popup.align = 'bottom, left';
+    this.popup.arrow = 'none';
+    this.popup.y = -1;
+    this.popup.type = 'dropdown';
+  }
+
   /**
    * Open the dropdown list
    */
@@ -339,12 +349,7 @@ export default class IdsDropdown extends Base {
     }
 
     // Open the popup and add a class
-    this.popup.alignTarget = this.fieldContainer;
-    this.popup.align = 'bottom, left';
-    this.popup.arrow = 'none';
-    this.popup.y = -1;
     this.popup.visible = true;
-    this.popup.type = 'dropdown';
     this.addOpenEvents();
     this.container.active = true;
     this.setAttribute('aria-expanded', 'true');

--- a/src/components/ids-dropdown/ids-dropdown.js
+++ b/src/components/ids-dropdown/ids-dropdown.js
@@ -118,13 +118,41 @@ export default class IdsDropdown extends Base {
       'aria-expanded': 'false',
       'aria-autocomplete': 'list',
       'aria-haspopup': 'listbox',
-      'aria-description': this.locale?.translate('PressDown'),
+      'aria-label': this.locale?.translate('PressDown'),
       'aria-controls': this.listBox?.getAttribute('id') || `ids-list-box-${this.id}`
     };
 
-    this.listBox?.setAttribute('id', `ids-list-box-${this.id}`);
+    if (this.listBox) {
+      this.listBox.setAttribute('id', `ids-list-box-${this.id}`);
+      this.listBox.setAttribute('aria-labelledby', this.id);
+    }
     Object.keys(attrs).forEach((key) => this.setAttribute(key, attrs[key]));
     return this;
+  }
+
+  #setAriaOnMenuOpen() {
+    this.setAttribute('aria-expanded', 'true');
+
+    // Add aria for the open state
+    const selected = this.selectedOption;
+    this.listBox.setAttribute('tabindex', '0');
+    this.listBox?.setAttribute('aria-activedescendant', selected?.id || this.selectedIndex);
+    if (selected) {
+      selected.setAttribute('tabindex', '0');
+      selected.focus();
+    }
+  }
+
+  #setAriaOnMenuClose() {
+    this.setAttribute('aria-expanded', 'false');
+    this.listBox.removeAttribute('tabindex');
+
+    const selected = this.selected;
+    if (selected) {
+      selected.classList.remove('is-selected');
+      selected.setAttribute('tabindex', '-1');
+      this.selectedOption.classList.add('is-selected');
+    }
   }
 
   /**
@@ -177,11 +205,21 @@ export default class IdsDropdown extends Base {
   get value() { return this.getAttribute('value'); }
 
   /**
-   * Returns the selected option DOM element
+   * Returns the selected Listbox option based on the Dropdown's value.
    * @returns {HTMLElement} the selected option
    */
   get selectedOption() {
     return this.querySelector(`ids-list-box-option[value="${this.value}"]`);
+  }
+
+  /**
+   * Returns the currently-selected Listbox option
+   * (may be different from the Dropdown's value because of user input)
+   * @readonly
+   * @returns {HTMLElement|null} Reference to a selected Listbox option if one is present
+   */
+  get selected() {
+    return this.querySelector('ids-list-box-option.is-selected');
   }
 
   /**
@@ -332,6 +370,11 @@ export default class IdsDropdown extends Base {
     this.popup.arrow = 'none';
     this.popup.y = -1;
     this.popup.type = 'dropdown';
+
+    // Fix aria if the menu is closed
+    if (!this.popup.visible) {
+      this.#setAriaOnMenuClose();
+    }
   }
 
   /**
@@ -352,15 +395,7 @@ export default class IdsDropdown extends Base {
     this.popup.visible = true;
     this.addOpenEvents();
     this.container.active = true;
-    this.setAttribute('aria-expanded', 'true');
-
-    // Add aria for the open state
-    this.listBox?.setAttribute('aria-activedescendant', this.selectedOption?.id || this.selectedIndex);
-    const selected = this.listBox?.querySelector('.is-selected');
-    if (selected) {
-      selected.setAttribute('tabindex', 0);
-      selected.focus();
-    }
+    this.#setAriaOnMenuOpen();
   }
 
   /**
@@ -408,14 +443,7 @@ export default class IdsDropdown extends Base {
   close(noFocus) {
     this.popup.visible = false;
     this.container.active = false;
-    this.setAttribute('aria-expanded', 'false');
-    const selected = this.querySelector('ids-list-box-option.is-selected');
-
-    if (selected) {
-      selected.classList.remove('is-selected');
-      this.selectedOption.classList.add('is-selected');
-    }
-
+    this.#setAriaOnMenuClose();
     this.removeOpenEvents();
 
     if (!noFocus) {
@@ -472,6 +500,16 @@ export default class IdsDropdown extends Base {
     this.onEvent('languagechange.data-grid-container', this.closest('ids-container'), () => {
       this.#addAria();
     });
+
+    // Listen to IdsPopup's `hide/show` events and control some attributes
+    // on ListBox items for accessibility purposes.
+    this.onEvent('hide', this.popup, () => {
+
+    });
+    this.onEvent('show', this.popup, () => {
+
+    });
+
     return this;
   }
 
@@ -491,7 +529,7 @@ export default class IdsDropdown extends Base {
       e.stopImmediatePropagation();
       e.preventDefault();
 
-      const selected = this.querySelector('ids-list-box-option.is-selected');
+      const selected = this.selected;
       if (e.key === 'ArrowUp' && e.altKey) {
         this.value = selected.getAttribute('value');
         this.close();
@@ -526,7 +564,7 @@ export default class IdsDropdown extends Base {
         return;
       }
 
-      const selected = this.querySelector('ids-list-box-option.is-selected');
+      const selected = this.selected;
       this.value = selected.getAttribute('value');
       this.close();
     });
@@ -541,7 +579,7 @@ export default class IdsDropdown extends Base {
         this.container.focus();
       }
 
-      const selected = this.querySelector('ids-list-box-option.is-selected');
+      const selected = this.selected;
       this.value = selected.getAttribute('value');
       this.close(true);
     });
@@ -561,7 +599,7 @@ export default class IdsDropdown extends Base {
       .filter((a) => a.textContent.toLowerCase().indexOf(keyString.toLowerCase()) === 0);
 
     if (matches[0]) {
-      const selected = this.querySelector('ids-list-box-option.is-selected');
+      const selected = this.selected;
       selected?.classList.remove('is-selected');
       selected?.setAttribute('tabindex', '-1');
       matches[0].classList.add('is-selected');

--- a/src/components/ids-list-box/ids-list-box.js
+++ b/src/components/ids-list-box/ids-list-box.js
@@ -18,7 +18,6 @@ export default class IdsListBox extends Base {
 
   connectedCallback() {
     this.setAttribute('role', 'listbox');
-    this.setAttribute('tabindex', '0');
   }
 
   /**

--- a/src/components/ids-popup/TODO.md
+++ b/src/components/ids-popup/TODO.md
@@ -5,3 +5,4 @@ adding `shouldUpdate: true` setting to the `connectedCallback`
 - [ ] Add tests for "type"
 - [ ] Add option to close on clicking out in the page
 - [ ] Improve "alignTarget" to accept an element reference directly (IDS Popup Menu).
+- [ ] Rename "containment" to "constraint"

--- a/src/components/ids-popup/demos/test-sandbox.html
+++ b/src/components/ids-popup/demos/test-sandbox.html
@@ -4,125 +4,85 @@
   <title><%= htmlWebpackPlugin.options.title %></title>
 </head>
 <body>
+  <ids-container id="test-ids-container" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
 
-  <div id="test-container">
-    <p>Test Container</p>
-  </div>
-
-  <section id="other-test-section">
-    <span class="align-target" id="second-target">Secondary Target</span>
-  </section>
-
-  <section id="another-test-section">
-    <span class="align-target" id="third-target">Third Target</span>
-  </section>
-
-  <section id="test-section">
-    <span class="align-target" id="center-point">Center Point</span>
-  </section>
-
-  <ids-popup id="test-popup" x="0" y="0" align-target="#center-point" align="bottom" animated="true" visible="true" type="menu">
-    <div slot="content">
-      <div class="demo-popup">
-        My Popup Contents<br />
-        are two lines big
-      </div>
+    <div id="test-container">
+      <ids-text font-size="12">Test Container</ids-text>
     </div>
-  </ids-popup>
 
-  <section id="test-controls" class="fixed-bottom">
-    <ids-layout-grid auto="true">
-      <ids-layout-grid-cell>
-        <fieldset id="align-targets" class="radio-group">
-          <legend>Alignment Targets:</legend>
-          <input type="radio" class="radio" name="align-targets" id="align-targets-option1" value="" />
-          <label for="align-targets-option1" class="radio-label">None (Use Coordinates)</label>
-          <br/>
-          <input type="radio" class="radio" name="align-targets" id="align-targets-option2" value="#center-point" checked="true" />
-          <label for="align-targets-option2" class="radio-label">`#center-point`</label>
-          <br/>
-          <input type="radio" class="radio" name="align-targets" id="align-targets-option3" value="#second-target" />
-          <label for="align-targets-option3" class="radio-label">`#second-target`</label>
-          <br/>
-          <input type="radio" class="radio" name="align-targets" id="align-targets-option4" value="#third-target" />
-          <label for="align-targets-option4" class="radio-label">`#third-target`</label>
-        </fieldset>
-        <fieldset id="containment" class="radio-group">
-          <legend>Containment:</legend>
-          <input type="radio" class="radio" name="containment" id="containment-option1" value="" checked="true" />
-          <label for="containment-option1" class="radio-label">Body (default)</label>
-          <br />
-          <input type="radio" class="radio" name="containment" id="containment-option2" value="ids-container"/>
-          <label for="containment-option2" class="radio-label">Ids Container</label>
-          <br />
-          <input type="radio" class="radio" name="containment" id="containment-option3" value="test-container" />
-          <label for="containment-option3" class="radio-label">Test Container</label>
-          <br />
-        </fieldset>
-      </ids-layout-grid-cell>
-      <ids-layout-grid-cell>
-        <fieldset id="alignment">
-          <legend>Alignment</legend>
-          <ids-text id="alignment-display" font-size="14">Edge order: "center, bottom"</ids-text>
+    <section id="other-test-section">
+      <ids-text font-size="12" class="align-target" id="second-target">Secondary Target</ids-text>
+    </section>
+
+    <section id="another-test-section">
+      <ids-text font-size="12" class="align-target" id="test-container-target">Test Container Target</ids-text>
+    </section>
+
+    <section id="test-section">
+      <ids-text font-size="12" class="align-target" id="center-point">Center Point</ids-text>
+    </section>
+
+    <ids-popup id="test-popup" x="0" y="0" align-target="#center-point" align="bottom" animated="true" visible="true" type="menu">
+      <div slot="content">
+        <div class="demo-popup">
+          <ids-text font-size="14" font-weight="bold">My Test Popup</ids-text>
+          <ids-button type="primary">This is Focusable</ids-button>
+        </div>
+      </div>
+    </ids-popup>
+
+    <section id="test-controls" class="fixed-bottom">
+      <ids-layout-grid auto="true">
+        <ids-layout-grid-cell>
+          <ids-radio-group id="align-targets" label="Alignment Targets:">
+            <ids-radio value="none" id="align-targets-option1" label="None (Use Coordinates)"></ids-radio>
+            <ids-radio value="#center-point" id="align-targets-option2" label="Center Point" checked="true"></ids-radio>
+            <ids-radio value="#second-target" id="align-targets-option3" label="Secondary Target"></ids-radio>
+            <ids-radio value="#test-container-target" id="align-targets-option4" label="Test Container Target"></ids-radio>
+          </ids-radio-group>
+          <ids-radio-group id="containment" label="Containment:">
+            <ids-radio value="none" id="containment-option1" label="Body Tag (default)" checked="true"></ids-radio>
+            <ids-radio value="ids-container" id="containment-option2" label="IdsContainer"></ids-radio>
+            <ids-radio value="test-container" id="containment-option3" label="Test Container"></ids-radio>
+          </ids-radio-group>
+        </ids-layout-grid-cell>
+
+        <ids-layout-grid-cell>
+          <ids-text>Alignment Edge Order: <span id="alignment-display">"center, bottom"</span></ids-text>
           <ids-layout-grid auto="true">
             <ids-layout-grid-cell>
-              <div id="x-alignments" class="radio-group">
-                <ids-text font-size="10">X Alignment</ids-text>
-                <input type="radio" class="radio" name="x-alignments" id="x-alignments-option1" value="left"/>
-                <label for="x-alignments-option1" class="radio-label">Left</label>
-                <br/>
-                <input type="radio" class="radio" name="x-alignments" id="x-alignments-option2" value="center" checked="true"/>
-                <label for="x-alignments-option2" class="radio-label">Center</label>
-                <br/>
-                <input type="radio" class="radio" name="x-alignments" id="x-alignments-option3" value="right" />
-                <label for="x-alignments-option3" class="radio-label">Right</label>
-              </div>
+              <ids-radio-group id="x-alignments" label="X Alignment:">
+                <ids-radio value="left" id="x-alignments-option1" label="Left"></ids-radio>
+                <ids-radio value="center" id="x-alignments-option2" label="Center" checked="true"></ids-radio>
+                <ids-radio value="right" id="x-alignments-option3" label="Right"></ids-radio>
+              </ids-radio-group>
             </ids-layout-grid-cell>
             <ids-layout-grid-cell>
-              <div id="y-alignments" class="radio-group">
-                <ids-text font-size="10">Y Alignment</ids-text>
-                <input type="radio" class="radio" name="y-alignments" id="y-alignments-option1" value="top"/>
-                <label for="y-alignments-option1" class="radio-label">Top</label>
-                <br/>
-                <input type="radio" class="radio" name="y-alignments" id="y-alignments-option2" value="center"/>
-                <label for="y-alignments-option2" class="radio-label">Center</label>
-                <br/>
-                <input type="radio" class="radio" name="y-alignments" id="y-alignments-option3" value="bottom" checked="true"/>
-                <label for="y-alignments-option3" class="radio-label">Bottom</label>
-              </div>
+              <ids-radio-group id="y-alignments" label="Y Alignment:">
+                <ids-radio value="top" id="y-alignments-option1" label="Top"></ids-radio>
+                <ids-radio value="center" id="y-alignments-option2" label="Center"></ids-radio>
+                <ids-radio value="bottom" id="y-alignments-option3" label="Bottom" checked="true"></ids-radio>
+              </ids-radio-group>
             </ids-layout-grid-cell>
           </ids-layout-grid>
-        </fieldset>
 
-      </ids-layout-grid-cell>
-      <ids-layout-grid-cell>
-        <fieldset id="xy-controls" class="radio-group">
-          <legend>Offsets</legend>
-          <label for="x-control">X: </label>
-          <input class="ids-input" id="x-control" value="0" />
-          <br />
-          <label for="y-control">Y: </label>
-          <input class="ids-input" id="y-control" value="0" />
-          <br />
-          <input type="checkbox" class="checkbox" name="xy-click-to-set" id="xy-click-to-set-option" checked="true" disabled/>
-          <label for="xy-click-to-set-option" class="radio-label">Click page to set coords</label>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell>
+          <ids-text id="xy-controls">Offsets</ids-text><br />
+          <ids-input id="x-control" value="0" label="X:" compact></ids-input>
+          <ids-input id="y-control" value="0" label="Y:" compact></ids-input>
+          <ids-checkbox id="xy-click-to-set-option" label="Click page to set coords" checked="true" disabled></ids-checkbox>
           <ids-button type="secondary" id="xy-controls-reset">Reset</ids-button>
-        </fieldset>
-      </ids-layout-grid-cell>
-      <ids-layout-grid-cell>
-        <fieldset id="other-controls" class="radio-group">
-          <legend>Other</legend>
-          <input type="checkbox" class="checkbox" name="animated" id="animated-option" checked="true" />
-          <label for="animated-option" class="checkbox-label">Animated</label>
-          <br />
-          <input type="checkbox" class="checkbox" name="visible" id="visible-option" checked="true"/>
-          <label for="visible-option" class="checkbox-label">Visible</label>
-          <br />
-          <input type="checkbox" class="checkbox" name="bleeds" id="bleeds-option" />
-          <label for="bleeds-option" class="checkbox-label">Allow Bleeds</label>
-        </fieldset>
-      </ids-layout-grid-cell>
-    </ids-layout-grid>
-  </section>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell>
+          <ids-text id="other-controls">Other</ids-text><br />
+          <ids-checkbox id="animated-option" label="Animated" checked="true"></ids-checkbox>
+          <ids-checkbox id="visible-option" label="Visible" checked="true"></ids-checkbox>
+          <ids-checkbox id="bleeds-option" label="Allow Bleeds"></ids-checkbox>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+    </section>
+  </ids-container>
 </body>
 </html>

--- a/src/components/ids-popup/demos/test-sandbox.html
+++ b/src/components/ids-popup/demos/test-sandbox.html
@@ -23,7 +23,7 @@
       <ids-text font-size="12" class="align-target" id="center-point">Center Point</ids-text>
     </section>
 
-    <ids-popup id="test-popup" x="0" y="0" align-target="#center-point" align="bottom" animated="true" visible="true" type="menu">
+    <ids-popup id="test-popup" x="0" y="0" align="top, left" animated="true" visible="true" type="menu">
       <div slot="content">
         <div class="demo-popup">
           <ids-text font-size="14" font-weight="bold">My Test Popup</ids-text>
@@ -36,8 +36,8 @@
       <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
           <ids-radio-group id="align-targets" label="Alignment Targets:">
-            <ids-radio value="none" id="align-targets-option1" label="None (Use Coordinates)"></ids-radio>
-            <ids-radio value="#center-point" id="align-targets-option2" label="Center Point" checked="true"></ids-radio>
+            <ids-radio value="none" id="align-targets-option1" label="None (Use Coordinates)" checked="true"></ids-radio>
+            <ids-radio value="#center-point" id="align-targets-option2" label="Center Point"></ids-radio>
             <ids-radio value="#second-target" id="align-targets-option3" label="Secondary Target"></ids-radio>
             <ids-radio value="#test-container-target" id="align-targets-option4" label="Test Container Target"></ids-radio>
           </ids-radio-group>
@@ -53,26 +53,26 @@
           <ids-layout-grid auto="true">
             <ids-layout-grid-cell>
               <ids-radio-group id="x-alignments" label="X Alignment:">
-                <ids-radio value="left" id="x-alignments-option1" label="Left"></ids-radio>
-                <ids-radio value="center" id="x-alignments-option2" label="Center" checked="true"></ids-radio>
+                <ids-radio value="left" id="x-alignments-option1" label="Left" checked="true"></ids-radio>
+                <ids-radio value="center" id="x-alignments-option2" label="Center"></ids-radio>
                 <ids-radio value="right" id="x-alignments-option3" label="Right"></ids-radio>
               </ids-radio-group>
             </ids-layout-grid-cell>
             <ids-layout-grid-cell>
               <ids-radio-group id="y-alignments" label="Y Alignment:">
-                <ids-radio value="top" id="y-alignments-option1" label="Top"></ids-radio>
+                <ids-radio value="top" id="y-alignments-option1" label="Top" checked="true"></ids-radio>
                 <ids-radio value="center" id="y-alignments-option2" label="Center"></ids-radio>
-                <ids-radio value="bottom" id="y-alignments-option3" label="Bottom" checked="true"></ids-radio>
+                <ids-radio value="bottom" id="y-alignments-option3" label="Bottom"></ids-radio>
               </ids-radio-group>
             </ids-layout-grid-cell>
           </ids-layout-grid>
 
         </ids-layout-grid-cell>
         <ids-layout-grid-cell>
-          <ids-text id="xy-controls">Offsets</ids-text><br />
-          <ids-input id="x-control" value="0" label="X:" compact></ids-input>
-          <ids-input id="y-control" value="0" label="Y:" compact></ids-input>
-          <ids-checkbox id="xy-click-to-set-option" label="Click page to set coords" checked="true" disabled></ids-checkbox>
+          <ids-text id="xy-controls">Coordinates</ids-text><br />
+          <ids-input id="x-control" value="0" label="X:" size="sm" compact></ids-input>
+          <ids-input id="y-control" value="0" label="Y:" size="sm" compact></ids-input>
+          <ids-checkbox id="xy-click-to-set-option" label="Click page to set coords" checked="true"></ids-checkbox>
           <ids-button type="secondary" id="xy-controls-reset">Reset</ids-button>
         </ids-layout-grid-cell>
         <ids-layout-grid-cell>

--- a/src/components/ids-popup/demos/test-sandbox.html
+++ b/src/components/ids-popup/demos/test-sandbox.html
@@ -72,7 +72,7 @@
           <ids-text id="xy-controls">Coordinates</ids-text><br />
           <ids-input id="x-control" value="0" label="X:" size="sm" compact></ids-input>
           <ids-input id="y-control" value="0" label="Y:" size="sm" compact></ids-input>
-          <ids-checkbox id="xy-click-to-set-option" label="Click page to set coords" checked="true"></ids-checkbox>
+          <ids-checkbox id="xy-click-to-set-option" label="Click page to set coords"></ids-checkbox>
           <ids-button type="secondary" id="xy-controls-reset">Reset</ids-button>
         </ids-layout-grid-cell>
         <ids-layout-grid-cell>

--- a/src/components/ids-popup/demos/test-sandbox.js
+++ b/src/components/ids-popup/demos/test-sandbox.js
@@ -206,12 +206,4 @@ document.addEventListener('DOMContentLoaded', () => {
       popupEl.setPosition(e.clientX, e.clientY, null, true);
     });
   });
-
-  // After all things on the page are done setting up,
-  // set the initial position of IdsPopup based on form control values.
-  requestAnimationFrame(() => {
-    popupEl.alignTarget = alignTargetGroupEl.value === 'none' ? null : alignTargetGroupEl.value;
-    popupEl.align = `${yAlignGroupEl.value}, ${xAlignGroupEl.value}`;
-    popupEl.setPosition(xControlEl.value, yControlEl.value, null, true);
-  });
 });

--- a/src/components/ids-popup/demos/test-sandbox.js
+++ b/src/components/ids-popup/demos/test-sandbox.js
@@ -1,5 +1,8 @@
 import IdsPopup from '../ids-popup';
 import IdsButton from '../../ids-button/ids-button';
+import IdsCheckbox from '../../ids-checkbox/ids-checkbox';
+import IdsFieldSet from '../../ids-fieldset/ids-fieldset';
+import IdsRadio from '../../ids-radio/ids-radio';
 import IdsInput from '../../ids-input/ids-input';
 import css from '../../../assets/css/ids-popup/test-sandbox.css';
 
@@ -17,11 +20,12 @@ let alignmentDisplayEl;
  * @param {Event} e the change event object
  */
 function targetChangeHandler(e) {
-  popupEl.alignTarget = e.target.value;
-  if (!e.target.value) {
+  if (e.target.value === 'none') {
+    popupEl.alignTarget = null;
     xyControlFieldsetLabelEl.textContent = 'Coordinates';
     xyClickToSetEl.disabled = false;
   } else {
+    popupEl.alignTarget = e.target.value;
     xyControlFieldsetLabelEl.textContent = 'Offsets';
     xyClickToSetEl.disabled = true;
   }
@@ -50,13 +54,11 @@ function containmentChangeHandler(e) {
  * @param {Event} e the change event object
  */
 function xAlignChangeHandler(e) {
-  const currentVal = popupEl.alignX;
   const newVal = e.target.value;
-
-  if (currentVal !== newVal) {
-    popupEl.alignX = newVal;
-  } else {
+  if (newVal !== 'center' && newVal !== popupEl.alignEdge) {
     popupEl.alignEdge = newVal;
+  } else {
+    popupEl.alignX = newVal;
   }
 }
 
@@ -64,35 +66,19 @@ function xAlignChangeHandler(e) {
  * @param {Event} e the change event object
  */
 function yAlignChangeHandler(e) {
-  const currentVal = popupEl.alignY;
   const newVal = e.target.value;
-
-  if (currentVal !== newVal) {
-    popupEl.alignY = newVal;
-  } else {
+  if (newVal !== 'center' && newVal !== popupEl.alignEdge) {
     popupEl.alignEdge = newVal;
+  } else {
+    popupEl.alignY = newVal;
   }
-}
-
-/**
- * @param {Event} e the change event object
- */
-function xPosChangeHandler(e) {
-  popupEl.setPosition(e.target.value, null, null, true);
-}
-
-/**
- * @param {Event} e the change event object
- */
-function yPosChangeHandler(e) {
-  popupEl.setPosition(null, e.target.value, null, true);
 }
 
 /**
  */
 function xyResetHandler() {
-  xControlEl.value = 0;
-  yControlEl.value = 0;
+  xControlEl.value = '0';
+  yControlEl.value = '0';
   popupEl.setPosition(0, 0, null, true);
 }
 
@@ -121,13 +107,13 @@ function bleedsChangeHandler(e) {
 // that can be modified by changing the attribute (tests the MutationObserver/ResizeObserver)
 document.addEventListener('DOMContentLoaded', () => {
   popupEl = document.querySelector('#test-popup');
-  xyControlFieldsetLabelEl = document.querySelector('#xy-controls legend');
+  xyControlFieldsetLabelEl = document.querySelector('#xy-controls');
   xyClickToSetEl = document.querySelector('#xy-click-to-set-option');
   alignmentDisplayEl = document.querySelector('#alignment-display');
 
   // const centerTargetEl = document.querySelector('#center-point');
   const secondTargetEl = document.querySelector('#second-target');
-  const thirdTargetEl = document.querySelector('#third-target');
+  const thirdTargetEl = document.querySelector('#test-container-target');
 
   // This one is centered on the page, but needs a 100px top margin to shift it around
   // centerTargetEl.style.marginTop = '';
@@ -139,47 +125,39 @@ document.addEventListener('DOMContentLoaded', () => {
   // This one is aligned 300px from the top and left viewport edges,
   // as well as allows the size to be controlled (tests some other math)
   thirdTargetEl.style.top = '300px';
-  thirdTargetEl.style.left = '300px';
+  thirdTargetEl.style.left = '350px';
   thirdTargetEl.style.height = '50px';
-  thirdTargetEl.style.width = '50px';
+  thirdTargetEl.style.width = '60px';
+
+  const posChangeHandler = () => {
+    popupEl.setPosition(xControlEl.value, yControlEl.value, null, true);
+  };
 
   // Setup X/Y coordinates/offsets controls
   xControlEl = document.querySelector('#x-control');
-  xControlEl.addEventListener('change', xPosChangeHandler);
+  xControlEl.addEventListener('change', posChangeHandler);
 
   yControlEl = document.querySelector('#y-control');
-  yControlEl.addEventListener('change', yPosChangeHandler);
+  yControlEl.addEventListener('change', posChangeHandler);
 
   const xyResetEl = document.querySelector('#xy-controls-reset');
   xyResetEl.addEventListener('click', xyResetHandler);
 
   // Setup align-target controls
   const alignTargetGroupEl = document.querySelector('#align-targets');
-  const targetRadioEls = alignTargetGroupEl.querySelectorAll('input[type="radio"]');
-  targetRadioEls.forEach((radioEl) => {
-    radioEl.addEventListener('change', targetChangeHandler);
-  });
+  alignTargetGroupEl.addEventListener('change', targetChangeHandler);
 
   // Setup containment controls
   const containmentGroupEl = document.querySelector('#containment');
-  const containmentRadioEls = containmentGroupEl.querySelectorAll('input[type="radio"]');
-  containmentRadioEls.forEach((radioEl) => {
-    radioEl.addEventListener('change', containmentChangeHandler);
-  });
+  containmentGroupEl.addEventListener('change', containmentChangeHandler);
 
   // Setup x-alignment controls
   const xAlignGroupEl = document.querySelector('#x-alignments');
-  const xAlignRadioEls = xAlignGroupEl.querySelectorAll('input[type="radio"]');
-  xAlignRadioEls.forEach((radioEl) => {
-    radioEl.addEventListener('click', xAlignChangeHandler);
-  });
+  xAlignGroupEl.addEventListener('click', xAlignChangeHandler);
 
   // Setup y-alignment controls
   const yAlignGroupEl = document.querySelector('#y-alignments');
-  const yAlignRadioEls = yAlignGroupEl.querySelectorAll('input[type="radio"]');
-  yAlignRadioEls.forEach((radioEl) => {
-    radioEl.addEventListener('click', yAlignChangeHandler);
-  });
+  yAlignGroupEl.addEventListener('click', yAlignChangeHandler);
 
   // Setup toggles
   const animatedControlEl = document.querySelector('#animated-option');
@@ -199,7 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (changedOnce || mutation.type !== 'attributes') {
         return;
       }
-      alignmentDisplayEl.textContent = `Edge order: "${popupEl.align}"`;
+      alignmentDisplayEl.textContent = `"${popupEl.align}"`;
       changedOnce = true;
     });
   });
@@ -218,14 +196,22 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      const withinFieldset = e.target.closest('fieldset');
+      const withinFieldset = e.target.closest('ids-radio-group');
       if (withinFieldset) {
         return;
       }
 
-      xControlEl.value = e.clientX;
-      yControlEl.value = e.clientY;
+      xControlEl.value = `${e.clientX}`;
+      yControlEl.value = `${e.clientY}`;
       popupEl.setPosition(e.clientX, e.clientY, null, true);
     });
+  });
+
+  // After all things on the page are done setting up,
+  // set the initial position of IdsPopup based on form control values.
+  requestAnimationFrame(() => {
+    popupEl.alignTarget = alignTargetGroupEl.value === 'none' ? null : alignTargetGroupEl.value;
+    popupEl.align = `${yAlignGroupEl.value}, ${xAlignGroupEl.value}`;
+    popupEl.setPosition(xControlEl.value, yControlEl.value, null, true);
   });
 });

--- a/src/components/ids-popup/ids-popup.js
+++ b/src/components/ids-popup/ids-popup.js
@@ -56,12 +56,6 @@ export default class IdsPopup extends Base {
     this.#setInitialState();
     this.shouldUpdate = true;
     this.#attachEventHandlers();
-
-    // Stagger visibility and initial placement, if applicable
-    window.requestAnimationFrame(() => {
-      this.refreshVisibility();
-      this.place();
-    });
   }
 
   disconnectedCallback() {
@@ -965,7 +959,7 @@ export default class IdsPopup extends Base {
   /**
    * Hides the Popup
    * @async
-   * @returns {Promise} resolved once hiding and animating the Popup is completed.
+   * @returns {void}
    */
   async hide() {
     if (this.visible) {

--- a/src/components/ids-popup/ids-popup.js
+++ b/src/components/ids-popup/ids-popup.js
@@ -6,7 +6,6 @@ import {
   getClosest,
   getClosestRootNode,
   getEditableRect,
-  processAnimationFrame,
   waitForTransitionEnd,
 } from '../../utils/ids-dom-utils/ids-dom-utils';
 
@@ -852,7 +851,7 @@ export default class IdsPopup extends Base {
     if (this.#visible && !cl.contains('open')) {
       await this.show();
     }
-    if (!this.#visible && cl.contains('visible')) {
+    if (!this.#visible && !this.hasAttribute('aria-hidden')) {
       await this.hide();
     }
   }
@@ -933,13 +932,11 @@ export default class IdsPopup extends Base {
       return;
     }
 
-    // Change `display: none;` to `display: block;`
-    this.container.classList.add('visible');
+    this.removeAttribute('aria-hidden');
+
     if (this.isFlipped) {
       this.container.classList.add('flipped');
     }
-
-    await processAnimationFrame();
 
     // Change transparency/visibility
     this.container.classList.add('open');
@@ -996,7 +993,7 @@ export default class IdsPopup extends Base {
       this.isFlipped = false;
     }
 
-    this.container.classList.remove('visible');
+    this.setAttribute('aria-hidden', 'true');
   }
 
   /**

--- a/src/components/ids-popup/ids-popup.js
+++ b/src/components/ids-popup/ids-popup.js
@@ -926,6 +926,13 @@ export default class IdsPopup extends Base {
       return;
     }
 
+    // Fix location first
+    this.place();
+
+    // If an arrow is displayed, place it correctly
+    this.#setArrowDirection('', this.arrow);
+    this.placeArrow();
+
     this.removeAttribute('aria-hidden');
 
     if (this.isFlipped) {
@@ -939,6 +946,9 @@ export default class IdsPopup extends Base {
       await waitForTransitionEnd(this.container, 'opacity');
     }
 
+    // Unblur if needed
+    this.#correct3dMatrix();
+
     this.triggerEvent('show', this, {
       bubbles: true,
       detail: {
@@ -946,13 +956,6 @@ export default class IdsPopup extends Base {
       }
     });
 
-    this.place();
-
-    // If an arrow is displayed, place it correctly.
-    this.#setArrowDirection('', this.arrow);
-    this.placeArrow();
-
-    this.#correct3dMatrix();
     this.open = true;
   }
 

--- a/src/components/ids-popup/ids-popup.js
+++ b/src/components/ids-popup/ids-popup.js
@@ -133,9 +133,8 @@ export default class IdsPopup extends Base {
    * CSS property, if applicable.
    */
   #fixPlacementOnResize() {
-    this.place().then(() => {
-      this.#fix3dMatrixOnResize();
-    });
+    this.place();
+    this.#fix3dMatrixOnResize();
   }
 
   /**
@@ -846,17 +845,16 @@ export default class IdsPopup extends Base {
   /**
    * Runs the show/hide routines of the Popup based on current visiblity state.
    * @async
-   * @returns {Promise} from the show/hide process
+   * @returns {void}
    */
   async refreshVisibility() {
     const cl = this.container.classList;
     if (this.#visible && !cl.contains('open')) {
-      return this.show();
+      await this.show();
     }
     if (!this.#visible && cl.contains('visible')) {
-      return this.hide();
+      await this.hide();
     }
-    return new Promise((resolve) => { resolve(); });
   }
 
   /**
@@ -913,17 +911,16 @@ export default class IdsPopup extends Base {
 
   /**
    * Sets an X/Y position and optionally shows/places the Popup
-   * @async
    * @param {number} x the x coordinate/offset value
    * @param {number} y the y coordinate/offset value
    * @param {boolean} doShow true if the Popup should be displayed before placing
    * @param {boolean} doPlacement true if the component should run its placement routine
    */
-  async setPosition(x = null, y = null, doShow = null, doPlacement = null) {
+  setPosition(x = null, y = null, doShow = null, doPlacement = null) {
     if (!Number.isNaN(x)) this.x = x;
     if (!Number.isNaN(y)) this.y = y;
     if (doShow) this.visible = true;
-    if (doPlacement) await this.place();
+    if (doPlacement) this.place();
   }
 
   /**
@@ -958,7 +955,7 @@ export default class IdsPopup extends Base {
       }
     });
 
-    await this.place();
+    this.place();
 
     // If an arrow is displayed, place it correctly.
     this.#setArrowDirection('', this.arrow);
@@ -1004,26 +1001,21 @@ export default class IdsPopup extends Base {
 
   /**
    * Runs the configured placement routine for the Popup
-   * @async
-   * @returns {Promise} resolved once placement has finished
+   * @returns {void}
    */
-  async place() {
-    return new Promise((resolve) => {
-      if (this.visible) {
-        this.#clearPlacement();
-        if (this.positionStyle === 'viewport') {
-          this.#placeInViewport();
+  place() {
+    if (this.visible) {
+      if (this.positionStyle === 'viewport') {
+        this.#placeInViewport();
+      } else {
+        const { alignTarget } = this;
+        if (!alignTarget) {
+          this.#placeAtCoords();
         } else {
-          const { alignTarget } = this;
-          if (!alignTarget) {
-            this.#placeAtCoords();
-          } else {
-            this.#placeAgainstTarget();
-          }
+          this.#placeAgainstTarget();
         }
-        resolve();
       }
-    });
+    }
   }
 
   /**

--- a/src/components/ids-popup/ids-popup.scss
+++ b/src/components/ids-popup/ids-popup.scss
@@ -15,7 +15,7 @@
 // When a popup is not visible, `aria-hidden="true"` is applied to the host element.
 // The element is still in document flow in this case, so we need to prevent clicks
 // from occuring inside the "invisible" Popup
-:host([aria-hidden="true"]) {
+:host([aria-hidden='true']) {
   pointer-events: none;
 }
 

--- a/src/components/ids-popup/ids-popup.scss
+++ b/src/components/ids-popup/ids-popup.scss
@@ -12,11 +12,24 @@
   position: static;
 }
 
+// When a popup is not visible, `aria-hidden="true"` is applied to the host element.
+// The element is still in document flow in this case, so we need to prevent clicks
+// from occuring inside the "invisible" Popup
+:host([aria-hidden="true"]) {
+  pointer-events: none;
+}
+
 .ids-popup {
   @include antialiased();
   @include z-3000();
 
   position: relative;
+
+  // This style is always applied when IdsPopup is not visible
+  // (goes hand-in-hand with `aria-hidden="true"` on the host element
+  &:not(.open) {
+    pointer-events: none;
+  }
 
   // Arrow definition
   .arrow {

--- a/src/components/ids-popup/ids-popup.scss
+++ b/src/components/ids-popup/ids-popup.scss
@@ -16,7 +16,6 @@
   @include antialiased();
   @include z-3000();
 
-  display: none;
   position: relative;
 
   // Arrow definition
@@ -98,11 +97,6 @@
         top: -9px;
       }
     }
-  }
-
-  // Actually renders the popup, but doesn't "unhide" it
-  &.visible {
-    display: block;
   }
 
   // Animates X/Y movement, fade in/out of the popup.

--- a/src/components/ids-time-picker/ids-time-picker.js
+++ b/src/components/ids-time-picker/ids-time-picker.js
@@ -398,7 +398,6 @@ export default class IdsTimePicker extends Base {
     const { triggerField, popup, triggerButton } = this.elements;
 
     if (!this.isOpen) {
-      popup.visible = true;
       const { bottom } = triggerButton.getBoundingClientRect();
       const positionBottom = (bottom + 100) < window.innerHeight;
 
@@ -406,6 +405,7 @@ export default class IdsTimePicker extends Base {
       popup.arrowTarget = triggerButton;
       popup.align = positionBottom ? 'bottom, left' : 'top, left';
       popup.arrow = positionBottom ? 'bottom' : 'top';
+      popup.visible = true;
 
       this.addOpenEvents();
     }

--- a/src/utils/ids-dom-utils/ids-dom-utils.js
+++ b/src/utils/ids-dom-utils/ids-dom-utils.js
@@ -59,14 +59,6 @@ export function getClosest(node, selector) {
 }
 
 /**
- * Promise-based function that waits for a single paint cycle to complete
- * @returns {Promise} resolved one paint cycle after it's fired
- */
-export const processAnimationFrame = () => new Promise((resolve) => {
-  requestAnimationFrame(resolve);
-});
-
-/**
  * Changes a CSS property with a transition,
  * @param {HTMLElement} el the element to act on
  * @param {string} property the CSS property with an attached transition to manipulate

--- a/src/utils/ids-dom-utils/ids-dom-utils.js
+++ b/src/utils/ids-dom-utils/ids-dom-utils.js
@@ -59,6 +59,14 @@ export function getClosest(node, selector) {
 }
 
 /**
+ * Promise-based function that waits for a single paint cycle to complete
+ * @returns {Promise} resolved one paint cycle after it's fired
+ */
+export const processAnimationFrame = () => new Promise((resolve) => {
+  requestAnimationFrame(resolve);
+});
+
+/**
  * Changes a CSS property with a transition,
  * @param {HTMLElement} el the element to act on
  * @param {string} property the CSS property with an attached transition to manipulate
@@ -69,7 +77,7 @@ export function transitionToPromise(el, property, value) {
   return new Promise((resolve) => {
     el.style[property] = value;
     const transitionEnded = (e) => {
-      if (e.propertyName !== property) return;
+      if (e.propertyName !== property) resolve();
       el.removeEventListener('transitionend', transitionEnded);
       resolve();
     };
@@ -87,7 +95,7 @@ export function transitionToPromise(el, property, value) {
 export function waitForTransitionEnd(el, property) {
   return new Promise((resolve) => {
     const transitionEnded = (e) => {
-      if (e.propertyName !== property) return;
+      if (e.propertyName !== property) resolve();
       el.removeEventListener('transitionend', transitionEnded);
       resolve();
     };

--- a/test/ids-about/ids-about-func-test.js.snap
+++ b/test/ids-about/ids-about-func-test.js.snap
@@ -13,7 +13,7 @@ exports[`IdsAbout Component (using properties) should render 1`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 2`] = `
-"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\"><ids-text slot=\\"product\\" type=\\"p\\">Controls 4.0.0</ids-text><ids-modal-button cancel=\\"\\" slot=\\"buttons\\" type=\\"tertiary\\" css-class=\\"ids-icon-button ids-modal-icon-button\\"><span class=\\"audible\\">Close modal</span><ids-icon slot=\\"icon\\" icon=\\"close\\"></ids-icon></ids-modal-button><ids-text slot=\\"device\\" type=\\"p\\">
+"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"><ids-text slot=\\"product\\" type=\\"p\\">Controls 4.0.0</ids-text><ids-modal-button cancel=\\"\\" slot=\\"buttons\\" type=\\"tertiary\\" css-class=\\"ids-icon-button ids-modal-icon-button\\"><span class=\\"audible\\">Close modal</span><ids-icon slot=\\"icon\\" icon=\\"close\\"></ids-icon></ids-modal-button><ids-text slot=\\"device\\" type=\\"p\\">
         <span>Platform : </span><br>
         <span>Mobile : false</span><br>
         <span>Browser :  jsdom (16.7.0)</span><br>
@@ -25,7 +25,7 @@ exports[`IdsAbout Component (using properties) should render 2`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 3`] = `
-"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\" style=\\"z-index: 1020;\\"><ids-text slot=\\"product\\" type=\\"p\\">Controls 4.0.0</ids-text><ids-modal-button cancel=\\"\\" slot=\\"buttons\\" type=\\"tertiary\\" css-class=\\"ids-icon-button ids-modal-icon-button\\"><span class=\\"audible\\">Close modal</span><ids-icon slot=\\"icon\\" icon=\\"close\\"></ids-icon></ids-modal-button><ids-text slot=\\"device\\" type=\\"p\\">
+"<ids-about id=\\"test-about-component\\" product-version=\\"4.0.0\\" product-name=\\"Controls\\" copyright-year=\\"2022\\" device-specs=\\"true\\" use-default-copyright=\\"true\\" aria-label=\\" Controls 4.0.0\\" role=\\"dialog\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"><ids-text slot=\\"product\\" type=\\"p\\">Controls 4.0.0</ids-text><ids-modal-button cancel=\\"\\" slot=\\"buttons\\" type=\\"tertiary\\" css-class=\\"ids-icon-button ids-modal-icon-button\\"><span class=\\"audible\\">Close modal</span><ids-icon slot=\\"icon\\" icon=\\"close\\"></ids-icon></ids-modal-button><ids-text slot=\\"device\\" type=\\"p\\">
         <span>Platform : </span><br>
         <span>Mobile : false</span><br>
         <span>Browser :  jsdom (16.7.0)</span><br>

--- a/test/ids-contextual-action-panel/ids-contextual-action-panel-func-test.js.snap
+++ b/test/ids-contextual-action-panel/ids-contextual-action-panel-func-test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`IdsContextualActionPanel Component renders correctly 1`] = `"<ids-contextual-action-panel role=\\"dialog\\"></ids-contextual-action-panel>"`;
 
-exports[`IdsContextualActionPanel Component renders correctly 2`] = `"<ids-contextual-action-panel role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\"></ids-contextual-action-panel>"`;
+exports[`IdsContextualActionPanel Component renders correctly 2`] = `"<ids-contextual-action-panel role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"></ids-contextual-action-panel>"`;
 
-exports[`IdsContextualActionPanel Component renders correctly 3`] = `"<ids-contextual-action-panel role=\\"dialog\\" style=\\"z-index: 1020;\\"></ids-contextual-action-panel>"`;
+exports[`IdsContextualActionPanel Component renders correctly 3`] = `"<ids-contextual-action-panel role=\\"dialog\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"></ids-contextual-action-panel>"`;

--- a/test/ids-dropdown/ids-dropdown-func-test.js.snap
+++ b/test/ids-dropdown/ids-dropdown-func-test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`IdsDropdown Component renders correctly 1`] = `
 "<ids-dropdown id=\\"dropdown-1\\" label=\\"Normal Dropdown\\" value=\\"opt2\\" dirty-tracker=\\"true\\" role=\\"combobox\\" aria-expanded=\\"false\\" aria-autocomplete=\\"list\\" aria-haspopup=\\"listbox\\" aria-description=\\"Press Down arrow to select\\" aria-controls=\\"ids-list-box-dropdown-1\\">
-      <ids-list-box id=\\"ids-list-box-dropdown-1\\" role=\\"listbox\\" tabindex=\\"0\\">
+      <ids-list-box id=\\"ids-list-box-dropdown-1\\" aria-labelledby=\\"dropdown-1\\" role=\\"listbox\\">
         <ids-list-box-option value=\\"opt1\\" id=\\"opt1\\" role=\\"option\\" tabindex=\\"-1\\">Option One</ids-list-box-option>
-        <ids-list-box-option value=\\"opt2\\" id=\\"opt2\\" aria-selected=\\"true\\" class=\\"is-selected\\" role=\\"option\\" tabindex=\\"-1\\">Option Two</ids-list-box-option>
+        <ids-list-box-option value=\\"opt2\\" id=\\"opt2\\" aria-selected=\\"true\\" class=\\"is-selected\\" tabindex=\\"-1\\" role=\\"option\\">Option Two</ids-list-box-option>
         <ids-list-box-option value=\\"opt3\\" id=\\"opt3\\" role=\\"option\\" tabindex=\\"-1\\">Option Three</ids-list-box-option>
         <ids-list-box-option value=\\"opt4\\" id=\\"opt4\\" role=\\"option\\" tabindex=\\"-1\\">Option Four</ids-list-box-option>
         <ids-list-box-option value=\\"opt5\\" id=\\"opt5\\" role=\\"option\\" tabindex=\\"-1\\">Option Five</ids-list-box-option>

--- a/test/ids-dropdown/ids-dropdown-func-test.js.snap
+++ b/test/ids-dropdown/ids-dropdown-func-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`IdsDropdown Component renders correctly 1`] = `
 "<ids-dropdown id=\\"dropdown-1\\" label=\\"Normal Dropdown\\" value=\\"opt2\\" dirty-tracker=\\"true\\" role=\\"combobox\\" aria-expanded=\\"false\\" aria-autocomplete=\\"list\\" aria-haspopup=\\"listbox\\" aria-description=\\"Press Down arrow to select\\" aria-controls=\\"ids-list-box-dropdown-1\\">
-      <ids-list-box id=\\"ids-list-box-dropdown-1\\" aria-labelledby=\\"dropdown-1\\" role=\\"listbox\\">
+      <ids-list-box id=\\"ids-list-box-dropdown-1\\" aria-label=\\"Listbox\\" role=\\"listbox\\">
         <ids-list-box-option value=\\"opt1\\" id=\\"opt1\\" role=\\"option\\" tabindex=\\"-1\\">Option One</ids-list-box-option>
         <ids-list-box-option value=\\"opt2\\" id=\\"opt2\\" aria-selected=\\"true\\" class=\\"is-selected\\" tabindex=\\"-1\\" role=\\"option\\">Option Two</ids-list-box-option>
         <ids-list-box-option value=\\"opt3\\" id=\\"opt3\\" role=\\"option\\" tabindex=\\"-1\\">Option Three</ids-list-box-option>

--- a/test/ids-editor/ids-editor-e2e-test.js
+++ b/test/ids-editor/ids-editor-e2e-test.js
@@ -14,7 +14,7 @@ describe('Ids Editor e2e Tests', () => {
   it('should pass Axe accessibility tests', async () => {
     await page.setBypassCSP(true);
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
-    await expect(page).toPassAxeTests({ disabledRules: ['nested-interactive'] });
+    await expect(page).toPassAxeTests({ disabledRules: ['aria-valid-attr', 'nested-interactive'] });
   });
 
   it('should make text bold, italic, underline, strikethrough and clearformatting', async () => {

--- a/test/ids-message/ids-message-func-test.js.snap
+++ b/test/ids-message/ids-message-func-test.js.snap
@@ -8,14 +8,14 @@ exports[`IdsMessage Component (using properties) should render 1`] = `
 `;
 
 exports[`IdsMessage Component (using properties) should render 2`] = `
-"<ids-message id=\\"test-message\\" message-title=\\"Lost Connection\\" aria-label=\\"error: Lost Connection\\" status=\\"error\\" role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\"><ids-text slot=\\"title\\" type=\\"h2\\" font-size=\\"24\\">Lost Connection</ids-text><div>This application has experienced a system error
+"<ids-message id=\\"test-message\\" message-title=\\"Lost Connection\\" aria-label=\\"error: Lost Connection\\" status=\\"error\\" role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"><ids-text slot=\\"title\\" type=\\"h2\\" font-size=\\"24\\">Lost Connection</ids-text><div>This application has experienced a system error
   due to the lack of internet access. Please restart the application in order to proceed.</div>
   <ids-modal-button slot=\\"buttons\\" type=\\"secondary\\" id=\\"my-message-cancel\\" cancel=\\"\\">Cancel</ids-modal-button>
   <ids-modal-button slot=\\"buttons\\" type=\\"primary\\" id=\\"my-message-confirm\\">Confirm</ids-modal-button></ids-message>"
 `;
 
 exports[`IdsMessage Component (using properties) should render 3`] = `
-"<ids-message id=\\"test-message\\" message-title=\\"Lost Connection\\" aria-label=\\"error: Lost Connection\\" status=\\"error\\" role=\\"dialog\\" style=\\"z-index: 1020;\\"><ids-text slot=\\"title\\" type=\\"h2\\" font-size=\\"24\\">Lost Connection</ids-text><div>This application has experienced a system error
+"<ids-message id=\\"test-message\\" message-title=\\"Lost Connection\\" aria-label=\\"error: Lost Connection\\" status=\\"error\\" role=\\"dialog\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"><ids-text slot=\\"title\\" type=\\"h2\\" font-size=\\"24\\">Lost Connection</ids-text><div>This application has experienced a system error
   due to the lack of internet access. Please restart the application in order to proceed.</div>
   <ids-modal-button slot=\\"buttons\\" type=\\"secondary\\" id=\\"my-message-cancel\\" cancel=\\"\\">Cancel</ids-modal-button>
   <ids-modal-button slot=\\"buttons\\" type=\\"primary\\" id=\\"my-message-confirm\\">Confirm</ids-modal-button></ids-message>"

--- a/test/ids-modal/ids-modal-func-test.js.snap
+++ b/test/ids-modal/ids-modal-func-test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`IdsModal Component renders correctly 1`] = `"<ids-modal role=\\"dialog\\"></ids-modal>"`;
 
-exports[`IdsModal Component renders correctly 2`] = `"<ids-modal role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\"></ids-modal>"`;
+exports[`IdsModal Component renders correctly 2`] = `"<ids-modal role=\\"dialog\\" visible=\\"\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"></ids-modal>"`;
 
-exports[`IdsModal Component renders correctly 3`] = `"<ids-modal role=\\"dialog\\" style=\\"z-index: 1020;\\"></ids-modal>"`;
+exports[`IdsModal Component renders correctly 3`] = `"<ids-modal role=\\"dialog\\" style=\\"z-index: 1020;\\" captures-focus=\\"true\\"></ids-modal>"`;

--- a/test/ids-popup/ids-popup-func-test.js
+++ b/test/ids-popup/ids-popup-func-test.js
@@ -619,12 +619,14 @@ describe('IdsPopup Component', () => {
     popup.visible = true;
     popup.show();
     await wait(200);
-    expect(popup.container.classList.contains('visible')).toBeTruthy();
+    expect(popup.hasAttribute('aria-hidden')).toBeFalsy();
+    expect(popup.hasAttribute('visible')).toBeTruthy();
 
     popup.visible = false;
     popup.hide();
     await wait(300);
-    expect(popup.container.classList.contains('visible')).toBeFalsy();
+    expect(popup.hasAttribute('aria-hidden')).toBeTruthy();
+    expect(popup.hasAttribute('visible')).toBeFalsy();
   });
 
   it('can enable/disable container bleed', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes some general improvements to the hide/show/place methods in IdsPopup:
- Animation between calls to `place()` is now respected properly when `animated` attribute is true
- Dependency on IdsRenderLoop for show/hide has been removed in favor of use of `async/await` and waiting for CSS Transitions to complete when animations are enabled
- Removed extraneous awaits/promises/etc
- When `animated` is false, time-staggered waiting for CSS animations to complete is bypassed.  This makes for faster/instantaneous reaction from things like tooltips/menus on show/hide, compared to a slight delay that used to exist.

This PR doesn't address some of the calculation problems with placement that still need fixing as part of #565.

**Related github/jira issue (required)**:
Partially Addresses #565

**Steps necessary to review your pull request (required)**:
Pull/Build/Run... then test these scenarios:

- Open http://localhost:4300/ids-popup and make sure the Popup toggles and opens in the correct position (to the right of the button)
- Smoke test http://localhost:4300/ids-popup/test-sandbox.html and make sure all configurations make sense (behavior is identical to main but the "default" configuration is now to use coordinates with top/left alignment).  All toggles should work and auto-update the component state.
- Open http://localhost:4300/ids-lookup/ and open the first Lookup Modal using its trigger button.  When the modal opens, it should not be blurry (this component is not fully implemented so the selections may not behave as expected).
- Smoke test http://localhost:4300/ids-contextual-action-panel/ (its behavior should be identical to Main)
- Smoke test http://localhost:4300/ids-menu-button (also should be identical)
- Smoke test http://localhost:4300/ids-dropdown (especially test the Dropdowns in the middle, which had some clicking/usability bugs initially after these fixes.  All behavior should be identical to main)

One test was adjusted but otherwise all previous tests should pass

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
