### PR TITLE
Chore: Sync more todos for listbuilder, listview and locale

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -37,13 +37,9 @@ For more details on breaking changes see each component in the individual README
 - `[Image]` The image css component is now a web component called `ids-image`. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-image/README.md#converting-from-previous-versions for details. ([#360](https://github.com/infor-design/enterprise-wc/issues/360))
 - `[Input]` The Input component is now a web component called `ids-input`. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-image/README.md#converting-from-previous-versions for details. ([#171](https://github.com/infor-design/enterprise-wc/issues/171))
 - `[LayoutGrid]` The Grid component is now a web component called `ids-layout-grid`. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-layout-grid/README.md#converting-from-previous-versions for details. ([#180](https://github.com/infor-design/enterprise-wc/issues/180))
-- `[ListView]` The List View component has been changed to a web component and renamed to ids-list-view.
-  - If using properties/settings these are now attributes.
-  - Markup has changed to a custom element `<ids-list-view></ids-list-view>`
-  - If using events events are now plain JS events for example
-  - The template is now a template element that uses simple string substitution
-  - Can now be imported as a single JS file and used with encapsulated styles
-- `[ListBuilder]` The List Builder component has been changed to a web component and renamed to ids-list-builder.
+- `[ListBuilder]` The List Builder component is now a web component called `ids-list-builder`. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-list-builder/README.md#converting-from-previous-versions for details. ([#365](https://github.com/infor-design/enterprise-wc/issues/365))
+- `[ListView]` The List View component is now a web component called `ids-list-view`. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-list-view/README.md#converting-from-previous-versions for details. ([#174](https://github.com/infor-design/enterprise-wc/issues/174))
+- `[Locale]` The locale component has been changed to a mixin and added to many but not all components. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-locale/README.md#converting-from-previous-versions for details. ([#121](https://github.com/infor-design/enterprise-wc/issues/121))
 - `[LoadingIndicator]` The Busy Indicator component has been changed to a web component and renamed to ids-loading-indicator.
   - Markup has changed to a custom element `<ids-loading-indicator></ids-loading-indicator>`
   - Can now be imported as a single JS file and used with encapsulated styles
@@ -88,8 +84,6 @@ For more details on breaking changes see each component in the individual README
   - Markup has changed to a custom element `<ids-progress-bar></ids-progress-bar>`
   - If using events, events are now plain JS events.
   - Can now be imported as a single JS file and used with encapsulated styles
-- `[Locale]` The locale component has been changed to a mixin and added to many but not all components. You can now change the locale on the `ids-container` element to have it propagate down.
-  - See the [locale components docs](../src/ids-locales/README.md) for more detailed change info the the "Converting from Previous Versions" sections
 - `[Radio]` The Radio component has been changed to a web component and use with ids-radio and ids-radio-group.
   - Markup has changed to a custom element `<ids-radio-group><ids-radio></ids-radio></ids-radio-group>`
   - If using events, events are now plain JS events.

--- a/src/components/ids-card/TODO.md
+++ b/src/components/ids-card/TODO.md
@@ -10,3 +10,4 @@
 - [ ] Add an example with the vertical action button (icon rotated 90 degrees) see https://github.com/infor-design/enterprise/blob/main/src/components/cards/cards.js#L16
 - [ ] Add a [section header example](https://github.com/infor-design/enterprise/issues/5651)
 - [ ] Actionable button card is not centered and add a new example like https://main-enterprise.demo.design.infor.com/components/cards/example-actionable.html
+- [ ] Add empty message example (maybe to ids-empty-message) https://main-enterprise.demo.design.infor.com/components/listview/test-empty-message.html

--- a/src/components/ids-date-picker/TODO.md
+++ b/src/components/ids-date-picker/TODO.md
@@ -27,3 +27,4 @@
 - [] Add test for this case https://github.com/infor-design/enterprise/issues/5255
 - [] Add side by side example
 - [] Fix bug https://github.com/infor-design/enterprise/issues/4605
+- [] Fix bug https://github.com/infor-design/enterprise/issues/5255

--- a/src/components/ids-list-builder/README.md
+++ b/src/components/ids-list-builder/README.md
@@ -92,11 +92,18 @@ Since this component inherits [IdsListView](../ids-list-view/README.md), it will
 
 - This component stretches to 100% width of its container
 
-## Converting from Previous Version
+## Converting from Previous Versions (Breaking Changes)
 
-### Converting from 4.x
+**3.x to 4.x**
 
-The Ids ListBuilder is now a Web Component. Instead of using classes to define it, it is done directly with a custom element and attributes:
+- New pattern for 4.x
+
+**4.x to 5.x**
+
+- The Ids ListBuilder is now a Web Component
+- Instead of using classes to define it, it is done directly with a custom element and attributes
+- Markup has changed to a custom element `<ids-list-builder></ids-list-builder>` (see examples above)
+- Can now be imported as a single JS file and used with encapsulated styles
 
 ```html
 <!-- 4.x example -->

--- a/src/components/ids-list-builder/TODO.md
+++ b/src/components/ids-list-builder/TODO.md
@@ -1,14 +1,17 @@
-# List Builder TODO's
+# IdsListBuilder TODOs
+
+## Major
+
+- [] Better keyboard support for all actions
+- [] Can't create a new item if no items in the list initially
+- [] Can multiselect but delete removes one at a time (select one, delete, select another, delete, select another, delete)
+- [] Editing style needs design review
+- [] Add same events as the prod component `move`, `selected`, `click`, `doubleclick` `change`, `add`, `beforeAdd`, `afterAdd`, `delete` `beforeDelete`, `afterDelete`
+- [] Hover state in high contrast mode is 100% black
+
+## Medium
 
 - [] Correct aria [see standards](https://design.infor.com/code/ids-enterprise/latest/listview#accessibility)
-- [] Better keyboard support for all actions
 - [] A way to save order / events
 - [] Make focus state on buttons white with box shadow
-- [] Fix performance of event handlers on products.json
-- [] Drag should only drag on the handle part
-- [] Tests for attachKeyboardListenersForLi to 100%
-- [] Weird styling when pressing new
-- [] Poor coverage
-- [] Can't create a new item if no items in the list
-- [] Pressing delete continues to delete
-- [] Can multiselect but delete removes one at a time
+- [] More test coverage

--- a/src/components/ids-list-builder/ids-list-builder.scss
+++ b/src/components/ids-list-builder/ids-list-builder.scss
@@ -115,7 +115,7 @@
         left: 0;
         transform: translate(100%, -8%);
         font-size: 24px;
-        content: '⁞';
+        content: '\205e';
         cursor: move;
       }
 

--- a/src/components/ids-list-view/README.md
+++ b/src/components/ids-list-view/README.md
@@ -74,19 +74,22 @@ The template shows the use of a string substitution to access the data element. 
 - The list body will expand vertically and horizontally to fill it the size of its parent container.
 - When used in homepages, special rules apply with sizes.
 
-## Converting from Previous Versions
+## Converting from Previous Versions (Breaking Changes)
 
-** From 3.x to 4.x**
+**3.x to 4.x**
+
 - Single select roughly replaces the inforListBox component.
 - Multi select is a new feature, however it replaces the listbox with checkboxes construct.
 
-** From 4.x to 5.x**
+**4.x to 5.x**
 
+- The List View component has been changed to a web component and renamed to ids-list-view.
 - If using properties/settings these are now attributes.
 - Markup has changed to a custom element `<ids-list-view></ids-list-view>`
 - If using events events are now plain JS events for example
 - The template is now a template element that uses simple string substitution
 - Can now be imported as a single JS file and used with encapsulated styles (in some browsers)
+- Alternate row colors is deprecated
 
 ## Accessibility Guidelines
 

--- a/src/components/ids-list-view/TODO.md
+++ b/src/components/ids-list-view/TODO.md
@@ -1,11 +1,19 @@
-# ListView TODO's
+# IdsListView TODOs
 
-## Tier One
+## Major
 
-- [] Paging
-- [] Organize Embellishment / template classes
-- [] Keyboard Navigation see [standards](https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-for-layout-grids) (actionable mode, cell navigation, row navigation, Selection)
-- [] Check all current events with sold source
-- [] Disabled
+- [] Paging https://main-enterprise.demo.design.infor.com/components/listview/example-paging-clientside.html
+- [] Click and Dblclick events https://main-enterprise.demo.design.infor.com/components/listview/example-click-events.html
+- [] Disabled https://main-enterprise.demo.design.infor.com/components/listview/test-contextual-disabled.html with api or setting (conditionally)
 - [] Accessibility see [standards](https://design.infor.com/code/ids-enterprise/latest/listview#accessibility)
 - [] Event delegation on the click event
+- [] Add selection events (use selected) and fix selection styling https://main-enterprise.demo.design.infor.com/components/listview/example-events.html
+- [] Fix styling in the high contrast mode
+
+## Minor
+
+- [] Organize Embellishment / template classes like the ones here to float using ids-text and listview  https://main-enterprise.demo.design.infor.com/components/listview/example-alternate-row-color.html (skip alternate color) and links https://main-enterprise.demo.design.infor.com/components/listview/example-links.html and status https://main-enterprise.demo.design.infor.com/components/listview/example-status.html and actions https://main-enterprise.demo.design.infor.com/components/listview/test-actions-button.html
+- [] https://main.wc.design.infor.com/ids-list-view/card.html example is broken
+- [] Add footer navigation bar https://main-enterprise.demo.design.infor.com/components/listview/example-footer-navigation.html (but make it smaller)
+- [] Add mixed and multiselect examples https://main-enterprise.demo.design.infor.com/components/listview/example-mixed-selection.html and https://main-enterprise.demo.design.infor.com/components/listview/example-multiselect.html
+- [] Add search bar https://main-enterprise.demo.design.infor.com/components/listview/example-search.html

--- a/src/components/ids-list-view/demos/card.html
+++ b/src/components/ids-list-view/demos/card.html
@@ -13,12 +13,12 @@
     <ids-layout-grid cols="2" gap="xl">
       <ids-layout-grid-cell col-span="1">
         <div class="parent-container">
-        <ids-card auto-fit>
+        <ids-card>
           <div slot="card-header">
             <ids-text font-size="20" type="h2">Product List</ids-text>
           </div>
           <div slot="card-content">
-            <ids-list-view>
+            <ids-list-view id="card-example">
               <template>
                 <ids-text font-size="16" type="h2">${productName}</ids-text>
                 <ids-text font-size="12" type="span">Count: ${units}</ids-text>

--- a/src/components/ids-list-view/demos/card.ts
+++ b/src/components/ids-list-view/demos/card.ts
@@ -1,0 +1,19 @@
+// Supporting components
+import '../ids-list-view';
+import '../../ids-card/ids-card';
+import '../../ids-draggable/ids-draggable';
+import productsJSON from '../../../assets/data/products.json';
+
+// Example for populating the List View
+const listView = document.querySelector('#card-example');
+
+// Do an ajax request and apply the data to the list
+const url: any = productsJSON;
+
+const setData = async () => {
+  const res = await fetch(url);
+  const data = await res.json();
+  (listView as any).data = data;
+};
+
+setData();

--- a/src/components/ids-list-view/demos/index.ts
+++ b/src/components/ids-list-view/demos/index.ts
@@ -12,17 +12,16 @@ if (head) {
 }
 
 // Example for populating the List View
-const listView = document.querySelectorAll('ids-list-view');
+const listView = document.querySelector('ids-list-view:not([id])');
+if (listView) {
+  // Do an ajax request and apply the data to the list
+  const url: any = eventsJSON;
 
-// Do an ajax request and apply the data to the list
-const url: any = eventsJSON;
+  const setData = async () => {
+    const res = await fetch(url);
+    const data = await res.json();
+    (listView as any).data = data;
+  };
 
-const setData = async () => {
-  const res = await fetch(url);
-  const data = await res.json();
-  listView.forEach((l: any) => {
-    l.data = data;
-  });
-};
-
-setData();
+  setData();
+}

--- a/src/components/ids-list-view/demos/sortable.html
+++ b/src/components/ids-list-view/demos/sortable.html
@@ -13,7 +13,7 @@
     <ids-layout-grid cols="2" gap="xl">
       <ids-layout-grid-cell col-span="1">
         <div class="parent-container">
-            <ids-list-view item-height="76" sortable>
+            <ids-list-view item-height="76" sortable selectable="single">
               <template>
                 <ids-text font-size="16" type="h2">${id} - ${subject}</ids-text>
               </template>

--- a/src/components/ids-list-view/ids-list-view.scss
+++ b/src/components/ids-list-view/ids-list-view.scss
@@ -39,7 +39,7 @@
 
       &.sortable:hover::before {
         position: absolute;
-        left: 0;
+        left: 3px;
         transform: translate(50%, 0);
         font-size: 24px;
         margin-top: -3px;

--- a/src/components/ids-locale/README.MD
+++ b/src/components/ids-locale/README.MD
@@ -256,26 +256,32 @@ locale.parseDate('2020-02-26 下午12:00', { dateFormat: 'yyyy/M/d ah:mm', local
 - `isIslamic(locale)` - Returns true if the current or provided locale uses the islamic calendar as the primary calendar
 - `isTRL(locale)` - Returns true if the current or provided locale is a right-to-left language
 
-## Converting from Previous Versions (Overview)
 
-- 3.x: Used the older Globalize open source utilities
-- 4.x: Has an entire new Locale API
-- 5.x: Has numerous breaking changes
-  - The `set` api is now called `setLocale`. The `setLanguage` is still called `setLanguage`
-  - The translate API and in general no longer require a cultures folder as this is contained in the npm package.
-  - `toLocaleString` Is deprecated as function as now `formatNumber` uses it
-  - The `formatNumber` function now uses `toLocaleString` internally which has some minor differences. As a result the the rounding and truncation behavior has slightly changed and some other details are listed in the formatDate section.
-  - The `formatDate` function now uses [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) internally which has some minor differences. This was done to reduce the number of locale bugs and code.
-  - The `getLocale` function is not needed since we can use await now so was removed
-  - We did not include the culturesPath as its not needed since the locales are contained with the locale code
-  - ShowAsUndefined option is deprecated, now undefined locales will all be shown in square brackets
-  - Round option on formatNumber is deprecated
-  - Options on formatNumber now use toLocaleString options (which are similar)
-  - `parseDate` is now much more limited and cannot parse long formats
-  - Its technically not possible to provide a new translation file as the files are in the npm folder. So if you want to add a new translation or locale lets us know and we will add it. You might have to sync the translations.
-  - `toUpperCase` can now be done with `toLocaleUpperCase` so is deprecated
-  - `toLowerCase` can now be done with `toLocaleLowerCase` so is deprecated
-  - `dateToUTC` is deprecated as its use case is limited
+## Converting from Previous Versions (Breaking Changes)
+
+**3.x to 4.x**
+
+- 3.x Used the older Globalize open source utilities
+- 4.x Has an entire new Locale API
+
+**4.x to 5.x**
+
+- You can now change the locale on the `ids-container` element to have it propagate down to the children components
+- The `set` api is now called `setLocale`. The `setLanguage` is still called `setLanguage`
+- The translate API and in general no longer require a cultures folder as this is contained in the npm package.
+- `toLocaleString` Is deprecated as function as now `formatNumber` uses it
+- The `formatNumber` function now uses `toLocaleString` internally which has some minor differences. As a result the the rounding and truncation behavior has slightly changed and some other details are listed in the formatDate section.
+- The `formatDate` function now uses [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) internally which has some minor differences. This was done to reduce the number of locale bugs and code.
+- The `getLocale` function is not needed since we can use await now so was removed
+- We did not include the culturesPath as its not needed since the locales are contained with the locale code
+- ShowAsUndefined option is deprecated, now undefined locales will all be shown in square brackets
+- Round option on formatNumber is deprecated
+- Options on formatNumber now use toLocaleString options (which are similar)
+- `parseDate` is now much more limited and cannot parse long formats
+- Its technically not possible to provide a new translation file as the files are in the npm folder. So if you want to add a new translation or locale lets us know and we will add it. You might have to sync the translations.
+- `toUpperCase` can now be done with `toLocaleUpperCase` so is deprecated
+- `toLowerCase` can now be done with `toLocaleLowerCase` so is deprecated
+- `dateToUTC` is deprecated as its use case is limited
 
 ## Regional Considerations
 

--- a/src/components/ids-locale/TODO.md
+++ b/src/components/ids-locale/TODO.md
@@ -1,11 +1,11 @@
-# TODO For Locales
+# IdsLocale TODOs
 
-- [] RTL all components
-- [] Number Inputs (value/mask)
-- [] Date Inputs (value/mask)
-- [] May have to review the need for Arabic Calendar as it included in Intl.DateTimeFormat we can try to use it via that
-- [] may have to review the cases parseNumber has
+## Major
 
-## TODO For Phase 2
-
+- [] Number Inputs (value/mask) https://github.com/infor-design/enterprise-wc/issues/564
+- [] Date Inputs (value/mask) https://github.com/infor-design/enterprise-wc/issues/564
 - [] Change fonts for some locales (how would we do this?)
+- [] Support Rounding/Not Rounding https://github.com/infor-design/enterprise-wc/issues/347
+- [] Fix https://github.com/infor-design/enterprise/issues/6123
+- [] Fix https://github.com/infor-design/enterprise/issues/6122
+- [] Fix https://github.com/infor-design/enterprise/issues/5119


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Did the todo work for listbuilder, listview and locale. Also fixed:

- some broken listview examples after the webpack sync PR
- a wierd character showing when you hover the list builder

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
- review inline content
- go to http://localhost:4300/ids-list-builder and hover the rows (should not see a wierd char like https://main.wc.design.infor.com/ids-list-builder/)
- try http://localhost:4300/ids-list-view/card.html and http://localhost:4300/ids-list-view/card.html http://localhost:4300/ids-list-view/selectable.html 

**Included in this Pull Request**:
- [x] A note to the change log.