### PR TITLE
589 - Add remaining features with ids-upload

### DIFF
--- a/src/components/ids-trigger-field/ids-trigger-field.scss
+++ b/src/components/ids-trigger-field/ids-trigger-field.scss
@@ -1,10 +1,12 @@
 @import '../../core/ids-base';
 @import '../ids-input/ids-input';
 
+.ids-trigger-field-slot-trigger-start,
 ::slotted(*[slot='trigger-start']:first-of-type:not([inline])) {
   @include ml-4();
 }
 
+.ids-trigger-field-slot-trigger-end,
 ::slotted(*[slot='trigger-end']:last-of-type:not([inline])) {
   @include mr-4();
 }

--- a/src/components/ids-upload/README.md
+++ b/src/components/ids-upload/README.md
@@ -11,7 +11,8 @@ A form element that allows users to choose a file they want to upload. A user ca
 ## Terminology
 
 **Input Type File:** A standard basic input element with type as file.
-**Label**: HTMLLabelElement to keep matching with HTMLInputElement. Make sure the label has a meaningful relative.
+**Label:** HTMLLabelElement to keep matching with HTMLInputElement. Make sure the label has a meaningful relative.
+**Drag and Drop:** File/s can be drag from finder/explorer window and drop into upload field.
 
 ## Features (With Code Samples)
 
@@ -57,17 +58,68 @@ Upload field with required validation
 <ids-upload label="Required" validate="required"></ids-upload>
 ```
 
+Upload field as tabbable
+
+```html
+<ids-upload label="Tabbable" tabbable="true"></ids-upload>
+```
+
+Upload field with hidden label state
+
+```html
+<ids-upload label="Label State (hidden)" label-state="hidden"></ids-upload>
+```
+
+Upload field with collapsed label state
+
+```html
+<ids-upload label="Label State (collapsed)" label-state="collapsed"></ids-upload>
+```
+
+Upload field as compact mode
+
+```html
+<ids-upload label="Compact" compact="true"></ids-upload>
+```
+
+Upload field with types of field heights
+
+```html
+<ids-upload field-height="xs" label="Extra Small (compact)"></ids-upload>
+<ids-upload field-height="sm" label="Small"></ids-upload>
+<ids-upload field-height="md" label="Medium (default)"></ids-upload>
+<ids-upload field-height="lg" label="Large"></ids-upload>
+```
+
+Upload field with types of sizes
+
+```html
+<ids-upload size="xs" label="Extra Small"></ids-upload>
+<ids-upload size="sm" label="Small"></ids-upload>
+<ids-upload size="mm" label="Small - Medium"></ids-upload>
+<ids-upload size="md" label="Medium (default)"></ids-upload>
+<ids-upload size="lg" label="Large"></ids-upload>
+<ids-upload size="full" label="Full"></ids-upload>
+```
+
 ## Settings (Attributes)
 
 - `accept` {string} sets limit the file types to be uploaded.
+- `colorVariant` {string} set the current color variant.
+- `compact` {boolean} sets the component to be compact mode.
 - `dirty-tracker` {boolean} sets the dirty tracking feature on to indicate a changed field. See [Ids Dirty Tracker Mixin](../../mixins/ids-dirty-tracker-mixin/README.md) for more information.
 - `disabled` {boolean} sets to disabled state.
+- `fieldHeight` {string} defines the field height. See [Ids Field Height Mixin](../../mixins/ids-field-height-mixin/README.md) for more information.
 - `label` {string} sets the label text for text input.
 - `labelFiletype` {string} sets the label text for file input.
+- `language` {string} Sets the language for RTL and inner labels
+- `labelRequired` {boolean} Sets the validation required indicator on label text, it's default to `true`
+- `labelState` {string} indicates that a label is hidden (note that for accessibility reasons, `label` should still
 - `multiple` {boolean} sets to allows multiple files to be uploaded.
-- `noTextEllipsis` {boolean} sets ellipsis to be not shown on text input.
+- `noMargins` {boolean} sets whether or not no-margins around the component.
+- `textEllipsis` {boolean} sets ellipsis to be shown on text input.
 - `placeholder` {string} sets the input placeholder text.
-- `size` {string} sets the size (width) of input, it will set `md` as defaults.
+- `size` {'sm '|'md'|'lg'|'full'|string} sets the size (width) of input, it will set `md` as defaults.
 - `readonly` {boolean} sets to readonly state.
 - `triggerLabel` {string} sets the label text for trigger button.
 - `validate` {string} sets text input validation rules, use `space` to add multiple validation rules.

--- a/src/components/ids-upload/TODO.md
+++ b/src/components/ids-upload/TODO.md
@@ -1,11 +1,1 @@
 # Ids Upload TODO
-
-Keep this file in sync with #589
-
-## Major
-
-- [ ] Pass down IdsInput attributes from the IdsUpload wrapper (not being done automatically due to wrapping IdsInput instead of inheriting)
-  - `field-height`/`compact`
-  - `label-state`
-  - `tabbable`
-  - Check for others

--- a/src/components/ids-upload/demos/sandbox.html
+++ b/src/components/ids-upload/demos/sandbox.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Ids Upload - Sandbox</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid cols="3" gap="md">
+      <ids-layout-grid-cell>
+        <ids-upload label="Single File"></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Multiple Files" multiple="true"></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Multiple Files Accept (.cvs,.xls,.xlsx)" multiple="true" accept=".cvs,.xls,.xlsx"></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Readonly" readonly="true"></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Disabled" disabled="true" value="Readme.txt"></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Dirty Tracker" dirty-tracker="true"></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Required" validate="required"></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Tabbable" tabbable></ids-upload>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-upload label="Label State (hidden)" label-state="hidden"></ids-upload>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h2">Ids Upload - Compact</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-upload label="Compact" compact="true"></ids-upload>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h2">Ids Upload - Field Heights (Height)</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <!-- Field Heights: [xs, sm, md, lg] -->
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-upload field-height="xs" label="Extra Small (compact)"></ids-upload>
+        <ids-upload field-height="sm" label="Small"></ids-upload>
+        <ids-upload field-height="md" label="Medium (default)"></ids-upload>
+        <ids-upload field-height="lg" label="Large"></ids-upload>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h2">Ids Upload - Sizes (Width)</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <!-- Sizes: [xs, sm, mm, md, lg, full] -->
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-upload size="xs" label="Extra Small"></ids-upload>
+        <ids-upload size="sm" label="Small"></ids-upload>
+        <ids-upload size="mm" label="Small - Medium"></ids-upload>
+        <ids-upload size="md" label="Medium (default)"></ids-upload>
+        <ids-upload size="lg" label="Large"></ids-upload>
+        <ids-upload size="full" label="Full"></ids-upload>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+  </ids-container>
+</body>
+
+</html>

--- a/src/components/ids-upload/demos/standalone-css.html
+++ b/src/components/ids-upload/demos/standalone-css.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+</head>
+<body hidden>
+  <div class="ids-layout-grid">
+    <div class="ids-layout-grid-cell">
+      <h1 class="ids-text ids-text-12">IDS Upload - Standalone CSS</h1>
+    </div>
+  </div>
+
+  <div class="ids-layout-grid">
+    <div class="ids-layout-grid-cell">
+
+      <!-- Basic -->
+      <div class="ids-upload">
+        <label for="ids-upload-id-1" class="ids-upload-filetype-label" aria-hidden="true" tabindex="-1">
+          <span class="ids-text audible label-filetype">Basic, Press Enter to Browse for files</span>
+        </label>
+        <input id="ids-upload-id-1" type="file" class="ids-upload-filetype" aria-hidden="true" tabindex="-1">
+        <div class="ids-trigger-field ids-input readonly md readonly-background field-height-md">
+          <label class="ids-label-text" for="ids-input-1-input-1" readonly="true">
+            <span class="ids-text">Basic</span>
+          </label>
+          <div class="field-container">
+            <input id="ids-input-1-input-1" type="text" class="ids-input-field left text-ellipsis" readonly="true">
+            <div class="btn-trigger trigger ids-trigger-field-slot-trigger-end">
+              <button class="ids-trigger-button ids-icon-button align-icon-start field-height-md" tabindex="-1">
+                <span class="ids-icon icon-trigger">
+                  <svg part="svg" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+                    viewBox="0 0 18 18" aria-hidden="true">
+                    <path d="M.5 4.5h11.214M.5 16.5h11.77c2.888 0 5.23-2.442 5.23-5.454V4.5h-5.885l-5.884-3H.5v15z"
+                      stroke="currentColor" vector-effect="non-scaling-stroke"></path>
+                  </svg>
+                </span>
+                <span class="text-trigger">
+                  <span class="audible">Trigger button for Basic</span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Clearable -->
+      <div class="ids-upload">
+        <label for="ids-upload-id-2" class="ids-upload-filetype-label" aria-hidden="true" tabindex="-1">
+          <span class="ids-text audible label-filetype">Clearable, Press Enter to Browse for files</span>
+        </label>
+        <input id="ids-upload-id-2" type="file" class="ids-upload-filetype" aria-hidden="true" tabindex="-1">
+        <div class="ids-trigger-field ids-input readonly md readonly-background has-clearable field-height-md">
+          <label class="ids-label-text" for="ids-input-1-input-2" readonly="true">
+            <span class="ids-text">Clearable</span>
+          </label>
+          <div class="field-container">
+            <input id="ids-input-1-input-2" type="text" class="ids-input-field left text-ellipsis" readonly="true" value="myfile.jpg">
+            <div class="btn-clear">
+              <button class="ids-trigger-button ids-icon-button no-margins field-height-md align-icon-start" tabindex="0">
+                <span class="ids-icon icon-clear">
+                  <svg part="svg" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="14" width="14" viewBox="0 0 18 18" aria-hidden="true">
+                    <path d="M17.5.5l-17 17m17 0L.5.5" stroke="currentColor" vector-effect="non-scaling-stroke"></path>
+                  </svg>
+                </span>
+                <span class="text-clear">
+                  <span class="audible">Clear</span>
+                </span>
+              </button>
+            </div>
+            <div class="btn-trigger trigger ids-trigger-field-slot-trigger-end">
+              <button class="ids-trigger-button ids-icon-button align-icon-start field-height-md" tabindex="-1">
+                <span class="ids-icon icon-trigger">
+                  <svg part="svg" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+                    viewBox="0 0 18 18" aria-hidden="true">
+                    <path d="M.5 4.5h11.214M.5 16.5h11.77c2.888 0 5.23-2.442 5.23-5.454V4.5h-5.885l-5.884-3H.5v15z"
+                      stroke="currentColor" vector-effect="non-scaling-stroke"></path>
+                  </svg>
+                </span>
+                <span class="text-trigger">
+                  <span class="audible">Trigger button for Clearable</span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Readonly -->
+      <div class="ids-upload readonly">
+        <label for="ids-upload-id-3" class="ids-upload-filetype-label" aria-hidden="true" tabindex="-1">
+          <span class="ids-text audible label-filetype">Readonly, Press Enter to Browse for files</span>
+        </label>
+        <input id="ids-upload-id-3" type="file" class="ids-upload-filetype" aria-hidden="true" tabindex="-1">
+        <div class="ids-trigger-field ids-input readonly md field-height-md">
+          <label class="ids-label-text" for="ids-input-1-input-3" readonly="true">
+            <span class="ids-text">Readonly</span>
+          </label>
+          <div class="field-container">
+            <input id="ids-input-1-input-3" type="text" class="ids-input-field left text-ellipsis" readonly="true">
+            <div class="btn-trigger trigger ids-trigger-field-slot-trigger-end">
+              <button class="ids-trigger-button ids-icon-button align-icon-start field-height-md" tabindex="-1">
+                <span class="ids-icon icon-trigger">
+                  <svg part="svg" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+                    viewBox="0 0 18 18" aria-hidden="true">
+                    <path d="M.5 4.5h11.214M.5 16.5h11.77c2.888 0 5.23-2.442 5.23-5.454V4.5h-5.885l-5.884-3H.5v15z"
+                      stroke="currentColor" vector-effect="non-scaling-stroke"></path>
+                  </svg>
+                </span>
+                <span class="text-trigger">
+                  <span class="audible">Trigger button for Readonly</span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Disabled -->
+      <div class="ids-upload">
+        <label for="ids-upload-id-4" class="ids-upload-filetype-label" aria-hidden="true" tabindex="-1">
+          <span class="ids-text audible label-filetype">Disabled, Press Enter to Browse for files</span>
+        </label>
+        <input id="ids-upload-id-4" type="file" class="ids-upload-filetype" aria-hidden="true" tabindex="-1" value="Readme.txt">
+        <div class="ids-trigger-field ids-input readonly md readonly-background field-height-md disabled">
+          <label class="ids-label-text" for="ids-input-1-input-4" readonly="true" disabled="true">
+            <span class="ids-text disabled">Disabled</span>
+          </label>
+          <div class="field-container">
+            <input id="ids-input-1-input-4" type="text" class="ids-input-field left text-ellipsis" disabled="true" value="Readme.txt">
+            <div class="btn-trigger trigger ids-trigger-field-slot-trigger-end">
+              <button class="ids-trigger-button ids-icon-button align-icon-start field-height-md" tabindex="-1" disabled="true">
+                <span class="ids-icon icon-trigger">
+                  <svg part="svg" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+                    viewBox="0 0 18 18" aria-hidden="true">
+                    <path d="M.5 4.5h11.214M.5 16.5h11.77c2.888 0 5.23-2.442 5.23-5.454V4.5h-5.885l-5.884-3H.5v15z"
+                      stroke="currentColor" vector-effect="non-scaling-stroke"></path>
+                  </svg>
+                </span>
+                <span class="text-trigger">
+                  <span class="audible">Trigger button for Disabled</span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Validation Required -->
+      <div class="ids-upload">
+        <label for="ids-upload-id-5" class="ids-upload-filetype-label" aria-hidden="true" tabindex="-1">
+          <span class="ids-text audible label-filetype">Required, Press Enter to Browse for files</span>
+        </label>
+        <input id="ids-upload-id-5" type="file" class="ids-upload-filetype" aria-hidden="true" tabindex="-1" readonly="true">
+        <div class="ids-trigger-field ids-input readonly md readonly-background field-height-md">
+          <label class="ids-label-text required" for="ids-input-1-input-5" readonly="true">
+            <span class="ids-text">Required</span>
+          </label>
+          <div class="field-container error">
+            <input id="ids-input-1-input-5" type="text" class="ids-input-field left text-ellipsis" readonly="true">
+            <div class="btn-trigger trigger ids-trigger-field-slot-trigger-end">
+              <button class="ids-trigger-button ids-icon-button align-icon-start field-height-md" tabindex="-1">
+                <span class="ids-icon icon-trigger">
+                  <svg part="svg" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18"
+                    viewBox="0 0 18 18" aria-hidden="true">
+                    <path d="M.5 4.5h11.214M.5 16.5h11.77c2.888 0 5.23-2.442 5.23-5.454V4.5h-5.885l-5.884-3H.5v15z"
+                      stroke="currentColor" vector-effect="non-scaling-stroke"></path>
+                  </svg>
+                </span>
+                <span class="text-trigger">
+                  <span class="audible">Trigger button for Required</span>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div id="ids-input-5-input-error" validation-id="required" class="validation-message error">
+            <span class="ids-icon">
+              <svg part="svg" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" aria-hidden="true">
+                <path
+                  d="M9 1a8 8 0 018 8h1a9 9 0 00-9-9v1zm8 8a8 8 0 01-8 8v1a9 9 0 009-9h-1zm-8 8a8 8 0 01-8-8H0a9 9 0 009 9v-1zM1 9a8 8 0 018-8V0a9 9 0 00-9 9h1zm7.5-4.423V9.5h1V4.577h-1zm0 6.538V12.5h1v-1.385h-1z"
+                  fill="currentColor" stroke="none"></path>
+              </svg>
+            </span>
+            <span class="ids-text error message-text"><span class="ids-text audible">Error </span>Required</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</body>
+</html>

--- a/src/components/ids-upload/demos/standalone-css.ts
+++ b/src/components/ids-upload/demos/standalone-css.ts
@@ -1,0 +1,18 @@
+import { appendStyleSheets } from '../../../../scripts/append-stylesheets';
+import uploadStyles from '../ids-upload.scss';
+import layoutStyles from '../../ids-layout-grid/ids-layout-grid.scss';
+import textStyles from '../../ids-text/ids-text.scss';
+import iconStyles from '../../ids-icon/ids-icon.scss';
+import inputStyles from '../../ids-input/ids-input.scss';
+import triggerFieldStyles from '../../ids-trigger-field/ids-trigger-field.scss';
+import triggerButtonStyles from '../../ids-trigger-field/ids-trigger-button.scss';
+
+appendStyleSheets(
+  uploadStyles,
+  layoutStyles,
+  textStyles,
+  iconStyles,
+  inputStyles,
+  triggerFieldStyles,
+  triggerButtonStyles
+);

--- a/src/components/ids-upload/ids-upload-base.ts
+++ b/src/components/ids-upload/ids-upload-base.ts
@@ -1,12 +1,27 @@
+import IdsLabelStateMixin from '../../mixins/ids-label-state-mixin/ids-label-state-mixin';
+import IdsFieldHeightMixin from '../../mixins/ids-field-height-mixin/ids-field-height-mixin';
+import IdsColorVariantMixin from '../../mixins/ids-color-variant-mixin/ids-color-variant-mixin';
+import IdsTooltipMixin from '../../mixins/ids-tooltip-mixin/ids-tooltip-mixin';
 import IdsDirtyTrackerMixin from '../../mixins/ids-dirty-tracker-mixin/ids-dirty-tracker-mixin';
 import IdsEventsMixin from '../../mixins/ids-events-mixin/ids-events-mixin';
+import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsThemeMixin from '../../mixins/ids-theme-mixin/ids-theme-mixin';
 import IdsElement from '../../core/ids-element';
 
-const Base = IdsDirtyTrackerMixin(
-  IdsThemeMixin(
-    IdsEventsMixin(
-      IdsElement
+const Base = IdsThemeMixin(
+  IdsLabelStateMixin(
+    IdsLocaleMixin(
+      IdsDirtyTrackerMixin(
+        IdsFieldHeightMixin(
+          IdsColorVariantMixin(
+            IdsTooltipMixin(
+              IdsEventsMixin(
+                IdsElement
+              )
+            )
+          )
+        )
+      )
     )
   )
 );

--- a/src/components/ids-upload/ids-upload.scss
+++ b/src/components/ids-upload/ids-upload.scss
@@ -11,6 +11,7 @@
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+    width: -webkit-fill-available;
     z-index: -1;
   }
 }

--- a/src/components/ids-upload/ids-upload.scss
+++ b/src/components/ids-upload/ids-upload.scss
@@ -1,8 +1,6 @@
 @import '../../core/ids-base';
 
 .ids-upload {
-  // @include mb-16();
-
   position: relative;
 
   .ids-upload-filetype {
@@ -11,7 +9,7 @@
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    width: -webkit-fill-available;
+    width: -webkit-fill-available; // stylelint-disable-line
     z-index: -1;
   }
 }

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -187,7 +187,6 @@ export const attributes = {
   NO_MARGINS: 'no-margins',
   NO_PADDING: 'no-padding',
   NO_RIPPLE: 'no-ripple',
-  NO_TEXT_ELLIPSIS: 'no-text-ellipsis',
   OPACITY: 'opacity',
   OVER: 'over',
   OVERFLOW: 'overflow',

--- a/test/ids-upload/ids-upload-func-test.ts
+++ b/test/ids-upload/ids-upload-func-test.ts
@@ -101,17 +101,28 @@ describe('IdsUpload Component', () => {
     upload.size = 'sm';
     upload.validate = 'required';
     upload.value = 'test-value';
+    upload.colorVariant = 'alternate-formatter';
+    upload.fieldHeight = 'lg';
+    upload.labelState = 'hidden';
+    upload.noMargins = true;
     upload.template();
     expect(upload.fileInput.getAttribute('accept')).toEqual('.jpg');
     expect(upload.fileInput.getAttribute('multiple')).toEqual('multiple');
     expect(upload.textInput.getAttribute('dirty-tracker')).toEqual('true');
     expect(upload.textInput.getAttribute('disabled')).toEqual('true');
-    expect(upload.textInput.getAttribute('text-ellipsis')).toEqual(null);
+    expect(upload.textInput.getAttribute('text-ellipsis')).toEqual('true');
     expect(upload.textInput.getAttribute('label')).toEqual('test');
     expect(upload.textInput.getAttribute('readonly')).toBeTruthy();
     expect(upload.textInput.getAttribute('size')).toEqual('sm');
     expect(upload.textInput.getAttribute('validate')).toEqual('required');
     expect(upload.textInput.value).toEqual('test-value');
+    expect(upload.textInput.colorVariant).toEqual('alternate-formatter');
+    expect(upload.textInput.fieldHeight).toEqual('lg');
+    expect(upload.textInput.labelState).toEqual('hidden');
+    expect(upload.textInput.noMargins).toEqual(true);
+    upload.compact = true;
+    upload.template();
+    expect(upload.textInput.compact).toEqual(true);
   });
 
   it('should set hasAccess', () => {
@@ -153,7 +164,9 @@ describe('IdsUpload Component', () => {
     upload.readonly = true;
     expect(upload.getAttribute('readonly')).toBeTruthy();
     expect(upload.textInput.readonlyBackground).toBeFalsy();
+    upload.textInput.readonly = false;
     upload.readonly = false;
+    expect(upload.textInput.readonly).toBe(true);
     expect(upload.getAttribute('readonly')).toEqual(null);
     expect(upload.textInput.readonlyBackground).toBeTruthy();
   });
@@ -180,17 +193,21 @@ describe('IdsUpload Component', () => {
     expect(upload.fileInput.getAttribute('multiple')).toEqual(null);
   });
 
-  it('renders as no-text-ellipsis', () => {
-    expect(upload.getAttribute('no-text-ellipsis')).toEqual(null);
-    expect(upload.noTextEllipsis).toBe(null);
+  it('should set text-ellipsis', () => {
+    expect(upload.getAttribute('text-ellipsis')).toEqual(null);
+    expect(upload.textEllipsis).toBe(true);
     expect(upload.textInput.textEllipsis).toBeTruthy();
-    upload.noTextEllipsis = true;
-    expect(upload.getAttribute('no-text-ellipsis')).toBeTruthy();
-    expect(upload.noTextEllipsis).toBeTruthy();
+    upload.textEllipsis = true;
+    expect(upload.getAttribute('text-ellipsis')).toBeTruthy();
+    expect(upload.textEllipsis).toBeTruthy();
+    expect(upload.textInput.textEllipsis).toBe(true);
+    upload.textEllipsis = false;
+    expect(upload.getAttribute('text-ellipsis')).toEqual('false');
+    expect(upload.textEllipsis).toBe(false);
     expect(upload.textInput.textEllipsis).toBe(false);
-    upload.noTextEllipsis = false;
-    expect(upload.getAttribute('no-text-ellipsis')).toEqual(null);
-    expect(upload.noTextEllipsis).toBe(null);
+    upload.textEllipsis = null;
+    expect(upload.getAttribute('text-ellipsis')).toEqual(null);
+    expect(upload.textEllipsis).toBe(true);
     expect(upload.textInput.textEllipsis).toBeTruthy();
   });
 
@@ -236,6 +253,78 @@ describe('IdsUpload Component', () => {
     upload.label = null;
     expect(upload.getAttribute('label')).toEqual(null);
     expect(upload.textInput.label).toBe('');
+  });
+
+  it('should set color variant', () => {
+    expect(upload.getAttribute('color-variant')).toEqual(null);
+    expect(upload.textInput.colorVariant).toBe(null);
+    upload.colorVariant = 'alternate-formatter';
+    expect(upload.getAttribute('color-variant')).toEqual('alternate-formatter');
+    expect(upload.textInput.colorVariant).toBe('alternate-formatter');
+  });
+
+  it('should set label state', () => {
+    expect(upload.getAttribute('label-state')).toEqual(null);
+    expect(upload.textInput.labelState).toBe(null);
+    upload.labelState = 'hidden';
+    expect(upload.getAttribute('label-state')).toEqual('hidden');
+    expect(upload.textInput.labelState).toBe('hidden');
+    upload.labelState = null;
+    expect(upload.getAttribute('label-state')).toEqual(null);
+    expect(upload.textInput.labelState).toBe(null);
+  });
+
+  it('should set label required', () => {
+    expect(upload.getAttribute('label-required')).toEqual(null);
+    expect(upload.textInput.labelRequired).toBe(true);
+    upload.labelRequired = 'false';
+    expect(upload.getAttribute('label-required')).toEqual('false');
+    expect(upload.textInput.labelRequired).toBe(false);
+    upload.labelRequired = null;
+    expect(upload.getAttribute('label-required')).toEqual(null);
+    expect(upload.textInput.labelRequired).toBe(true);
+  });
+
+  it('should set no margins', () => {
+    expect(upload.getAttribute('no-margins')).toEqual(null);
+    expect(upload.textInput.noMargins).toBe(false);
+    upload.noMargins = true;
+    expect(upload.getAttribute('no-margins')).toEqual('true');
+    expect(upload.textInput.noMargins).toBe(true);
+    upload.noMargins = null;
+    expect(upload.getAttribute('no-margins')).toEqual(null);
+    expect(upload.textInput.noMargins).toBe(false);
+  });
+
+  it('should set tabbable', () => {
+    expect(upload.getAttribute('tabbable')).toEqual(null);
+    expect(upload.textInput.tabbable).toBe(false);
+    upload.tabbable = true;
+    expect(upload.getAttribute('tabbable')).toEqual('true');
+    expect(upload.textInput.tabbable).toBe(true);
+    upload.tabbable = null;
+    expect(upload.getAttribute('tabbable')).toEqual(null);
+    expect(upload.textInput.tabbable).toBe(false);
+  });
+
+  it('should set field-height and compact', () => {
+    expect(upload.getAttribute('field-height')).toEqual(null);
+    expect(upload.getAttribute('compact')).toEqual(null);
+    expect(upload.textInput.fieldHeight).toBe(null);
+    upload.fieldHeight = 'lg';
+    expect(upload.getAttribute('field-height')).toEqual('lg');
+    expect(upload.getAttribute('compact')).toEqual(null);
+    expect(upload.textInput.fieldHeight).toBe('lg');
+    upload.fieldHeight = null;
+    upload.compact = true;
+    expect(upload.getAttribute('field-height')).toEqual(null);
+    expect(upload.getAttribute('compact')).toEqual('');
+    expect(upload.textInput.fieldHeight).toBe(null);
+    upload.compact = null;
+    upload.onFieldHeightChange();
+    expect(upload.getAttribute('field-height')).toEqual(null);
+    expect(upload.getAttribute('compact')).toEqual(null);
+    expect(upload.textInput.fieldHeight).toBe(null);
   });
 
   it('should render label filetype', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
- Added tabbable, label-state, field-height/compact settings to sync ids-upload with ids-input/ids-trigger-field.
- Added standalone css example
- More tests and coverage
- Update docs and other cleanup

**Related github/jira issue (required)**:
Closes #589

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-upload/sandbox.html
- See examples for tabbable, label-state, field-height/compact
- Standalone css: http://localhost:4300/ids-upload/standalone-css.html
- See the styles for all states

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
