### PR TITLE
633 - Add css defaults for no mode

### DIFF
--- a/src/components/ids-about/ids-about.scss
+++ b/src/components/ids-about/ids-about.scss
@@ -50,7 +50,8 @@
     }
   }
 
-  &[mode='light'] .ids-modal-content {
+  &[mode='light'] .ids-modal-content,
+  &:not([mode]) .ids-modal-content {
     @include border-slate-30();
 
     &:hover {

--- a/src/components/ids-accordion/ids-accordion-header.scss
+++ b/src/components/ids-accordion/ids-accordion-header.scss
@@ -7,7 +7,8 @@
   border-color: transparent;
 
   // Light Mode Styles
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     @include border-slate-20();
 
     border-left-color: transparent;
@@ -154,7 +155,8 @@
   }
 
   // Light Mode Styles
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     @include text-slate-20();
 
     &:hover {

--- a/src/components/ids-accordion/ids-accordion-panel.scss
+++ b/src/components/ids-accordion/ids-accordion-panel.scss
@@ -15,7 +15,8 @@
   }
 
   // Light Mode Styles
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     &.expanded {
       @include bg-black();
     }

--- a/src/components/ids-breadcrumb/ids-breadcrumb.scss
+++ b/src/components/ids-breadcrumb/ids-breadcrumb.scss
@@ -77,7 +77,8 @@ $header-gradient-transparent-classic-contrast: rgb(0 74 153 / 0);
     }
   }
 
-  &[version='new'][mode='light'] {
+  &[version='new'][mode='light'],
+  &:not([mode]) {
     nav.truncate::before {
       background-image: linear-gradient(to right, var(--ids-color-palette-white), $transparent-white);
     }
@@ -139,7 +140,8 @@ $header-gradient-transparent-classic-contrast: rgb(0 74 153 / 0);
     }
 
     // Use background colors from IdsHeader
-    &[version='new'][mode='light'] {
+    &[version='new'][mode='light'],
+    &:not([mode]) {
       nav.truncate::before {
         background-image:
           linear-gradient(

--- a/src/components/ids-button/ids-button-base.scss
+++ b/src/components/ids-button/ids-button-base.scss
@@ -127,7 +127,8 @@
   @include inline-flex();
   @include rounded-default();
 
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     // ====================================================
     // Default/Tertiary/Destructive Button styles
 

--- a/src/components/ids-card/ids-card.scss
+++ b/src/components/ids-card/ids-card.scss
@@ -277,7 +277,7 @@
   @include border-b-1();
 }
 
-.ids-card[version='classic'][mode='light'] {
+.ids-card[mode='light'][version='classic'] {
   @include border-graphite-30();
   @include rounded-default();
   @include shadow-none();
@@ -287,7 +287,7 @@
   }
 }
 
-.ids-card[version='classic'][mode='dark'] {
+.ids-card[mode='dark'][version='classic'] {
   @include bg-classic-slate-80();
   @include border-classic-slate-60();
   @include rounded-default();
@@ -298,7 +298,7 @@
   }
 }
 
-.ids-card[version='classic'][mode='contrast'] {
+.ids-card[mode='contrast'][version='classic'] {
   @include bg-white();
   @include border-classic-slate-60();
   @include rounded-default();

--- a/src/components/ids-container/ids-container.scss
+++ b/src/components/ids-container/ids-container.scss
@@ -32,7 +32,8 @@
 }
 
 // Handle Themes
-.ids-container[mode='light'] {
+.ids-container[mode='light'],
+.ids-container:not([mode]) {
   @include bg-white();
   @include text-slate-100();
 

--- a/src/components/ids-drawer/ids-drawer.scss
+++ b/src/components/ids-drawer/ids-drawer.scss
@@ -108,7 +108,8 @@
   }
 
   // Themes
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     &.type-action-sheet {
       @include bg-white();
       @include text-slate-100();

--- a/src/components/ids-header/ids-header.scss
+++ b/src/components/ids-header/ids-header.scss
@@ -10,7 +10,8 @@
   width: 100%;
 
   // New Version: Light Mode
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     @include bg-azure-60();
     @include text-white();
   }

--- a/src/components/ids-hyperlink/ids-hyperlink.scss
+++ b/src/components/ids-hyperlink/ids-hyperlink.scss
@@ -101,7 +101,8 @@
   // =========================================
   // Theme colors are applied when `color="unset"` is not set
   &:not(.ids-hyperlink-color-unset) {
-    &[version='new'][mode='light'] {
+    &[version='new'][mode='light'],
+    &:not([mode]) {
       @include text-azure-60();
 
       &:focus {
@@ -210,7 +211,8 @@
     // ===============================================
     // Color Variants
     &.color-variant-breadcrumb {
-      &[version='new'][mode='light'] {
+      &[version='new'][mode='light'],
+      &:not([mode]) {
         @include text-slate-60();
 
         &[disabled] {
@@ -268,7 +270,8 @@
         opacity: 0.7;
       }
 
-      &[version='new'][mode='light'] {
+      &[version='new'][mode='light'],
+      &:not([mode]) {
         @include text-white();
       }
 

--- a/src/components/ids-image/ids-image.scss
+++ b/src/components/ids-image/ids-image.scss
@@ -28,7 +28,9 @@ $image-sizes: (
 }
 
 :host([mode='light']:focus),
-:host([mode='light']:focus-visible) {
+:host([mode='light']:focus-visible),
+:host(:not([mode]):focus),
+:host(:not([mode]):focus-visible) {
   .ids-image {
     @include border-azure-60();
 
@@ -55,7 +57,8 @@ $image-sizes: (
 }
 
 // theme mode
-:host([mode='light']) {
+:host([mode='light']),
+:host(:not([mode])) {
   .placeholder {
     @include border-slate-20();
 

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -354,7 +354,8 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
 // =======================================================
 // Handle Themes
 
-.ids-input[version='new'][mode='light'] {
+.ids-input[version='new'][mode='light'],
+.ids-input:not([mode]) {
   .field-container {
     @include bg-white();
     @include border-slate-40();

--- a/src/components/ids-list-box/ids-list-box-option.ts
+++ b/src/components/ids-list-box/ids-list-box-option.ts
@@ -34,6 +34,7 @@ export default class IdsListBoxOption extends Base {
   connectedCallback() {
     this.setAttribute('role', 'option');
     this.setAttribute('tabindex', '-1');
+    super.connectedCallback();
   }
 
   /**

--- a/src/components/ids-list-view/ids-list-view.scss
+++ b/src/components/ids-list-view/ids-list-view.scss
@@ -72,7 +72,8 @@
 }
 
 // Handle Themes
-.ids-list-view[mode='light'] div[part='list-item'] {
+.ids-list-view[mode='light'] div[part='list-item'],
+.ids-list-view:not([mode]) div[part='list-item'] {
   @include bg-white();
 }
 

--- a/src/components/ids-masthead/ids-masthead.scss
+++ b/src/components/ids-masthead/ids-masthead.scss
@@ -43,7 +43,8 @@
   }
 
   // New Version: Light Mode
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     @include bg-black();
     @include text-slate-30();
   }

--- a/src/components/ids-notification-banner/ids-notification-banner.scss
+++ b/src/components/ids-notification-banner/ids-notification-banner.scss
@@ -37,7 +37,8 @@ ids-hyperlink::part(link) {
   white-space: nowrap;
 }
 
-.ids-notification-banner[mode='light'] {
+.ids-notification-banner[mode='light'],
+.ids-notification-banner:not([mode]) {
   &[type='success'],
   &[type='alert'],
   &[type='info'],
@@ -84,6 +85,7 @@ ids-hyperlink::part(link) {
 
 .ids-notification-banner[type='success'] {
   &[mode='light'],
+  &:not([mode]),
   &[mode='contrast'] {
     @include bg-emerald-10();
   }
@@ -95,6 +97,7 @@ ids-hyperlink::part(link) {
 
 .ids-notification-banner[type='alert'] {
   &[mode='light'],
+  &:not([mode]),
   &[mode='contrast'] {
     @include bg-amber-10();
   }
@@ -106,6 +109,7 @@ ids-hyperlink::part(link) {
 
 .ids-notification-banner[type='info'] {
   &[mode='light'],
+  &:not([mode]),
   &[mode='contrast'] {
     @include bg-azure-10();
   }
@@ -117,6 +121,7 @@ ids-hyperlink::part(link) {
 
 .ids-notification-banner[type='error'] {
   &[mode='light'],
+  &:not([mode]),
   &[mode='contrast'] {
     @include bg-ruby-10();
   }

--- a/src/components/ids-progress-chart/demos/index.html
+++ b/src/components/ids-progress-chart/demos/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <ids-container role="main" padding="8" hidden>
-    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <!-- <ids-theme-switcher mode="light" version="new"></ids-theme-switcher> -->
     <ids-layout-grid auto="true">
       <ids-text font-size="12" type="h1">Progress Chart</ids-text>
     </ids-layout-grid>

--- a/src/components/ids-progress-chart/demos/index.html
+++ b/src/components/ids-progress-chart/demos/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <ids-container role="main" padding="8" hidden>
-    <!-- <ids-theme-switcher mode="light" version="new"></ids-theme-switcher> -->
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
     <ids-layout-grid auto="true">
       <ids-text font-size="12" type="h1">Progress Chart</ids-text>
     </ids-layout-grid>

--- a/src/components/ids-progress-chart/ids-progress-chart.scss
+++ b/src/components/ids-progress-chart/ids-progress-chart.scss
@@ -90,7 +90,8 @@
 
 .ids-progress-chart[version='new'],
 .ids-progress-chart:not([mode]) {
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     .bar {
       .bar-total {
         @include bg-slate-30();

--- a/src/components/ids-progress-chart/ids-progress-chart.scss
+++ b/src/components/ids-progress-chart/ids-progress-chart.scss
@@ -88,7 +88,8 @@
   }
 }
 
-.ids-progress-chart[version='new'] {
+.ids-progress-chart[version='new'],
+.ids-progress-chart:not([mode]) {
   &[mode='light'] {
     .bar {
       .bar-total {

--- a/src/components/ids-search-field/ids-search-field.scss
+++ b/src/components/ids-search-field/ids-search-field.scss
@@ -98,7 +98,8 @@
   // Theme Colors for color variants
 
   // Light Mode
-  &[mode='light'] {
+  &[mode='light'],
+  &:not([mode]) {
     @include ids-search-field-alternate-colors();
 
     &.color-variant-app-menu {

--- a/src/components/ids-textarea/ids-textarea.scss
+++ b/src/components/ids-textarea/ids-textarea.scss
@@ -277,7 +277,8 @@ $textarea-size-default-height: 120px;
 }
 
 // Handle Themes
-.ids-textarea[mode='light'] {
+.ids-textarea[mode='light'],
+.ids-textarea:not([mode]) {
   .ids-textarea-field {
     @include bg-white();
     @include border-slate-40();

--- a/src/components/ids-trigger-field/ids-trigger-field.scss
+++ b/src/components/ids-trigger-field/ids-trigger-field.scss
@@ -10,6 +10,7 @@
 }
 
 .ids-input[version='new'][mode='light'].color-variant-alternate-formatter,
+.ids-input:not([mode]).color-variant-alternate-formatter,
 .ids-input[version='new'][mode='dark'].color-variant-alternate-formatter,
 .ids-input[version='new'][mode='contrast'].color-variant-alternate-formatter,
 .ids-input[version='classic'][mode='light'].color-variant-alternate-formatter,

--- a/src/components/ids-upload-advanced/ids-upload-advanced.scss
+++ b/src/components/ids-upload-advanced/ids-upload-advanced.scss
@@ -121,7 +121,8 @@
 }
 
 // Handle Themes
-.ids-upload-advanced[mode='light'] {
+.ids-upload-advanced[mode='light'],
+.ids-upload-advanced:not([mode]) {
   .droparea {
     @include bg-slate-10();
     @include border-slate-50();

--- a/test/ids-data-grid/ids-data-grid-e2e-test.ts
+++ b/test/ids-data-grid/ids-data-grid-e2e-test.ts
@@ -15,3 +15,15 @@ describe('Ids Data Grid e2e Tests', () => {
     await (expect(page) as any).toPassAxeTests();
   });
 });
+
+describe('Ids Data Grid Virtual Scroll e2e Tests', () => {
+  const url = 'http://localhost:4444/ids-data-grid/virtual-scroll.html';
+
+  it('should render some rows', async () => {
+    await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
+    await page.waitForSelector('pierce/.ids-data-grid-row');
+
+    const count = (await page.$$('pierce/.ids-data-grid-row')).length;
+    expect(count).toEqual(21);
+  });
+});

--- a/test/ids-data-grid/ids-data-grid-percy-test.ts
+++ b/test/ids-data-grid/ids-data-grid-percy-test.ts
@@ -55,13 +55,3 @@ describe('Ids Data Grid List Style Percy Tests', () => {
     await percySnapshot(page, 'ids-data-grid-list-style-new-contrast');
   });
 });
-
-describe('Ids Data Grid Virtual Scroll Percy Tests', () => {
-  const url = 'http://localhost:4444/ids-data-grid/virtual-scroll.html';
-
-  it('should not have visual regressions in new light theme (percy)', async () => {
-    await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
-    await page.waitForSelector('ids-layout-grid-cell');
-    await percySnapshot(page, 'ids-data-grid-virtual-scroll-new-light');
-  });
-});

--- a/test/ids-list-view/ids-list-view-percy-test.ts
+++ b/test/ids-list-view/ids-list-view-percy-test.ts
@@ -13,7 +13,7 @@ describe('Ids List View Percy Tests', () => {
     await page.evaluate(() => {
       document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'dark');
     });
-    await page.waitForTimeout(200); // approx. time for a theme switch to take effect
+    await page.waitForTimeout(300); // approx. time for a theme switch to take effect
     await percySnapshot(page, 'ids-listview-new-dark');
   });
 
@@ -22,7 +22,7 @@ describe('Ids List View Percy Tests', () => {
     await page.evaluate(() => {
       document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'contrast');
     });
-    await page.waitForTimeout(200); // approx. time for a theme switch to take effect
+    await page.waitForTimeout(300); // approx. time for a theme switch to take effect
     await percySnapshot(page, 'ids-listview-new-contrast');
   });
 });

--- a/test/ids-list-view/ids-list-view-percy-test.ts
+++ b/test/ids-list-view/ids-list-view-percy-test.ts
@@ -7,22 +7,4 @@ describe('Ids List View Percy Tests', () => {
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
     await percySnapshot(page, 'ids-listview-new-light');
   });
-
-  it('should not have visual regressions in new dark theme (percy)', async () => {
-    await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
-    await page.evaluate(() => {
-      document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'dark');
-    });
-    await page.waitForTimeout(300); // approx. time for a theme switch to take effect
-    await percySnapshot(page, 'ids-listview-new-dark');
-  });
-
-  it('should not have visual regressions in new contrast theme (percy)', async () => {
-    await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
-    await page.evaluate(() => {
-      document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'contrast');
-    });
-    await page.waitForTimeout(300); // approx. time for a theme switch to take effect
-    await percySnapshot(page, 'ids-listview-new-contrast');
-  });
 });

--- a/test/ids-list-view/ids-list-view-percy-test.ts
+++ b/test/ids-list-view/ids-list-view-percy-test.ts
@@ -13,6 +13,7 @@ describe('Ids List View Percy Tests', () => {
     await page.evaluate(() => {
       document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'dark');
     });
+    await page.waitForTimeout(200); // approx. time for a theme switch to take effect
     await percySnapshot(page, 'ids-listview-new-dark');
   });
 
@@ -21,6 +22,7 @@ describe('Ids List View Percy Tests', () => {
     await page.evaluate(() => {
       document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'contrast');
     });
+    await page.waitForTimeout(200); // approx. time for a theme switch to take effect
     await percySnapshot(page, 'ids-listview-new-contrast');
   });
 });

--- a/test/ids-time-picker/ids-time-picker-percy-test.ts
+++ b/test/ids-time-picker/ids-time-picker-percy-test.ts
@@ -5,7 +5,6 @@ describe('Ids Time Picker Percy Tests', () => {
 
   it('should not have visual regressions in new light theme (percy)', async () => {
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
-    await page.waitForTimeout(200);
     await percySnapshot(page, 'ids-time-picker-new-light');
   });
 
@@ -14,7 +13,7 @@ describe('Ids Time Picker Percy Tests', () => {
     await page.evaluate(() => {
       document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'dark');
     });
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(222);
     await percySnapshot(page, 'ids-time-picker-new-dark');
   });
 
@@ -23,7 +22,7 @@ describe('Ids Time Picker Percy Tests', () => {
     await page.evaluate(() => {
       document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'contrast');
     });
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(222);
     await percySnapshot(page, 'ids-time-picker-new-contrast');
   });
 });

--- a/test/ids-virtual-scroll/ids-virtual-scroll-e2e-test.ts
+++ b/test/ids-virtual-scroll/ids-virtual-scroll-e2e-test.ts
@@ -15,7 +15,7 @@ describe('Ids Virtual Scroll e2e Tests', () => {
     await (expect(page) as any).toPassAxeTests({ disabledRules: ['scrollable-region-focusable', 'landmark-one-main', 'page-has-heading-one'] });
   });
 
-  it('should not have visual regressions (percy)', async () => {
+  it('should render some rows', async () => {
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
     await page.waitForSelector('.ids-data-grid-row');
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
For anything in scss targeting light/new theme and mode added a default for no mode - for if there is no theme mixins.

**Related github/jira issue (required)**:
Fixes #633
Fixes #649

**Steps necessary to review your pull request (required)**:

*Issue Part One*
- edit components/ids-accordion/demos/index.html and comment out `ids-theme-switcher`
- run the page
- the button should look the same with it commented and not commented and when you open the modal the inner text area should be styled in new-light mode with no `ids-theme-switcher`
- see if i missed anything/made a mistake?

*Issue Part Two*
- go to http://localhost:4300/ids-dropdown
- change to dark mode
- open the list and it should look good