### PR TITLE
564 - Integrate Masked Inputs with IdsLocale

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -47,7 +47,8 @@ For more details on breaking changes see each component in the individual README
   make it a sticky/bar indicator that sticks to the top of a component via the `sticky` flag.
   - Can make the indicator determinate by providing a `progress` attribute with a number representing the percentage
   from 0-100 that the indicator is representing a process completed so far.
-- `[Menu Button]` The menu button component was converted to a web component. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-menu-button/README.md#converting-from-previous-versions for details. ([#173](https://github.com/infor-design/enterprise-wc/issues/173))
+- `[Mask]` The mask component has been changed to a mixin and added to IdsInput components. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-mask/README.md#converting-from-previous-versions-breaking-changes) for details. ([#125](https://github.com/infor-design/enterprise-wc/issues/125))
+- `[Menu Button]` The menu button component was converted to a web component. See the [README](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-menu-button/README.md#converting-from-previous-versions-breaking-changes) for details. ([#173](https://github.com/infor-design/enterprise-wc/issues/173))
 - `[Message]` The Message is now a web component called ids-message
   - The Message component now extends the Modal component, containing the same properties and methods.
   - Modal Buttons, Title, Status, and Message can be changed via API

--- a/src/components/ids-mask/README.md
+++ b/src/components/ids-mask/README.md
@@ -79,6 +79,8 @@ input.mask = (rawValue, opts) => {
 
 Ids Mask comes with some built in masking functions.  These hook into other IDS components and utilities to provide localization and formatting.
 
+#### Date Masks
+
 For example, configuring an input field to mask as a U.S. localized short-hand date could be done this way:
 
 ```js
@@ -96,6 +98,10 @@ As a convenience, built-in masks can also be automatically applied with shorthan
 ```js
 input.mask = 'date';
 ```
+
+When using the date mask this way, the automatically-applied date format will be a short date format supplied by [IdsLocale](../ids-locale/README.MD).
+
+#### Number Mask
 
 Another example is configuring an input field to mask a fully-formatted number, with proper localization of thousands separator, decimal, and currency symbol placement.  An example of configuring the field for a U.S. localized formatted number could be this:
 
@@ -119,6 +125,8 @@ As a convenience, the number formatter can also be applied by string:
 input.mask = 'number';
 ```
 
+When using the number mask this way, the number will be formatted with localized decimal, thousands (group) separator, negative, and currency symbols supplied by [IdsLocale](../ids-locale/README.MD).
+
 ## Settings (Attributes)
 
 - `mask` {Array<string|RegExp>|Function} the mask that is applied to the input.
@@ -126,10 +134,18 @@ input.mask = 'number';
 - `mask-retain-positions` {boolean} if true, combined with guides, creates masked input that allows sections between literal characters to be removed/replaced without altering the position of the characters in other sections.
 - `mask-guide` {boolean} if true, displays the complete mask as a "placeholder" in the input field once input has been entered.  Pattern characters are represented as `_` or other defined character, and literal characters are shown in-line.  This feature is only applicable to array-based pattern masks.
 
-## Converting from Previous Versions
+## Converting from Previous Versions (Breaking Changes)
 
-### Converting from 4.x
+**3.x to 4.x**
 
-The Mask is no longer a standalone component, but applied as a mixin to all [Ids Input Components](../ids-input/README.md).  To enable a mask, all that's necessary is to define the `mask` property of an Ids Input.
+- Mask is a new component in 4.0.0
+- Invoke with `.mask()` on any `<input type="text">` element
 
-What used to be defined as a `patternOptions` setting in 4.x will now be applied to the Ids Input's `maskOptions` property.  All the previous built-in mask settings have remained unchanged between 4.x and 5.x
+**4.x to 5.x**
+
+- Mask is now an Ids Mixin applied to [IdsInput](../ids-input/README.md)
+- To enable a mask, all that's necessary is to define the `mask` attribute of an IdsInput
+- If using events, events are now plain JS events
+- 4.x `patternOptions` settings are applied to masks with the `mask-options` attribute on IdsInput. All the previous built-in mask settings have remained unchanged between 4.x and 5.x
+- When using `mask="date"` on the element, an [IdsLocale](../ids-locale/README.md)-driven date format is applied to the field's mask
+- When using `mask="number"` on the element, an [IdsLocale](../ids-locale/README.md)-driven number format is applied to the field's mask

--- a/src/components/ids-mask/TODO.md
+++ b/src/components/ids-mask/TODO.md
@@ -1,0 +1,11 @@
+# Ids Mask TODO
+
+Keep this file in sync with #678
+
+## Minor
+
+- [ ] Finish implementing correct Typescript types ([#575](https://github.com/infor-design/enterprise-wc/issues/575))
+- [ ] Split up built-in mask functions into their own source (improves dependency chain) ([#574](https://github.com/infor-design/enterprise-wc/issues/574))
+- [ ] Re-implement built-in "range" masks (date ranges, number ranges) ([]())
+- [ ] Fix integration of built-in autocorrected date pipe function for fixing incorrect dates as they're typed in ([]())
+- [ ] Fix number mask bug with locales that use the Space character as a thousands separator or decimal ([]())

--- a/src/components/ids-mask/demos/index.html
+++ b/src/components/ids-mask/demos/index.html
@@ -23,7 +23,7 @@
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
         <ids-input id="mask-number" label="Formatted Number"
-          placeholder="-1,000,000.00"></ids-input>
+          placeholder="-1,000,000.00" text-align="right"></ids-input>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-mask/demos/index.yaml
+++ b/src/components/ids-mask/demos/index.yaml
@@ -11,6 +11,10 @@
     description: Shows a mask set but a string attribute
   - link: number-leading-zeros.html
     description: Shows a test with leading zeros
+  - link: localized-dates.html
+    desrciption: Shows masked input fields containing dates that are fixed to the current Locale
+  - link: localized-numbers.html
+    desrciption: Shows masked input fields containing numbers that are fixed to the current Locale
   - link: prefix-suffix.html
     description: Shows adding a prefix or suffix to the mask
   - link: side-by-side.html

--- a/src/components/ids-mask/demos/localized-dates.html
+++ b/src/components/ids-mask/demos/localized-dates.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+</head>
+
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid cols="3" gap="md">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h1">Masked Inputs (Localized Dates)</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid cols="1" gap="md">
+      <ids-layout-grid-cell>
+        <ids-dropdown id="locales" size="sm" label="Choose Locale" dirty-tracker="true" value="en-US">
+          <ids-list-box>
+            <ids-list-box-option value="en-US">en-US</ids-list-box-option>
+            <ids-list-box-option value="de-DE">de-DE</ids-list-box-option>
+            <ids-list-box-option value="he-IL">he-IL</ids-list-box-option>
+            <ids-list-box-option value="ar-EG">ar-EG</ids-list-box-option>
+            <ids-list-box-option value="zh-TW">zh-TW</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid cols="3" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-date-short" size="sm" label="Short Date"></ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid cols="3" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-date-time" size="sm" label="Timestamp"></ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+
+</html>

--- a/src/components/ids-mask/demos/localized-dates.ts
+++ b/src/components/ids-mask/demos/localized-dates.ts
@@ -1,0 +1,43 @@
+// Supporting components
+import '../../ids-input/ids-input';
+import '../../ids-dropdown/ids-dropdown';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const pageContainer: any = document.querySelector('ids-container');
+  const dropdown: any = document.querySelector('ids-dropdown');
+  let calendar = pageContainer.locale.calendar();
+
+  // Configure date inputs
+  const dateInputShort: any = document.querySelector('#mask-date-short');
+  dateInputShort.mask = 'date';
+  dateInputShort.maskOptions = {
+    format: calendar.dateFormat.short || 'M/d/yyyy'
+  };
+  dateInputShort.placeholder = calendar.dateFormat.short;
+  const dateInputTime: any = document.querySelector('#mask-date-time');
+  dateInputTime.mask = 'date';
+  dateInputTime.maskOptions = {
+    format: calendar.dateFormat.timestamp || 'M/d/yyyy'
+  };
+  dateInputTime.placeholder = calendar.dateFormat.timestamp;
+
+  // Change the IdsContainer's locale setting when the dropdown is modified
+  dropdown.addEventListener('change', async (e: any) => {
+    await pageContainer.setLocale(e.target.value);
+  });
+
+  // Change locale on the date input when the Page container's locale changes
+  pageContainer.addEventListener('localechange', () => {
+    calendar = pageContainer.locale.calendar();
+    const shortFormat = calendar.dateFormat.short;
+    const timeFormat = calendar.dateFormat.timestamp;
+
+    dateInputShort.value = '';
+    dateInputShort.placeholder = shortFormat;
+    dateInputShort.maskOptions.format = shortFormat;
+
+    dateInputTime.value = '';
+    dateInputTime.placeholder = timeFormat;
+    dateInputTime.maskOptions.format = timeFormat;
+  });
+});

--- a/src/components/ids-mask/demos/localized-dates.ts
+++ b/src/components/ids-mask/demos/localized-dates.ts
@@ -7,19 +7,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const dropdown: any = document.querySelector('ids-dropdown');
   let calendar = pageContainer.locale.calendar();
 
-  // Configure date inputs
+  // Configure Short Date input
   const dateInputShort: any = document.querySelector('#mask-date-short');
   dateInputShort.mask = 'date';
-  dateInputShort.maskOptions = {
-    format: calendar.dateFormat.short || 'M/d/yyyy'
-  };
-  dateInputShort.placeholder = calendar.dateFormat.short;
+  dateInputShort.placeholder = dateInputShort.maskOptions.format;
+
+  // The default date format absorbed by the Mask Mixin from IdsLocale is "short".
+  // For the timestamp field, we have to manually override the format set by the mixin.
   const dateInputTime: any = document.querySelector('#mask-date-time');
   dateInputTime.mask = 'date';
   dateInputTime.maskOptions = {
-    format: calendar.dateFormat.timestamp || 'M/d/yyyy'
+    format: calendar.dateFormat.timestamp
   };
-  dateInputTime.placeholder = calendar.dateFormat.timestamp;
+  dateInputTime.placeholder = dateInputTime.maskOptions.format;
 
   // Change the IdsContainer's locale setting when the dropdown is modified
   dropdown.addEventListener('change', async (e: any) => {
@@ -33,11 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const timeFormat = calendar.dateFormat.timestamp;
 
     dateInputShort.value = '';
-    dateInputShort.placeholder = shortFormat;
     dateInputShort.maskOptions.format = shortFormat;
+    dateInputShort.placeholder = dateInputShort.maskOptions.format;
 
     dateInputTime.value = '';
-    dateInputTime.placeholder = timeFormat;
     dateInputTime.maskOptions.format = timeFormat;
+    dateInputTime.placeholder = dateInputTime.maskOptions.format;
   });
 });

--- a/src/components/ids-mask/demos/localized-numbers.html
+++ b/src/components/ids-mask/demos/localized-numbers.html
@@ -65,6 +65,104 @@
         <ids-input id="mask-number-groups-thousands-decimal-negative" label="Thousands + Groups + Decimal + Negative"></ids-input>
       </ids-layout-grid-cell>
     </ids-layout-grid>
+
+    <!-- Millions-length Inputs without groups -->
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-millions" label="Millions"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-millions-negative" label="Millions + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-millions-decimal" label="Millions + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-millions-decimal-negative" label="Millions + Decimal + Negative"></ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <!-- Millions-length Inputs with groups -->
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-millions" label="Millions + Groups"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-millions-negative" label="Millions + Groups + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-millions-decimal" label="Millions + Groups + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-millions-decimal-negative" label="Millions + Groups + Decimal + Negative"></ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <!-- Billions-length Inputs without groups -->
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-billions" label="Billions"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-billions-negative" label="Billions + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-billions-decimal" label="Billions + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-billions-decimal-negative" label="Billions + Decimal + Negative"></ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <!-- Billions-length Inputs with groups -->
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-billions" label="Billions + Groups"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-billions-negative" label="Billions + Groups + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-billions-decimal" label="Billions + Groups + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-billions-decimal-negative" label="Billions + Groups + Decimal + Negative">
+        </ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <!-- Quintillions-length Inputs without groups -->
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-quintillions" label="Quintillions"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-quintillions-negative" label="Quintillions + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-quintillions-decimal" label="Quintillions + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-quintillions-decimal-negative" label="Quintillions + Decimal + Negative"></ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <!-- Quintillions-length Inputs with groups -->
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-quintillions" label="Quintillions + Groups"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-quintillions-negative" label="Quintillions + Groups + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-quintillions-decimal" label="Quintillions + Groups + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-quintillions-decimal-negative" label="Quintillions + Groups + Decimal + Negative">
+        </ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
   </ids-container>
 </body>
 

--- a/src/components/ids-mask/demos/localized-numbers.html
+++ b/src/components/ids-mask/demos/localized-numbers.html
@@ -12,7 +12,7 @@
     <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
     <ids-layout-grid cols="3" gap="md">
       <ids-layout-grid-cell>
-        <ids-text font-size="12" type="h1">Masked Inputs (Localized Dates)</ids-text>
+        <ids-text font-size="12" type="h1">Masked Inputs (Localized Numbers)</ids-text>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
@@ -34,15 +34,35 @@
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
-    <ids-layout-grid cols="3" gap="md">
+    <!-- Thousands-length Inputs without groups -->
+    <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
-        <ids-input id="mask-date-short" size="sm" label="Short Date"></ids-input>
+        <ids-input id="mask-number-thousands" label="Thousands"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-thousands-negative" label="Thousands + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-thousands-decimal" label="Thousands + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-thousands-decimal-negative" label="Thousands + Decimal + Negative"></ids-input>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
-    <ids-layout-grid cols="3" gap="md">
+    <!-- Thousands-length Inputs with groups -->
+    <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
-        <ids-input id="mask-date-time" size="sm" label="Timestamp"></ids-input>
+        <ids-input id="mask-number-groups-thousands" label="Thousands + Groups"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-thousands-negative" label="Thousands + Groups + Negative"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-thousands-decimal" label="Thousands + Groups + Decimal"></ids-input>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-input id="mask-number-groups-thousands-decimal-negative" label="Thousands + Groups + Decimal + Negative"></ids-input>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-mask/demos/localized-numbers.ts
+++ b/src/components/ids-mask/demos/localized-numbers.ts
@@ -6,8 +6,6 @@ import { deepClone } from '../../../utils/ids-deep-clone-utils/ids-deep-clone-ut
 document.addEventListener('DOMContentLoaded', () => {
   const pageContainer: any = document.querySelector('ids-container');
   const dropdown: any = document.querySelector('ids-dropdown');
-  let options = pageContainer.locale.locale.options;
-  let numbers = options.numbers;
 
   // Uses the defined integer/decimal limits to create an IdsInput
   // `placeholder` definition based on the actual length of the mask.
@@ -52,14 +50,6 @@ document.addEventListener('DOMContentLoaded', () => {
   allInputs.forEach((input) => {
     input.textAlign = 'right';
     input.mask = 'number';
-    input.maskOptions = {
-      symbols: {
-        currency: options.currencySign,
-        decimal: numbers.decimal,
-        negative: numbers.minusSign,
-        thousands: numbers.group,
-      }
-    };
   });
 
   const allNegativeInputs: Array<any> = [...document.querySelectorAll('[id*="negative"]')];
@@ -94,13 +84,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Change localized strings on all number inputs when the Page container's locale changes
   pageContainer.addEventListener('localechange', () => {
-    options = pageContainer.locale.locale.options;
-    numbers = options.numbers;
     allInputs.forEach((input) => {
-      input.maskOptions.symbols.currency = options.currencySign;
-      input.maskOptions.symbols.decimal = numbers.decimal;
-      input.maskOptions.symbols.negative = numbers.minusSign;
-      input.maskOptions.symbols.thousands = numbers.group;
+      input.value = '';
       createPlaceholder(input);
     });
   });

--- a/src/components/ids-mask/demos/localized-numbers.ts
+++ b/src/components/ids-mask/demos/localized-numbers.ts
@@ -76,6 +76,30 @@ document.addEventListener('DOMContentLoaded', () => {
     createPlaceholder(input);
   });
 
+  // Set limits on "millions-length" inputs
+  const allMillionsInputs: Array<any> = [...document.querySelectorAll('[id*="millions"]')];
+  allMillionsInputs.forEach((input) => {
+    input.maskOptions.integerLimit = 7;
+    createPlaceholder(input);
+  });
+
+  // Set limits on "billions-length" inputs
+  const allBillionsInputs: Array<any> = [...document.querySelectorAll('[id*="billions"]')];
+  allBillionsInputs.forEach((input) => {
+    input.maskOptions.integerLimit = 10;
+    createPlaceholder(input);
+  });
+
+  // Set limits on "quintillions-length" inputs
+  const allQuintillionsInputs: Array<any> = [...document.querySelectorAll('[id*="quintillions"]')];
+  allQuintillionsInputs.forEach((input) => {
+    input.maskOptions.integerLimit = 18;
+    if (input.id.includes('decimal')) {
+      input.maskOptions.decimalLimit = 6;
+    }
+    createPlaceholder(input);
+  });
+
   // ===================================================
   // Change the IdsContainer's locale setting when the dropdown is modified
   dropdown.addEventListener('change', async (e: any) => {

--- a/src/components/ids-mask/demos/localized-numbers.ts
+++ b/src/components/ids-mask/demos/localized-numbers.ts
@@ -1,0 +1,107 @@
+// Supporting components
+import '../../ids-input/ids-input';
+import '../../ids-dropdown/ids-dropdown';
+import { deepClone } from '../../../utils/ids-deep-clone-utils/ids-deep-clone-utils';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const pageContainer: any = document.querySelector('ids-container');
+  const dropdown: any = document.querySelector('ids-dropdown');
+  let options = pageContainer.locale.locale.options;
+  let numbers = options.numbers;
+
+  // Uses the defined integer/decimal limits to create an IdsInput
+  // `placeholder` definition based on the actual length of the mask.
+  const createPlaceholder = (input: any) => {
+    const ints = input.maskOptions.integerLimit;
+    const decs = input.maskOptions.decimalLimit || 0;
+    let placeholder = '';
+
+    for (let i = 0; i < ints; i++) {
+      placeholder += '1';
+    }
+
+    if (input.maskOptions.allowDecimal) {
+      placeholder += input.maskOptions.symbols.decimal;
+      for (let i = 0; i < decs; i++) {
+        placeholder += '1';
+      }
+    }
+
+    // calling `input.mask()` directly doesn't include the locale,
+    // since it's normally added by the IdsInput
+    const opts = deepClone(input.maskOptions);
+    opts.locale = input.locale;
+    const maskArray = input.mask(placeholder, opts).mask;
+
+    // Write a placeholder string based on a slightly-modified mask array
+    // (removes "[]"" caret traps and replaces regex matchers with "#")
+    input.placeholder = `${maskArray.map((el: any) => {
+      if (typeof el !== 'string') {
+        return '#';
+      }
+      if (el === '[]') {
+        return '';
+      }
+      return el;
+    }).join('')}`;
+  };
+
+  // ===================================================
+  // Set basic rules on all input fields
+  const allInputs: Array<any> = [...document.querySelectorAll('ids-input')];
+  allInputs.forEach((input) => {
+    input.textAlign = 'right';
+    input.mask = 'number';
+    input.maskOptions = {
+      symbols: {
+        currency: options.currencySign,
+        decimal: numbers.decimal,
+        negative: numbers.minusSign,
+        thousands: numbers.group,
+      }
+    };
+  });
+
+  const allNegativeInputs: Array<any> = [...document.querySelectorAll('[id*="negative"]')];
+  allNegativeInputs.forEach((input) => {
+    input.maskOptions.allowNegative = true;
+  });
+
+  const allDecimalInputs: Array<any> = [...document.querySelectorAll('[id*="decimal"]')];
+  allDecimalInputs.forEach((input) => {
+    input.maskOptions.allowDecimal = true;
+    input.maskOptions.decimalLimit = 2;
+  });
+
+  const allGroupInputs: Array<any> = [...document.querySelectorAll('[id*="group"]')];
+  allGroupInputs.forEach((input) => {
+    input.maskOptions.allowThousandsSeparator = true;
+  });
+
+  // ===================================================
+  // Set limits on "thousands-length" inputs
+  const allThousandsInputs: Array<any> = [...document.querySelectorAll('[id*="thousands"]')];
+  allThousandsInputs.forEach((input) => {
+    input.maskOptions.integerLimit = 4;
+    createPlaceholder(input);
+  });
+
+  // ===================================================
+  // Change the IdsContainer's locale setting when the dropdown is modified
+  dropdown.addEventListener('change', async (e: any) => {
+    await pageContainer.setLocale(e.target.value);
+  });
+
+  // Change localized strings on all number inputs when the Page container's locale changes
+  pageContainer.addEventListener('localechange', () => {
+    options = pageContainer.locale.locale.options;
+    numbers = options.numbers;
+    allInputs.forEach((input) => {
+      input.maskOptions.symbols.currency = options.currencySign;
+      input.maskOptions.symbols.decimal = numbers.decimal;
+      input.maskOptions.symbols.negative = numbers.minusSign;
+      input.maskOptions.symbols.thousands = numbers.group;
+      createPlaceholder(input);
+    });
+  });
+});

--- a/src/components/ids-mask/ids-mask-api.ts
+++ b/src/components/ids-mask/ids-mask-api.ts
@@ -27,7 +27,7 @@ class MaskAPI {
    * @param {object} [opts] process options
    * @returns {object} containing the processed mask along with some meta-data
    */
-  process(rawValue: string, opts: IdsMaskOptions) {
+  process(rawValue: string, opts: IdsMaskOptions = {}) {
     if (typeof rawValue !== 'string') {
       throw new Error('No string provided');
     }
@@ -56,6 +56,7 @@ class MaskAPI {
       const maskOpts = deepClone(opts.patternOptions);
       maskOpts.caretPos = opts.selection.start;
       maskOpts.previousMaskResult = opts.previousMaskResult;
+      maskOpts.locale = opts.locale;
 
       // Get a processed mask pattern from the function.
       // See #4079 for an explanation of the change from just an array to an object with meta-data.

--- a/src/mixins/ids-locale-mixin/ids-locale-mixin.ts
+++ b/src/mixins/ids-locale-mixin/ids-locale-mixin.ts
@@ -17,6 +17,9 @@ const IdsLocaleMixin = (superclass: any) => class extends superclass {
     this.offEvent('localechange.mixin');
     this.onEvent('localechange.mixin', getClosest(this, 'ids-container'), () => {
       this.setDirection();
+      if (typeof this.onLocaleChange === 'function') {
+        this.onLocaleChange(this.locale);
+      }
     });
     super.connectedCallback?.();
   }

--- a/src/mixins/ids-mask-mixin/ids-mask-mixin.ts
+++ b/src/mixins/ids-mask-mixin/ids-mask-mixin.ts
@@ -124,21 +124,39 @@ const IdsMaskMixin = (superclass: any) => class extends superclass {
     } else {
       // Assume string in all other cases
       switch (val) {
-      // Using 'date' as a string automatically connects the standard date mask function
+        // Using 'date' as a string automatically connects the standard date mask function
         case 'date':
           trueVal = dateMask;
+          this.onLocaleChange = () => {
+            if (!this.maskOptions.format) {
+              this.maskOptions.format = this.locale.calendar().dateFormat.short;
+            }
+          };
           break;
           // Using 'number' as a string automatically connects the standard number mask function
         case 'number':
           trueVal = numberMask;
+          this.onLocaleChange = () => {
+            const newLocale = this.locale.locale;
+            this.maskOptions.symbols = {
+              currency: newLocale.options.currencySign,
+              decimal: newLocale.options.numbers.decimal,
+              negative: newLocale.options.numbers.minusSign,
+              thousands: newLocale.options.numbers.group
+            };
+          };
           break;
         default:
           trueVal = convertPatternFromString(val);
+          this.onLocaleChange = undefined;
           break;
       }
     }
 
     this.maskState.pattern = trueVal;
+    if (typeof this.onLocaleChange === 'function') {
+      this.onLocaleChange();
+    }
   }
 
   handleMaskEvents() {

--- a/src/mixins/ids-mask-mixin/ids-mask-mixin.ts
+++ b/src/mixins/ids-mask-mixin/ids-mask-mixin.ts
@@ -1,5 +1,5 @@
 import maskAPI from '../../components/ids-mask/ids-mask-global';
-import { convertPatternFromString, PLACEHOLDER_CHAR } from '../../components/ids-mask/ids-mask-common';
+import { convertPatternFromString, PLACEHOLDER_CHAR, IdsMaskOptions } from '../../components/ids-mask/ids-mask-common';
 import { dateMask, numberMask } from '../../components/ids-mask/ids-masks';
 import { attributes } from '../../core/ids-attributes';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
@@ -148,11 +148,11 @@ const IdsMaskMixin = (superclass: any) => class extends superclass {
   /**
    * Uses an input value and pattern options to process a masked string.
    * @param {string} rawValue the value to be checked for masking.
-   * @param {object} opts various options that can be passed to the masking process.
+   * @param {IdsMaskOptions} opts various options that can be passed to the masking process.
    * @param {boolean} [doSetValue=false] if true, attempts to set input state when masking completes
    * @returns {string|boolean} the result of the mask.  If no masking was performed, return `false`
    */
-  processMask = (rawValue: string, opts: any, doSetValue = false) => {
+  processMask = (rawValue: string, opts: IdsMaskOptions = {}, doSetValue = false) => {
     // If no mask function/pattern is defined, do not process anything.
     if (!this.mask) {
       return false;
@@ -177,6 +177,7 @@ const IdsMaskMixin = (superclass: any) => class extends superclass {
     const processOptions: any = {
       caretTrapIndexes: [],
       guide: this.maskState.guide,
+      locale: this.locale,
       keepCharacterPositions: this.maskState.keepCharacterPositions,
       pattern: this.mask,
       patternOptions: opts,

--- a/src/mixins/ids-mask-mixin/ids-mask-mixin.ts
+++ b/src/mixins/ids-mask-mixin/ids-mask-mixin.ts
@@ -127,17 +127,17 @@ const IdsMaskMixin = (superclass: any) => class extends superclass {
         // Using 'date' as a string automatically connects the standard date mask function
         case 'date':
           trueVal = dateMask;
-          this.onLocaleChange = () => {
+          this.onLocaleChange = (locale: any) => {
             if (!this.maskOptions.format) {
-              this.maskOptions.format = this.locale.calendar().dateFormat.short;
+              this.maskOptions.format = locale.calendar().dateFormat.short;
             }
           };
           break;
           // Using 'number' as a string automatically connects the standard number mask function
         case 'number':
           trueVal = numberMask;
-          this.onLocaleChange = () => {
-            const newLocale = this.locale.locale;
+          this.onLocaleChange = (locale: any) => {
+            const newLocale = locale.locale;
             this.maskOptions.symbols = {
               currency: newLocale.options.currencySign,
               decimal: newLocale.options.numbers.decimal,
@@ -154,8 +154,8 @@ const IdsMaskMixin = (superclass: any) => class extends superclass {
     }
 
     this.maskState.pattern = trueVal;
-    if (typeof this.onLocaleChange === 'function') {
-      this.onLocaleChange();
+    if (typeof this.onLocaleChange === 'function' && this.locale) {
+      this.onLocaleChange(this.locale);
     }
   }
 

--- a/test/ids-mask/ids-mask-date-api-func-test.ts
+++ b/test/ids-mask/ids-mask-date-api-func-test.ts
@@ -122,7 +122,7 @@ describe('IdsMaskAPI (Date)', () => {
   });
 
   // @TODO: fix partial autocorrect
-  it('can partially autocorrect incorrect dates', () => {
+  it.skip('can partially autocorrect incorrect dates', () => {
     const textValue = '15/32/2020';
     const opts: IdsMaskOptions = {
       selection: {

--- a/test/ids-mask/ids-mask-date-api-func-test.ts
+++ b/test/ids-mask/ids-mask-date-api-func-test.ts
@@ -122,12 +122,13 @@ describe('IdsMaskAPI (Date)', () => {
   });
 
   // @TODO: fix partial autocorrect
-  it.skip('can partially autocorrect incorrect dates', () => {
+  it('can partially autocorrect incorrect dates', () => {
     const textValue = '15/32/2020';
     const opts: IdsMaskOptions = {
       selection: {
         start: 0
       },
+      locale,
       pattern: dateMask,
       patternOptions: {
         format: 'M/d/yyyy',

--- a/test/ids-mask/ids-mask-date-api-func-test.ts
+++ b/test/ids-mask/ids-mask-date-api-func-test.ts
@@ -170,8 +170,7 @@ describe('Date Mask function', () => {
     expect(result.mask.length).toBe(12);
   });
 
-  // @TODO: Re-enable after Locale exists
-  it.skip('can handle `ah`', () => {
+  it('can handle `ah`', () => {
     const result = dateMask('202006', {
       format: 'ah:mm'
     });

--- a/test/ids-mask/ids-mask-date-api-func-test.ts
+++ b/test/ids-mask/ids-mask-date-api-func-test.ts
@@ -4,6 +4,7 @@
 import MaskAPI from '../../src/components/ids-mask/ids-mask-api';
 import { IdsMaskOptions } from '../../src/components/ids-mask/ids-mask-common';
 import { dateMask, autoCorrectedDatePipe } from '../../src/components/ids-mask/ids-masks';
+import locale from '../../src/components/ids-locale/ids-locale-global';
 
 describe('IdsMaskAPI (Date)', () => {
   let api: any;
@@ -162,6 +163,7 @@ describe('Date Mask function', () => {
 
   it('can handle time periods', () => {
     const result = dateMask('1212am', {
+      locale,
       format: 'HH:mm a'
     });
 
@@ -172,6 +174,7 @@ describe('Date Mask function', () => {
 
   it('can handle `ah`', () => {
     const result = dateMask('202006', {
+      locale,
       format: 'ah:mm'
     });
 

--- a/test/ids-mask/ids-mask-number-api-func-test.ts
+++ b/test/ids-mask/ids-mask-number-api-func-test.ts
@@ -4,6 +4,7 @@
 import MaskAPI from '../../src/components/ids-mask/ids-mask-api';
 import { IdsMaskOptions } from '../../src/components/ids-mask/ids-mask-common';
 import { numberMask } from '../../src/components/ids-mask/ids-masks';
+import locale from '../../src/components/ids-locale/ids-locale-global';
 
 let api: any;
 
@@ -49,9 +50,11 @@ describe('IdsMaskAPI (Number)', () => {
       selection: {
         start: 0
       },
+      locale,
       pattern: numberMask,
       patternOptions: {
         locale: 'en-US',
+        allowDecimal: false,
         allowThousandsSeparator: true,
         integerLimit: 10
       }
@@ -268,6 +271,7 @@ describe('IdsMaskAPI (Number)', () => {
       selection: {
         start: 0
       },
+      locale,
       pattern: numberMask,
       patternOptions: {
         allowLeadingZeros: true,
@@ -344,6 +348,7 @@ describe('Number Mask function', () => {
 
   it('should account for decimal placement', () => {
     const result = numberMask('.', {
+      allowDecimal: true,
       symbols: {
         decimal: '.'
       }
@@ -400,6 +405,9 @@ describe('Number Mask function', () => {
       allowLeadingZeros: true,
       allowNegative: true,
       allowThousandsSeparator: true,
+      decimalLimit: 2,
+      integerLimit: 7,
+      locale,
       prefix: 'X',
       suffix: 'W',
     };

--- a/test/ids-mask/ids-mask-number-api-func-test.ts
+++ b/test/ids-mask/ids-mask-number-api-func-test.ts
@@ -41,8 +41,8 @@ describe('IdsMaskAPI (Number)', () => {
     expect(result.conformedValue).toEqual('1234.56');
   });
 
-  // @TODO Re-enable this when `Locale.formatNumber()` is implemented.
-  it.skip('should process numbers with thousands separators', () => {
+  // Test that `Locale.formatNumber()` is implemented.
+  it('should process numbers with thousands separators', () => {
     // Handle big numbers with thousands separators
     let textValue = '1111111111';
     const opts: IdsMaskOptions = {
@@ -294,8 +294,7 @@ describe('IdsMaskAPI (Number)', () => {
 
     expect(result.conformedValue).toEqual('00000.123');
 
-    /*
-    // @TODO Re-enable this when `Locale.formatNumber()` is implemented.
+    // Test that `Locale.formatNumber()` is implemented.
     textValue = '10000';
     result = api.process(textValue, opts);
 
@@ -310,7 +309,6 @@ describe('IdsMaskAPI (Number)', () => {
     result = api.process(textValue, opts);
 
     expect(result.conformedValue).toEqual('10,000.100');
-    */
   });
 });
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR reintroduces some mask functionality related to localization of dates and numbers that we previously had in the enterprise components:
- Enabling localized number and date inputs is now possible using `mask="number"` and `mask="date"` attributes on IdsInput
- Added example pages demonstrating how locale can be changed on these fields (not totally automatic since formats can be customized)
- Re-enabled skipped tests and added docs
- Also added final TODOs for mask conversion

**Related github/jira issue (required)**:
- Closes #564 
- Adds TODOs as part of #404 

**Steps necessary to review your pull request (required)**:
Pull/Build/Run, then smoke test the following:

- http://localhost:4300/ids-mask - behavior shouldn't be different than `main`, except for the formatted number field applies group (thousands) separators
- http://localhost:4300/ids-mask/number-leading-zeros.html - try entering a number like `00012345`.  The leading zeros should not interfere with the placement of the group separator
- http://localhost:4300/ids-mask/localized-dates.html - try switching the locale and entering dates/times.  Formatting specified by the placeholders should be respected
- http://localhost:4300/ids-mask/localized-numbers.html - try switching locale and entering numbers.  Formatting specified by the placeholders should be respected
- Check http://localhost:4300/ids-spinbox which uses a number mask internally

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
