### PR TITLE
N/A - Remove IdsRenderLoop dependency from IdsElement

### DIFF
--- a/src/core/ids-element.ts
+++ b/src/core/ids-element.ts
@@ -1,6 +1,4 @@
 import { version } from './ids-attributes';
-import renderLoop from '../components/ids-render-loop/ids-render-loop-global';
-import IdsRenderLoopItem from '../components/ids-render-loop/ids-render-loop-item';
 import { camelCase } from '../utils/ids-string-utils/ids-string-utils';
 import IdsEventsMixin from '../mixins/ids-events-mixin/ids-events-mixin';
 import styles from './ids-element.scss';
@@ -120,12 +118,9 @@ export default class IdsElement extends IdsEventsMixin(HTMLElement) {
 
     // Runs on next next paint to be sure rendered() fully
     if (this.rendered) {
-      renderLoop.register(new IdsRenderLoopItem({
-        duration: 1,
-        timeoutCallback: () => {
-          this.rendered();
-        }
-      }));
+      requestAnimationFrame(() => {
+        this.rendered();
+      });
     }
 
     return this;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes a small change to IdsElement that changes a time-delayed function from using a 1ms `IdsRenderLoopItem` with `requestAnimationFrame()`.  This change results in removing a dependency on IdsRenderLoop from all IdsElements. We previously made similar changes to some individual components, but missed this one instance.

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
Pull/Build/Run, then smoke test components that depend on the time-delayed `rendered()` method.  Behavior of these components should be the same as `main`:

- [IdsMasthead](http://localhost:4300/ids-masthead/example.html)
- [IdsSpinbox](http://localhost:4300/ids-spinbox/example.html)
- [IdsSwipeAction](http://localhost:4300/ids-swipe-action/example.html) - test with mobile browser or responsive dev tools to make swiping work
- [IdsTabs](http://localhost:4300/ids-tabs/example.html)