### PR TITLE
623 - IdsDatepicker/IdsTimepicker: fix not able to reset value

### DIFF
--- a/src/components/ids-date-picker/demos/axe.html
+++ b/src/components/ids-date-picker/demos/axe.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Date Picker AXE Test</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid cols="2" gap="sm">
+      <ids-layout-grid-cell col-start="1" row-start="1">
+        <ids-date-picker id="datepicker-axe" label="Date Field" value="3/4/2016"></ids-date-picker>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-date-picker/ids-date-picker.js
+++ b/src/components/ids-date-picker/ids-date-picker.js
@@ -420,6 +420,12 @@ class IdsDatePicker extends Base {
       });
     }
 
+    // Input value change triggers component value change
+    this.offEvent('change.date-picker-input');
+    this.onEvent('change.date-picker-input', this.#triggerField, (e) => {
+      this.setAttribute(attributes.VALUE, e.detail.value);
+    });
+
     return this;
   }
 

--- a/src/components/ids-time-picker/demos/index.html
+++ b/src/components/ids-time-picker/demos/index.html
@@ -21,7 +21,7 @@
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-time-picker label="Uses Current Locale"></ids-time-picker>
+        <ids-time-picker label="Uses Current Locale" id="e2e-timepicker-locale"></ids-time-picker>
         <ids-time-picker label="12 Hour - hh:mm:ss a" format="hh:mm:ss a" value="10:30:00 AM"></ids-time-picker>
         <ids-time-picker label="12 Hour - hh:mm:ss" format="hh:mm:ss" value="10:30:00"></ids-time-picker>
         <ids-time-picker label="12 Hour - hh:mm" format="hh:mm" value="10:30"></ids-time-picker>

--- a/src/components/ids-time-picker/ids-time-picker.js
+++ b/src/components/ids-time-picker/ids-time-picker.js
@@ -648,6 +648,12 @@ export default class IdsTimePicker extends Base {
       }
     });
 
+    // Input value change triggers component value change
+    this.offEvent('change.time-picker-input');
+    this.onEvent('change.time-picker-input', this.elements.triggerField, (e) => {
+      this.setAttribute(attributes.VALUE, e.detail.value);
+    });
+
     return this;
   }
 

--- a/test/ids-date-picker/ids-date-picker-e2e-test.js
+++ b/test/ids-date-picker/ids-date-picker-e2e-test.js
@@ -681,7 +681,7 @@ describe('Ids Date Picker e2e Tests', () => {
     expect(value).toEqual('1/2/2021 - 1/25/2021');
   });
 
-  it.only('should change value on input value change', async () => {
+  it('should change value on input value change', async () => {
     // Set value to the input
     await page.$eval(
       '#e2e-datepicker-required',

--- a/test/ids-date-picker/ids-date-picker-e2e-test.js
+++ b/test/ids-date-picker/ids-date-picker-e2e-test.js
@@ -1,19 +1,16 @@
 describe('Ids Date Picker e2e Tests', () => {
   const url = 'http://localhost:4444/ids-date-picker';
+  const axeUrl = `${url}/axe.html`;
 
-  beforeAll(async () => {
-    await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
+  it('should pass Axe accessibility tests', async () => {
+    await page.setBypassCSP(true);
+    await page.goto(axeUrl, { waitUntil: ['networkidle2', 'load'] });
+    await expect(page).toPassAxeTests();
   });
 
   it('should not have errors', async () => {
-    await expect(page.title()).resolves.toMatch('IDS Date Picker Component');
-  });
-
-  // @TODO: Revisit and figure out accessibility issues
-  it.skip('should pass Axe accessibility tests', async () => {
-    await page.setBypassCSP(true);
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
-    await expect(page).toPassAxeTests();
+    await expect(page.title()).resolves.toMatch('IDS Date Picker Component');
   });
 
   it('should handle calendar popup events', async () => {

--- a/test/ids-date-picker/ids-date-picker-e2e-test.js
+++ b/test/ids-date-picker/ids-date-picker-e2e-test.js
@@ -680,4 +680,32 @@ describe('Ids Date Picker e2e Tests', () => {
     value = await page.$eval('#e2e-range-picker', (el) => el?.value);
     expect(value).toEqual('1/2/2021 - 1/25/2021');
   });
+
+  it.only('should change value on input value change', async () => {
+    // Set value to the input
+    await page.$eval(
+      '#e2e-datepicker-required',
+      (el) => el?.container.querySelector('ids-trigger-field')?.setAttribute('value', '4/5/2022')
+    );
+
+    let value = await page.$eval(
+      '#e2e-datepicker-required',
+      (el) => el?.value
+    );
+
+    expect(value).toEqual('4/5/2022');
+
+    // Reset value in the input
+    await page.$eval(
+      '#e2e-datepicker-required',
+      (el) => el?.container.querySelector('ids-trigger-field')?.setAttribute('value', '')
+    );
+
+    value = await page.$eval(
+      '#e2e-datepicker-required',
+      (el) => el?.value
+    );
+
+    expect(value).toEqual('');
+  });
 });

--- a/test/ids-time-picker/ids-time-picker-e2e-test.js
+++ b/test/ids-time-picker/ids-time-picker-e2e-test.js
@@ -23,4 +23,32 @@ describe('Ids Time Picker e2e Tests', () => {
   it.skip('should show popup on clicking the trigger-button', async () => {});
   it.skip('setting the language will update the labels', () => {});
   it.skip('setting the locale will update the dropdowns and field', () => {});
+
+  it('should change value on input value change', async () => {
+    // Set value to the input
+    await page.$eval(
+      '#e2e-timepicker-locale',
+      (el) => el?.container.querySelector('ids-trigger-field')?.setAttribute('value', '01:00 AM')
+    );
+
+    let value = await page.$eval(
+      '#e2e-timepicker-locale',
+      (el) => el?.value
+    );
+
+    expect(value).toEqual('01:00 AM');
+
+    // Reset value in the input
+    await page.$eval(
+      '#e2e-timepicker-locale',
+      (el) => el?.container.querySelector('ids-trigger-field')?.setAttribute('value', '')
+    );
+
+    value = await page.$eval(
+      '#e2e-timepicker-locale',
+      (el) => el?.value
+    );
+
+    expect(value).toEqual('');
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
The PR fixes an issue with IdsDatepicker/IdsTimepicker where when changing trigger field value component value doesn't change.
Add extra page for date picker axe tests with just one date picker component. To check if it fixes Axe tests timeout issue

**Related github/jira issue (required)**:
Closes #623 

**Steps necessary to review your pull request (required)**:
- pull/build/run

sorry, I'm going to borrow the issue steps text if you don't mind

Issue 1
- Navigate to: http://localhost:4300/ids-time-picker
- See time-picker with label as Uses Current Locale on the page, should be blank
- Open console and run `const timePicker = document.querySelector('ids-time-picker[label="Uses Current Locale"]');`
- `timePicker.value;` This should return `""` empty value
- On page open time-picker with label as Uses Current Locale popup and select time (01:00 AM)
- Run in console `timePicker.value;` This should return `"01:00 AM"`
- Now on click in time-picker with label as Uses Current Locale and remove all value (make it blank)
- Run in console `timePicker.value;`
- Value should be blank `""` at this point

Issue 2
- Navigate to: http://localhost:4300/ids-date-picker/
- See 2nd date-picker on the page, should be blank
- Open console and run `const datePicker = document.querySelector('#e2e-datepicker-required');`
- `datePicker.value;` This should return `""` empty value
- On page open 2nd date-picker popup and select date (4/5/2022)
- Run in console datePicker.value; This should return "4/5/2022"
- Now on click in 2nd date-picker and remove all value (make it blank)
- Run in console `datePicker.value;`
- Value should be blank `""` at this point

Issue 3
It was fixed in the PR https://github.com/infor-design/enterprise-wc/pull/614 so steps can be applied on production link
- Navigate to: https://main.wc.design.infor.com/ids-date-picker/
- See 2nd date-picker on the page, should be blank
- Click to open popup for this date-picker
- In popup you see today's date highlighted with blue background
- Try to click on that date to select
- Today's date can be selected

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
~- [ ] A note to the change log.~

<!-- After submitting your PR, please check back to make sure checks on the PR -->
