### PR TITLE
607 - Fix Popup menu behavior when selecting with Enter key

### DIFF
--- a/src/components/ids-menu/ids-menu.ts
+++ b/src/components/ids-menu/ids-menu.ts
@@ -88,6 +88,7 @@ export default class IdsMenu extends Base {
       const thisItem = e.target.closest('ids-menu-item');
       this.selectItem(thisItem);
       this.lastNavigated = thisItem;
+      e.preventDefault();
       e.stopPropagation();
     });
   }

--- a/test/ids-menu-button/ids-menu-button-func-test.ts
+++ b/test/ids-menu-button/ids-menu-button-func-test.ts
@@ -151,6 +151,34 @@ describe('IdsMenuButton Component', () => {
     expect(buttonEl.shadowRoot.querySelector('.ids-icon-button')).toBeTruthy();
   });
 
+  it('should select item via keyboard', async () => {
+    menuEl.innerHTML = `<ids-menu-group id="primary" select="single">
+      <ids-menu-item id="item1" value="1">Item 1</ids-menu-item>
+    </ids-menu-group>`;
+
+    // open menu
+    const clickEvent = new MouseEvent('click');
+    buttonEl.dispatchEvent(clickEvent);
+    expect(menuEl.visible).toBeTruthy();
+
+    // select menu item
+    const item1 = menuEl.querySelector('#item1');
+    const enterEvent = new KeyboardEvent('keydown', {
+      code: 'Enter',
+      key: 'Enter',
+      charCode: 13,
+      keyCode: 13,
+      view: window,
+      bubbles: true
+    });
+    item1.focus();
+    item1.dispatchEvent(enterEvent);
+    expect(item1.selected).toBeTruthy();
+
+    // ensure popup closed after selection
+    expect(menuEl.visible).toBeFalsy();
+  });
+
   it('focuses the button when the menu is closed with the `Escape` key', () => {
     const closeEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
     menuEl.show();


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes popup opening/closing twice when enter key is used to select menu item.

**Related github/jira issue (required)**:
Closes #607 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, `npm install`, `npm run start`
2. Navigate to http://localhost:4300/ids-menu-button
3. Keyboard navigate to menu button example
4. Open popup when with Enter/Spacebar
5. Select `Small`, `Medium`, or `Large` with Enter/Spacebar
6. Ensure popup closes once and can be reopened.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
