### PR TITLE
IdsPopup: Implement 'onPlace' callback

### DIFF
--- a/src/components/ids-popup/README.md
+++ b/src/components/ids-popup/README.md
@@ -184,6 +184,20 @@ If we decide to remove containment by the element, we can simply set it back to 
 popup.containingElem = document.querySelector('ids-container');
 ```
 
+### Alter placement programmatically
+
+In some cases, you may want to slightly adjust the values provided by the built-in placement methods.  The `onPlace` callback can be implemented for this purpose:
+
+```js
+popup.onPlace = (popupRect) => {
+    popupRect.x += 100;
+    popupRect.y += 50;
+    return popupRect;
+}
+```
+
+The `popupRect` argument provides access to the editable [`DOMRect`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect) object that the IdsPopup uses to place itself.  The callback returns the DOMRect with modified values.
+
 ## Usage Tips
 
 - When making a Popup that is placed in reference to an adjacent element, it must be placed AFTER it in the DOM. Placing it BEFORE the adjacent element can cause its placement to be incorrect on its first render.

--- a/src/components/ids-popup/demos/on-place.html
+++ b/src/components/ids-popup/demos/on-place.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+</head>
+
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h1">Popup (with onPlace callback)</ids-text><br/>
+        <ids-text>This IdsPopup implements an `onPlace` callback that logs x/y to the dev tools console.<br />
+          It also moves 50px down and 100px to the right from where it would have normally been placed.</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-button id="popup-trigger-btn" type="secondary">
+          <span slot="text">Trigger a Popup</span>
+        </ids-button>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-popup x="15" y="0" align-target="#popup-trigger-btn" align="right" animated="true" type="menu" id="popup-1">
+      <div slot="content">
+        <div class="demo-popup">
+          <ids-text font-size="12" type="span">My Popup Content</ids-text>
+        </div>
+      </div>
+    </ids-popup>
+  </ids-container>
+</body>
+
+</html>

--- a/src/components/ids-popup/demos/on-place.js
+++ b/src/components/ids-popup/demos/on-place.js
@@ -1,0 +1,27 @@
+// Supporting components
+import IdsPopup from '../ids-popup';
+import css from '../../../assets/css/ids-popup/index.css';
+
+const cssLink = `<link href="${css}" rel="stylesheet">`;
+document.querySelector('head').insertAdjacentHTML('afterbegin', cssLink);
+
+document.addEventListener('DOMContentLoaded', () => {
+  const popup = document.querySelector('#popup-1');
+  if (!popup) {
+    return;
+  }
+
+  // Implement `onPlace` callback to alter popup values and provide logging
+  popup.onPlace = (popupRect) => {
+    // eslint-disable-next-line
+    console.log('Before `onPlace` occurs:', popupRect.x, popupRect.y);
+
+    popupRect.x += 100;
+    popupRect.y += 50;
+
+    // eslint-disable-next-line
+    console.log('After `onPlace` occurs:', popupRect.x, popupRect.y);
+
+    return popupRect;
+  };
+});

--- a/src/components/ids-popup/ids-popup.js
+++ b/src/components/ids-popup/ids-popup.js
@@ -1054,6 +1054,11 @@ export default class IdsPopup extends Base {
     // Account for absolute-positioned parents
     popupRect = this.#removeAbsoluteParentDistance(this.parentNode, popupRect);
 
+    // Make user-defined adjustments, if applicable
+    if (typeof this.onPlace === 'function') {
+      popupRect = this.onPlace(popupRect);
+    }
+
     this.#renderPlacementInPixels(popupRect);
   }
 
@@ -1164,6 +1169,11 @@ export default class IdsPopup extends Base {
     // Account for absolute-positioned parents
     popupRect = this.#removeAbsoluteParentDistance(this.parentNode, popupRect);
 
+    // Make user-defined adjustments, if applicable
+    if (typeof this.onPlace === 'function') {
+      popupRect = this.onPlace(popupRect);
+    }
+
     this.#renderPlacementInPixels(popupRect);
   }
 
@@ -1173,6 +1183,16 @@ export default class IdsPopup extends Base {
    */
   #placeInViewport() {
     this.#renderPlacementWithTransform();
+  }
+
+  /**
+   * Optional callback that can be used to adjust the Popup's placement
+   * after all internal adjustments are made.
+   * @param {DOMRect} popupRect a Rect object representing the current state of the popup.
+   * @returns {object} an adjusted Rect object with "nudged" coordinates.
+   */
+  onPlace(popupRect) {
+    return popupRect;
   }
 
   /**

--- a/test/ids-popup/ids-popup-func-test.js
+++ b/test/ids-popup/ids-popup-func-test.js
@@ -879,4 +879,20 @@ describe('IdsPopup Component', () => {
       expect(e).toBeDefined();
     }
   });
+
+  it('can alter placement values using the onPlace callback', async () => {
+    popup.onPlace = jest.fn(() => ({
+      x: 300,
+      y: 300,
+      width: 50,
+      height: 50,
+      top: 300,
+      right: 350,
+      bottom: 350,
+      left: 300
+    }));
+    popup.visible = true;
+
+    expect(popup.onPlace.mock.calls.length).toBe(1);
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR implements a simple callback that allows external changes to the DOMRect object that determines the Popup Position, along with a demo/test for the functionality.

**Related github/jira issue (required)**:
Closes #546 

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4300/ids-popup/on-place.html
- Click the button to toggle the Popup.  Its position should be shifted to the right/down from its normal placement.
- See in dev tools console the before/after values.
- Also see the new test should pass

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
