### PR TITLE
683 - IdsTabs Additional Features

### DIFF
--- a/src/components/ids-swappable/README.md
+++ b/src/components/ids-swappable/README.md
@@ -4,7 +4,8 @@
 IdsSwappable is an abstract component that provides functionality for drag and drop between items or lists. It consists of two components `ids-swappable` which is a container for and number of `ids-swappable-item`. The `ids-swappable-item` makes use of s single `slot` where the user can use virtually any component they would like, most commonly `ids-text` or `ids-card`.
 
 ## Use Cases
-IdsSwappable is used to create the IdsSwaplist, which is used to move objects between 2 or more lists, but is not limited to this use case. It can also be used to create standalone sortable/swappable lists.
+
+IdsSwappable is used to create the [IdsSwaplist](../ids-swaplist/README.md), which is used to move objects between 2 or more lists, but is not limited to this use case. It can also be used to create standalone sortable/swappable element collections.
 
 ## Features (With Code Samples)
 
@@ -41,12 +42,37 @@ data.forEach((d) => {
     `;
 });
 ```
+
+### Mix with other components
+
+Some components support composition with IdsSwappable, such as [IdsTabs](../ids-tabs/README.md).  Since Tabs have their own process for handling selection, using `dragMode="always"` ensures tabs can be moved around regardless of selection:
+
+```html
+<ids-tabs>
+    <ids-swappable dropzone="move">
+        <ids-swappable-item drag-mode="always">
+            <ids-tab value="contracts">Contracts</ids-tab>
+        </ids-swappable-item>
+        <ids-swappable-item drag-mode="always">
+            <ids-tab value="opportunities">Opportunities</ids-tab>
+        </ids-swappable-item>
+        <ids-swappable-item drag-mode="always">
+            <ids-tab value="attachments" disabled>Attachments</ids-tab>
+        </ids-swappable-item>
+        <ids-swappable-item drag-mode="always">
+            <ids-tab value="notes">Notes</ids-tab>
+        </ids-swappable-item>
+    </ids-swappable>
+</ids-tabs>
+```
+
 ## Settings (Attributes)
 
 ### ids-swappable
 **selectedItems** Sets the multi-select attribute. Defaults to false.
 
 ### ids-swappable-item
+**drag-mode** Defines how/when dragging can occur.  By default (`select`), swappable items must first be selected in order to be dragged.  Setting to `always` makes dragging possible at all times.
 **selected** Sets the selected attribute. Items need to be selected before that can be dragged.
 **originalText** Sets the originalText attribute. This happens when the component is connected and is used to revert the text after item is dropped.
 **tabbable** Sets if the item is tabbable. Defaults to true.

--- a/src/components/ids-swappable/ids-swappable-item.scss
+++ b/src/components/ids-swappable/ids-swappable-item.scss
@@ -81,6 +81,7 @@
   position: relative;
   margin: -1px;
 }
+
 ::slotted(ids-tab:not([orientation='vertical'])) {
   margin-inline-start: 3px;
 }

--- a/src/components/ids-swappable/ids-swappable-item.scss
+++ b/src/components/ids-swappable/ids-swappable-item.scss
@@ -73,3 +73,14 @@
 :host([mode='dark'][dragging]) {
   background-color: var(--ids-color-brand-primary-base);
 }
+
+// Fixes slotted IdsTabs to appear flush with their containers
+// (IdsSwappableItem causes a 1px boundary as a result of its required transparent border)
+// @TODO: Relocate this to another component / review wrapping, separation of concerns
+::slotted(ids-tab) {
+  position: relative;
+  margin: -1px;
+}
+::slotted(ids-tab:not([orientation='vertical'])) {
+  margin-inline-start: 3px;
+}

--- a/src/components/ids-swappable/ids-swappable-item.ts
+++ b/src/components/ids-swappable/ids-swappable-item.ts
@@ -204,8 +204,7 @@ export default class IdsSwappableItem extends Base {
    * @param {any} event dragstart event
    */
   #dragOver(event: any) {
-    event.dataTransfer.dropEffect = 'move';
-
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
     if (this.hasAttribute(attributes.DRAGGING)) {
       this.removeAttribute(attributes.OVER);
     } else {

--- a/src/components/ids-swappable/ids-swappable-item.ts
+++ b/src/components/ids-swappable/ids-swappable-item.ts
@@ -201,8 +201,11 @@ export default class IdsSwappableItem extends Base {
 
   /**
    * Handle functionality for the dragover event
+   * @param {any} event dragstart event
    */
-  #dragOver() {
+  #dragOver(event: any) {
+    event.dataTransfer.dropEffect = 'move';
+
     if (this.hasAttribute(attributes.DRAGGING)) {
       this.removeAttribute(attributes.OVER);
     } else {
@@ -312,8 +315,8 @@ export default class IdsSwappableItem extends Base {
     this.offEvent('drop', this, () => this.#dragEnd());
     this.onEvent('drop', this, () => this.#dragEnd());
 
-    this.offEvent('dragover', this, () => this.#dragOver());
-    this.onEvent('dragover', this, () => this.#dragOver());
+    this.offEvent('dragover', this, (e: any) => this.#dragOver(e));
+    this.onEvent('dragover', this, (e: any) => this.#dragOver(e));
 
     this.offEvent('dragleave', this, () => this.#dragLeave());
     this.onEvent('dragleave', this, () => this.#dragLeave());

--- a/src/components/ids-swappable/ids-swappable-item.ts
+++ b/src/components/ids-swappable/ids-swappable-item.ts
@@ -179,6 +179,9 @@ export default class IdsSwappableItem extends Base {
   #dragStart(event: any) {
     event.dataTransfer?.setData('text/plain', event.target.innerText);
     this.setAttribute(attributes.DRAGGING, '');
+    [...this.children].forEach((elem) => {
+      elem.setAttribute(attributes.DRAGGING, '');
+    });
   }
 
   /**
@@ -189,6 +192,9 @@ export default class IdsSwappableItem extends Base {
       this.setAttribute(attributes.DRAGGABLE, 'false');
     }
     this.removeAttribute(attributes.DRAGGING);
+    [...this.children].forEach((elem) => {
+      elem.removeAttribute(attributes.DRAGGING, '');
+    });
     this.removeAttribute(attributes.SELECTED);
     this.removeAttribute(attributes.OVER);
   }

--- a/src/components/ids-swappable/ids-swappable-item.ts
+++ b/src/components/ids-swappable/ids-swappable-item.ts
@@ -8,6 +8,8 @@ import Base from './ids-swappable-item-base';
 import styles from './ids-swappable-item.scss';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 
+type IdsSwappableDragMode = 'select' | 'always';
+
 /**
  * IDS Swappable Item Component
  * @type {IdsSwappableItem}
@@ -24,14 +26,18 @@ export default class IdsSwappableItem extends Base {
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute('tabbable', 'true');
-    this.setAttribute('draggable', 'false');
+    this.setAttribute(attributes.TABBABLE, 'true');
+    if (!this.hasAttribute(attributes.DRAG_MODE)) {
+      this.setAttribute(attributes.DRAG_MODE, 'select');
+    }
+    this.setAttribute(attributes.DRAGGABLE, this.dragMode === 'select' ? 'false' : 'true');
     this.attachEventListeners();
   }
 
   static get attributes() {
     return [
       ...super.attributes,
+      attributes.DRAG_MODE,
       attributes.DRAGGING,
       attributes.ORIGINAL_TEXT,
       attributes.OVER,
@@ -42,6 +48,19 @@ export default class IdsSwappableItem extends Base {
 
   template(): string {
     return `<slot></slot>`;
+  }
+
+  set dragMode(value: IdsSwappableDragMode) {
+    if (value === 'select') {
+      this.setAttribute(attributes.DRAGGABLE, 'false');
+    } else {
+      // "always"
+      this.setAttribute(attributes.DRAGGABLE, 'true');
+    }
+  }
+
+  get dragMode(): IdsSwappableDragMode {
+    return this.getAttribute(attributes.DRAG_MODE);
   }
 
   /**
@@ -58,7 +77,9 @@ export default class IdsSwappableItem extends Base {
     } else {
       this.removeAttribute(attributes.SELECTED);
       this.removeAttribute('aria-selected');
-      this.setAttribute('draggable', 'false');
+      if (this.dragMode === 'select') {
+        this.setAttribute('draggable', 'false');
+      }
     }
   }
 
@@ -164,7 +185,9 @@ export default class IdsSwappableItem extends Base {
    * Handle functionality for the dragend event
    */
   #dragEnd() {
-    this.setAttribute(attributes.DRAGGABLE, 'false');
+    if (this.dragMode === 'select') {
+      this.setAttribute(attributes.DRAGGABLE, 'false');
+    }
     this.removeAttribute(attributes.DRAGGING);
     this.removeAttribute(attributes.SELECTED);
     this.removeAttribute(attributes.OVER);
@@ -193,16 +216,24 @@ export default class IdsSwappableItem extends Base {
    * ids-swappable is not set to selection
    */
   #toggleSelect() {
-    if (this.selected) {
+    const clearSelection = () => {
       this.removeAttribute(attributes.SELECTED);
-      this.querySelector('div[part="list-item"]')?.removeAttribute(attributes.SELECTED, 'selected');
+      this.querySelector('div[part="list-item"]')?.removeAttribute(attributes.SELECTED);
+    };
+
+    if (this.dragMode === 'select') {
+      if (this.selected) {
+        clearSelection();
+      } else {
+        this.allItems.forEach((item: any) => {
+          item.removeAttribute(attributes.SELECTED);
+          item.querySelector('div[part="list-item"]')?.removeAttribute(attributes.SELECTED);
+        });
+        this.setAttribute(attributes.SELECTED, '');
+        this.querySelector('div[part="list-item"]')?.setAttribute(attributes.SELECTED, 'selected');
+      }
     } else {
-      this.allItems.forEach((item: any) => {
-        item.removeAttribute(attributes.SELECTED);
-        item.querySelector('div[part="list-item"]')?.removeAttribute(attributes.SELECTED);
-      });
-      this.setAttribute(attributes.SELECTED, '');
-      this.querySelector('div[part="list-item"]')?.setAttribute(attributes.SELECTED, 'selected');
+      clearSelection();
     }
   }
 

--- a/src/components/ids-swappable/ids-swappable.scss
+++ b/src/components/ids-swappable/ids-swappable.scss
@@ -1,7 +1,7 @@
 @import '../../core/ids-base';
 
 :host {
-  display: block;
+  display: inherit;
   border: 1px dashed transparent;
   height: 100%;
 }

--- a/src/components/ids-tabs/README.md
+++ b/src/components/ids-tabs/README.md
@@ -101,6 +101,14 @@ Some items slotted in IdsTabs should not spill into the "More Actions" area and 
 
 When this component is present in a tab list, it will only be displayed when there is not enough space to display all other tabs present.  When clicking on this tab, it opens an [IdsPopupMenu](../ids-popup-menu/README.md) containing menu items that reflect all tabs currently "overflowed" (in practice, the tabs that are hidden).  Selecting an item from the menu causes the menu item's corresponding tab to be activated.
 
+### Dismissible Tabs
+
+Tabs can be configured to display an optional [IdsTriggerButton](../ids-trigger-field/README.md) (marked with an "X") that will remove it from the tab list when clicked.  If a content pane with a matching `value` attribute exists, the IdsTabsContext element locates and removes it. When a tab is dismissed, it emits a `tabremove` event.
+
+```html
+<ids-tab value="one" dismissible>Example One</dismissible>
+```
+
 ## Settings and Attributes
 
 ### Tab Container Settings (`ids-tabs`)

--- a/src/components/ids-tabs/TODO.md
+++ b/src/components/ids-tabs/TODO.md
@@ -6,10 +6,9 @@ Keep this file in sync with #683
 
 - [x] Add Module Tabs ([#729](https://github.com/infor-design/enterprise-wc/issues/729))
 - [x] Add overflow detection feature (may need design review?)
-- [ ] Dismissible Tabs
-- [ ] Review current solution for potential optimization (remove extraneous elements and looping)
-- [ ] `ids-tab-divider`: Improve accessibility + add aXe tests
-- [ ] Sortable Behavior ([Example](https://main-enterprise.demo.design.infor.com/components/tabs-module/example-sortable.html))
+- [x] Dismissible Tabs
+- [x] `ids-tab-divider`: Improve accessibility + add aXe tests
+- [x] Sortable Behavior ([Example](https://main-enterprise.demo.design.infor.com/components/tabs-module/example-sortable.html))
 
 ## Minor
 
@@ -18,3 +17,5 @@ Keep this file in sync with #683
 - [ ] test: figure out why ids-tab.selected = false doesn't trigger in Jest
 - [ ] test: resolve aXe color contrast issues (disabled state, similar to other components)
 - [ ] test: re-enable skipped Percy tests, resolve missing initial selected state (no selected state is present in the tests, but exists when the browser loads the same test page)
+- [ ] Review current solution for potential optimization (remove extraneous elements and looping)
+- [ ] Review changes to IdsSwappable to allow swappable tabs, ensure containment/separation of concerns is correct

--- a/src/components/ids-tabs/demos/counts.html
+++ b/src/components/ids-tabs/demos/counts.html
@@ -11,12 +11,12 @@
       <ids-tab value="pending" count="0">Pending</ids-tab>
       <ids-tab-divider></ids-tab-divider>
       <ids-tab value="unreleased" count="12">Unreleased</ids-tab>
-      <ids-tab value="not confirmed" count="100">Not Confirmed</ids-tab>
+      <ids-tab value="not confirmed" count="100" dismissible>Not Confirmed</ids-tab>
       <ids-tab-divider></ids-tab-divider>
-      <ids-tab value="requests" count="0">Requests</ids-tab>
+      <ids-tab value="requests" count="0" dismissible>Requests</ids-tab>
       <ids-tab value="purchase-orders" count="99">Purchase Orders</ids-tab>
       <ids-tab value="receipts" count="12">Receipts</ids-tab>
-      <ids-tab value="feedback" count="1">Feedback</ids-tab>
+      <ids-tab value="feedback" count="1" dismissible>Feedback</ids-tab>
       <ids-tab value="invoices" count="200">Invoices</ids-tab>
     </ids-tabs>
   </ids-container>

--- a/src/components/ids-tabs/demos/dismissible.html
+++ b/src/components/ids-tabs/demos/dismissible.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Tabs (Dismissible)</ids-text>
+    </ids-layout-grid>
+    <ids-tabs-context>
+      <ids-tabs>
+        <ids-tab value="contracts" dismissible>Contracts</ids-tab>
+        <ids-tab value="opportunities" dismissible>Opportunities</ids-tab>
+        <ids-tab value="attachments" disabled dismissible>Attachments</ids-tab>
+        <ids-tab value="notes" dismissible>Notes</ids-tab>
+      </ids-tabs>
+      <div class="ids-tabs-content">
+        <ids-tab-content value="contracts">
+          <ids-layout-grid auto="true">
+            <ids-text font-size="16" type="p">Facilitate cultivate monetize, seize e-services peer-to-peer content
+              integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery
+              leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize
+              robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower
+              relationships, solutions, metrics architectures.</ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+        <ids-tab-content value="opportunities">
+          <div class="tab-content">
+            <ids-layout-grid auto="true">
+              <ids-text font-size="16" type="p">
+                Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant
+                global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services
+                leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+              </ids-text>
+            </ids-layout-grid>
+          </div>
+        </ids-tab-content>
+        <ids-tab-content value="attachments">
+          <ids-layout-grid auto="true">
+            <ids-text font-size="16" type="p">
+              Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end
+              optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless
+              web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich
+              user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive:
+              granular morph.
+            </ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+        <ids-tab-content value="notes">
+          <ids-layout-grid auto="true">
+            <ids-text font-size="16" type="p">
+              Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic
+              24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash
+              reinvent innovative podcasts citizen-media networking.
+            </ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+      </div>
+    </ids-tabs-context>
+  </ids-container>
+</body>
+
+</html>

--- a/src/components/ids-tabs/demos/index.yaml
+++ b/src/components/ids-tabs/demos/index.yaml
@@ -29,3 +29,6 @@
   - link: standalone-css.html
     type: Standalone CSS
     description: Showing limited tabs that works with css only
+  - link: swappable.html
+    type: Example
+    description: Shows how to create swappable tabs

--- a/src/components/ids-tabs/demos/index.yaml
+++ b/src/components/ids-tabs/demos/index.yaml
@@ -11,6 +11,9 @@
   - link: counts.html
     type: Example
     description: Shows tabs with a count for each tab
+  - link: dismissible.html
+    type: Example
+    description: Shows tabs that are dismissible by way of an inline trigger button
   - link: header-tabs.html
     type: Example
     description: Shows header tabs

--- a/src/components/ids-tabs/demos/module.ts
+++ b/src/components/ids-tabs/demos/module.ts
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const addTab: any = document.querySelector('ids-tab[value="add"]');
   addTab.onAction = () => {
-    addTab.insertAdjacentHTML('beforebegin', `<ids-tab color-variant="module" value="new-tab-${newTabCount}">New Tab ${newTabCount}</ids-tab>`);
+    addTab.insertAdjacentHTML('beforebegin', `<ids-tab color-variant="module" value="new-tab-${newTabCount}" dismissible>New Tab ${newTabCount}</ids-tab>`);
     tabContentContainer.insertAdjacentHTML('beforeend', `<ids-tab-content value="new-tab-${newTabCount}">
       <ids-layout-grid auto="true">
         <ids-layout-grid-cell>

--- a/src/components/ids-tabs/demos/swappable.html
+++ b/src/components/ids-tabs/demos/swappable.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Tabs</ids-text>
+    </ids-layout-grid>
+    <ids-tabs-context>
+      <ids-tabs>
+        <ids-swappable dropzone="move">
+          <ids-swappable-item drag-mode="always">
+            <ids-tab value="contracts">Contracts</ids-tab>
+          </ids-swappable-item>
+          <ids-swappable-item drag-mode="always">
+            <ids-tab value="opportunities">Opportunities</ids-tab>
+          </ids-swappable-item>
+          <ids-swappable-item drag-mode="always">
+            <ids-tab value="attachments" disabled>Attachments</ids-tab>
+          </ids-swappable-item>
+          <ids-swappable-item drag-mode="always">
+            <ids-tab value="notes">Notes</ids-tab>
+          </ids-swappable-item>
+        </ids-swappable>
+      </ids-tabs>
+      <div class="ids-tabs-content">
+        <ids-tab-content value="contracts">
+          <ids-layout-grid auto="true">
+            <ids-text font-size="16" type="p">Facilitate cultivate monetize, seize e-services peer-to-peer content
+              integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery
+              leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize
+              robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower
+              relationships, solutions, metrics architectures.</ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+        <ids-tab-content value="opportunities">
+          <div class="tab-content">
+            <ids-layout-grid auto="true">
+              <ids-text font-size="16" type="p">
+                Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant
+                global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services
+                leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+              </ids-text>
+            </ids-layout-grid>
+          </div>
+        </ids-tab-content>
+        <ids-tab-content value="attachments">
+          <ids-layout-grid auto="true">
+            <ids-text font-size="16" type="p">
+              Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end
+              optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless
+              web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich
+              user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive:
+              granular morph.
+            </ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+        <ids-tab-content value="notes">
+          <ids-layout-grid auto="true">
+            <ids-text font-size="16" type="p">
+              Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic
+              24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash
+              reinvent innovative podcasts citizen-media networking.
+            </ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+      </div>
+    </ids-tabs-context>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-tabs/demos/swappable.ts
+++ b/src/components/ids-tabs/demos/swappable.ts
@@ -1,0 +1,10 @@
+import '../../ids-swappable/ids-swappable';
+import '../../ids-swappable/ids-swappable-item';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tabElements = [...document.querySelectorAll('ids-tabs')];
+
+  tabElements.forEach((el) => el.addEventListener('change', (e: Event | CustomEvent | any) => {
+    console.info(`ids-tabs.on('change') =>`, e.target?.value);
+  }));
+});

--- a/src/components/ids-tabs/ids-tab-divider.ts
+++ b/src/components/ids-tabs/ids-tab-divider.ts
@@ -25,6 +25,6 @@ export default class IdsTabDivider extends Base {
   }
 
   connectedCallback() {
-    this.setAttribute('role', 'presentation');
+    this.setAttribute('role', 'separator');
   }
 }

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -318,6 +318,13 @@ $ids-tab-vertical-height: 42px;
   }
 
   // =================================================
+  // Tabs combined with IdsSwappable create "swappable" tabs
+
+  &.swappable {
+    @include pl-8();
+  }
+
+  // =================================================
   // Light Mode
 
   &:not([mode]),

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -127,6 +127,9 @@ $ids-tab-vertical-height: 42px;
   }
 }
 
+// =================================================
+// Main Container Styles
+
 .ids-tab {
   @include px-4();
   @include border-1();
@@ -279,6 +282,7 @@ $ids-tab-vertical-height: 42px;
 
   // =================================================
   // Structural rules for Module Tabs color variant
+
   &.color-variant-module {
     // Scoped to the first child text element to avoid conflicts with menus
     > ids-text,
@@ -313,7 +317,9 @@ $ids-tab-vertical-height: 42px;
     &:focus-visible,
     &:focus,
     &:focus-within {
-      @include ids-tabs-focus-border();
+      &:not(.disabled) {
+        @include ids-tabs-focus-border();
+      }
     }
   }
 

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -111,7 +111,20 @@ $ids-tab-vertical-height: 42px;
 }
 
 ::slotted(ids-icon) {
+  color: currentColor;
   pointer-events: none;
+}
+
+::slotted(ids-trigger-button) {
+  color: currentColor;
+  height: fit-content;
+  place-self: center;
+}
+
+:host([count]) {
+  ::slotted(ids-trigger-button) {
+    @include pl-8();
+  }
 }
 
 .ids-tab {
@@ -149,6 +162,14 @@ $ids-tab-vertical-height: 42px;
   }
 
   // =================================================
+  // Trigger Button Slot
+
+  .ids-tab-trigger-container {
+    display: flex;
+    place-content: center;
+  }
+
+  // =================================================
   // Actionable
 
   &.actionable {
@@ -160,6 +181,11 @@ $ids-tab-vertical-height: 42px;
 
   &.count {
     @include px-12();
+
+    .ids-tab-count-container {
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   // =================================================
@@ -188,8 +214,6 @@ $ids-tab-vertical-height: 42px;
 
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      align-items: flex-start;
-      justify-content: flex-end;
 
       // Show the underline
       @include ids-tabs-selected-underline();

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -188,7 +188,6 @@ $ids-tab-vertical-height: 42px;
 
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      flex-direction: column;
       align-items: flex-start;
       justify-content: flex-end;
 
@@ -269,6 +268,22 @@ $ids-tab-vertical-height: 42px;
 
     &.actionable {
       min-width: $ids-tab-actionable-min-width;
+    }
+
+    &.dismissible {
+      justify-content: space-around;
+
+      > ids-text,
+      > .ids-text {
+        flex-grow: 1;
+      }
+
+      ::slotted(ids-trigger-button),
+      > .ids-trigger-button,
+      > ids-trigger-button {
+        flex-grow: 0;
+        flex-shrink: 1;
+      }
     }
 
     &:focus-visible,

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -38,6 +38,7 @@ export default class IdsTab extends Base {
       ...super.attributes,
       attributes.ACTIONABLE,
       attributes.COUNT,
+      attributes.DISMISSIBLE,
       attributes.DISABLED,
       attributes.SELECTED,
       attributes.VALUE
@@ -79,7 +80,27 @@ export default class IdsTab extends Base {
       </ids-text>`;
     }
 
-    return `<div ${cssClassAttr} tabindex="-1" part="container">${innerContent}</div>`;
+    return `<div ${cssClassAttr} tabindex="-1" part="container">
+      ${innerContent}
+      <slot name="close"></slot>
+    </div>`;
+  }
+
+  /**
+   * @returns {string} draws the dismissible button
+   */
+  #templateDismissible(): string {
+    let colorVariant = '';
+    if (this.colorVariant) {
+      colorVariant = ` color-variant="${this.#getDismissibleVariant()}"`;
+    }
+    return `<ids-trigger-button slot="close" label="Close"${colorVariant}>
+      <ids-icon slot="icon" icon="close" size="xsmall"></ids-icon>
+    </ids-trigger-button>`;
+  }
+
+  #getDismissibleVariant() {
+    return this.colorVariant === 'module' ? 'alternate' : this.colorVariant;
   }
 
   connectedCallback() {
@@ -129,6 +150,28 @@ export default class IdsTab extends Base {
    */
   get actionable(): boolean {
     return this.hasAttribute(attributes.ACTIONABLE);
+  }
+
+  /**
+   * @param {boolean} isDismissible true if this Tab should contain an "X" icon used for dismissal
+   */
+  set dismissible(isDismissible: boolean | string) {
+    if (stringToBool(isDismissible)) {
+      this.setAttribute(attributes.DISMISSIBLE, '');
+      this.container.classList.add(attributes.DISMISSIBLE);
+      this.insertAdjacentHTML('beforeend', this.#templateDismissible());
+    } else {
+      this.removeAttribute(attributes.DISMISSIBLE);
+      this.container.classList.remove(attributes.DISMISSIBLE);
+      this.querySelector('ids-trigger-button').remove();
+    }
+  }
+
+  /**
+   * @returns {boolean} true if this Tab should contain an "X" icon used for dismissal
+   */
+  get dismissible(): boolean {
+    return this.hasAttribute(attributes.DISMISSIBLE);
   }
 
   /**
@@ -280,5 +323,13 @@ export default class IdsTab extends Base {
 
   focus() {
     this.container.focus();
+  }
+
+  onColorVariantRefresh(): void {
+    const closeBtn = this.querySelector('ids-trigger-button');
+    if (closeBtn) {
+      const target = this.#getDismissibleVariant();
+      closeBtn.colorVariant = target;
+    }
   }
 }

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -38,7 +38,6 @@ export default class IdsTab extends Base {
       ...super.attributes,
       attributes.ACTIONABLE,
       attributes.COUNT,
-      attributes.DISMISSIBLE,
       attributes.DISABLED,
       attributes.SELECTED,
       attributes.VALUE
@@ -50,13 +49,6 @@ export default class IdsTab extends Base {
    * @returns {Array<string>} List of available color variants for this component
    */
   colorVariants = ['alternate', 'module'];
-
-  /**
-   * @returns {Array<string>} Drawer vetoable events
-   */
-  vetoableEventTypes = [
-    'beforetabremove',
-  ];
 
   /**
    * Create the Template for the contents
@@ -79,39 +71,15 @@ export default class IdsTab extends Base {
         <slot></slot>
       </ids-text>`;
     } else if (hasCount) {
-      innerContent = `<div class="ids-tab-count-container">
-        <ids-text overflow="ellipsis" font-size="28"${selectedAttr}>
-          ${this.getAttribute(attributes.COUNT)}
-        </ids-text>
-        <ids-text overflow="ellipsis" size="22">
-          <slot></slot>
-        </ids-text>
-      </div>`;
+      innerContent = `<ids-text overflow="ellipsis" font-size="28"${selectedAttr}>
+        ${this.getAttribute(attributes.COUNT)}
+      </ids-text>
+      <ids-text overflow="ellipsis" size="22">
+        <slot></slot>
+      </ids-text>`;
     }
 
-    return `<div ${cssClassAttr} tabindex="-1" part="container">
-      ${innerContent}
-      <div class="ids-tab-trigger-container">
-        <slot name="close"></slot>
-      </div>
-    </div>`;
-  }
-
-  /**
-   * @returns {string} draws the dismissible button
-   */
-  #templateDismissible(): string {
-    let colorVariant = '';
-    if (this.colorVariant) {
-      colorVariant = ` color-variant="${this.#getDismissibleVariant()}"`;
-    }
-    return `<ids-trigger-button slot="close" label="Close"${colorVariant}>
-      <ids-icon slot="icon" icon="close" size="xsmall"></ids-icon>
-    </ids-trigger-button>`;
-  }
-
-  #getDismissibleVariant() {
-    return this.colorVariant === 'module' ? 'alternate' : this.colorVariant;
+    return `<div ${cssClassAttr} tabindex="-1" part="container">${innerContent}</div>`;
   }
 
   connectedCallback() {
@@ -121,7 +89,6 @@ export default class IdsTab extends Base {
     this.setAttribute(htmlAttributes.ARIA_SELECTED, `${Boolean(this.selected)}`);
     this.setAttribute(htmlAttributes.TABINDEX, stringToBool(this.selected) ? '0' : '-1');
     this.setAttribute(htmlAttributes.ARIA_LABEL, this.#getReadableAriaLabel());
-    this.#detectSwappable();
   }
 
   /**
@@ -165,36 +132,6 @@ export default class IdsTab extends Base {
   }
 
   /**
-   * @param {boolean} isDismissible true if this Tab should contain an "X" icon used for dismissal
-   */
-  set dismissible(isDismissible: boolean | string) {
-    if (stringToBool(isDismissible)) {
-      this.setAttribute(attributes.DISMISSIBLE, '');
-      this.container.classList.add(attributes.DISMISSIBLE);
-      this.insertAdjacentHTML('beforeend', this.#templateDismissible());
-    } else {
-      this.removeAttribute(attributes.DISMISSIBLE);
-      this.container.classList.remove(attributes.DISMISSIBLE);
-      this.dismissibleBtnEl.remove();
-    }
-  }
-
-  /**
-   * @returns {boolean} true if this Tab should contain an "X" icon used for dismissal
-   */
-  get dismissible(): boolean {
-    return this.hasAttribute(attributes.DISMISSIBLE);
-  }
-
-  /**
-   * Provides a reference to a close button, if applicable
-   * @returns {HTMLElement | null} IdsTriggerButton
-   */
-  get dismissibleBtnEl(): any {
-    return this.querySelector('ids-trigger-button');
-  }
-
-  /**
    * @param {boolean | string} isDisabled true if the tab should become disabled
    */
   set disabled(isDisabled: boolean | string) {
@@ -202,15 +139,9 @@ export default class IdsTab extends Base {
     if (newValue) {
       this.setAttribute(attributes.DISABLED, '');
       this.container.classList.add(attributes.DISABLED);
-      if (this.dismissibleBtnEl) {
-        this.dismissibleBtnEl.disabled = true;
-      }
     } else {
       this.removeAttribute(attributes.DISABLED);
       this.container.classList.remove(attributes.DISABLED);
-      if (this.dismissibleBtnEl) {
-        this.dismissibleBtnEl.disabled = false;
-      }
     }
   }
 
@@ -347,43 +278,9 @@ export default class IdsTab extends Base {
     }
   };
 
-  /**
-   * Sets/removes CSS classes on this tab that control "swappable" display
-   */
-  #detectSwappable(): void {
-    const swappableParent = this.parentElement && this.parentElement.tagName === 'IDS-SWAPPABLE-ITEM';
-    this.container.classList[swappableParent ? 'add' : 'remove']('swappable');
-  }
-
-  /**
-   * Dismisses this tab, if possible
-   */
-  dismiss(): void {
-    if (this.dismissible) {
-      if (!this.triggerVetoableEvent('beforetabremove')) return;
-
-      this.triggerEvent('tabremove', this, {
-        bubbles: true,
-        detail: {
-          elem: this,
-          value: this.value
-        }
-      });
-    }
-  }
-
-  /**
-   * Causes the tab to become focused
-   */
-  focus(): void {
-    this.container.focus();
-  }
-
-  onColorVariantRefresh(): void {
-    const closeBtn = this.dismissibleBtnEl;
-    if (closeBtn) {
-      const target = this.#getDismissibleVariant();
-      closeBtn.colorVariant = target;
+  focus() {
+    if (!this.disabled) {
+      this.container.focus();
     }
   }
 }

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -105,7 +105,7 @@ export default class IdsTab extends Base {
     if (this.colorVariant) {
       colorVariant = ` color-variant="${this.#getDismissibleVariant()}"`;
     }
-    return `<ids-trigger-button slot="close" label="Close"${colorVariant}>
+    return `<ids-trigger-button slot="close" label="Close"${colorVariant} inherit-color>
       <ids-icon slot="icon" icon="close" size="xsmall"></ids-icon>
     </ids-trigger-button>`;
   }

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -121,6 +121,7 @@ export default class IdsTab extends Base {
     this.setAttribute(htmlAttributes.ARIA_SELECTED, `${Boolean(this.selected)}`);
     this.setAttribute(htmlAttributes.TABINDEX, stringToBool(this.selected) ? '0' : '-1');
     this.setAttribute(htmlAttributes.ARIA_LABEL, this.#getReadableAriaLabel());
+    this.#detectSwappable();
   }
 
   /**
@@ -345,6 +346,14 @@ export default class IdsTab extends Base {
       idsText.container.setAttribute('data-text', `"${slotNode.textContent.trim()}"`);
     }
   };
+
+  /**
+   * Sets/removes CSS classes on this tab that control "swappable" display
+   */
+  #detectSwappable(): void {
+    const swappableParent = this.parentElement && this.parentElement.tagName === 'IDS-SWAPPABLE-ITEM';
+    this.container.classList[swappableParent ? 'add' : 'remove']('swappable');
+  }
 
   /**
    * Dismisses this tab, if possible

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -52,6 +52,13 @@ export default class IdsTab extends Base {
   colorVariants = ['alternate', 'module'];
 
   /**
+   * @returns {Array<string>} Drawer vetoable events
+   */
+  vetoableEventTypes = [
+    'beforetabremove',
+  ];
+
+  /**
    * Create the Template for the contents
    * @returns {string} the template to render
    */
@@ -163,7 +170,7 @@ export default class IdsTab extends Base {
     } else {
       this.removeAttribute(attributes.DISMISSIBLE);
       this.container.classList.remove(attributes.DISMISSIBLE);
-      this.querySelector('ids-trigger-button').remove();
+      this.dismissibleBtnEl.remove();
     }
   }
 
@@ -175,6 +182,14 @@ export default class IdsTab extends Base {
   }
 
   /**
+   * Provides a reference to a close button, if applicable
+   * @returns {HTMLElement | null} IdsTriggerButton
+   */
+  get dismissibleBtnEl(): any {
+    return this.querySelector('ids-trigger-button');
+  }
+
+  /**
    * @param {boolean | string} isDisabled true if the tab should become disabled
    */
   set disabled(isDisabled: boolean | string) {
@@ -182,9 +197,15 @@ export default class IdsTab extends Base {
     if (newValue) {
       this.setAttribute(attributes.DISABLED, '');
       this.container.classList.add(attributes.DISABLED);
+      if (this.dismissibleBtnEl) {
+        this.dismissibleBtnEl.disabled = true;
+      }
     } else {
       this.removeAttribute(attributes.DISABLED);
       this.container.classList.remove(attributes.DISABLED);
+      if (this.dismissibleBtnEl) {
+        this.dismissibleBtnEl.disabled = false;
+      }
     }
   }
 
@@ -321,12 +342,32 @@ export default class IdsTab extends Base {
     }
   };
 
-  focus() {
+  /**
+   * Dismisses this tab, if possible
+   */
+  dismiss(): void {
+    if (this.dismissible) {
+      if (!this.triggerVetoableEvent('beforetabremove')) return;
+
+      this.triggerEvent('tabremove', this, {
+        bubbles: true,
+        detail: {
+          elem: this,
+          value: this.value
+        }
+      });
+    }
+  }
+
+  /**
+   * Causes the tab to become focused
+   */
+  focus(): void {
     this.container.focus();
   }
 
   onColorVariantRefresh(): void {
-    const closeBtn = this.querySelector('ids-trigger-button');
+    const closeBtn = this.dismissibleBtnEl;
     if (closeBtn) {
       const target = this.#getDismissibleVariant();
       closeBtn.colorVariant = target;

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -79,17 +79,21 @@ export default class IdsTab extends Base {
         <slot></slot>
       </ids-text>`;
     } else if (hasCount) {
-      innerContent = `<ids-text overflow="ellipsis" font-size="28"${selectedAttr}>
-        ${this.getAttribute(attributes.COUNT)}
-      </ids-text>
-      <ids-text overflow="ellipsis" size="22">
-        <slot></slot>
-      </ids-text>`;
+      innerContent = `<div class="ids-tab-count-container">
+        <ids-text overflow="ellipsis" font-size="28"${selectedAttr}>
+          ${this.getAttribute(attributes.COUNT)}
+        </ids-text>
+        <ids-text overflow="ellipsis" size="22">
+          <slot></slot>
+        </ids-text>
+      </div>`;
     }
 
     return `<div ${cssClassAttr} tabindex="-1" part="container">
       ${innerContent}
-      <slot name="close"></slot>
+      <div class="ids-tab-trigger-container">
+        <slot name="close"></slot>
+      </div>
     </div>`;
   }
 

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -38,6 +38,7 @@ export default class IdsTab extends Base {
       ...super.attributes,
       attributes.ACTIONABLE,
       attributes.COUNT,
+      attributes.DISMISSIBLE,
       attributes.DISABLED,
       attributes.SELECTED,
       attributes.VALUE
@@ -49,6 +50,13 @@ export default class IdsTab extends Base {
    * @returns {Array<string>} List of available color variants for this component
    */
   colorVariants = ['alternate', 'module'];
+
+  /**
+   * @returns {Array<string>} Drawer vetoable events
+   */
+  vetoableEventTypes = [
+    'beforetabremove',
+  ];
 
   /**
    * Create the Template for the contents
@@ -71,15 +79,39 @@ export default class IdsTab extends Base {
         <slot></slot>
       </ids-text>`;
     } else if (hasCount) {
-      innerContent = `<ids-text overflow="ellipsis" font-size="28"${selectedAttr}>
-        ${this.getAttribute(attributes.COUNT)}
-      </ids-text>
-      <ids-text overflow="ellipsis" size="22">
-        <slot></slot>
-      </ids-text>`;
+      innerContent = `<div class="ids-tab-count-container">
+        <ids-text overflow="ellipsis" font-size="28"${selectedAttr}>
+          ${this.getAttribute(attributes.COUNT)}
+        </ids-text>
+        <ids-text overflow="ellipsis" size="22">
+          <slot></slot>
+        </ids-text>
+      </div>`;
     }
 
-    return `<div ${cssClassAttr} tabindex="-1" part="container">${innerContent}</div>`;
+    return `<div ${cssClassAttr} tabindex="-1" part="container">
+      ${innerContent}
+      <div class="ids-tab-trigger-container">
+        <slot name="close"></slot>
+      </div>
+    </div>`;
+  }
+
+  /**
+   * @returns {string} draws the dismissible button
+   */
+  #templateDismissible(): string {
+    let colorVariant = '';
+    if (this.colorVariant) {
+      colorVariant = ` color-variant="${this.#getDismissibleVariant()}"`;
+    }
+    return `<ids-trigger-button slot="close" label="Close"${colorVariant}>
+      <ids-icon slot="icon" icon="close" size="xsmall"></ids-icon>
+    </ids-trigger-button>`;
+  }
+
+  #getDismissibleVariant() {
+    return this.colorVariant === 'module' ? 'alternate' : this.colorVariant;
   }
 
   connectedCallback() {
@@ -89,6 +121,7 @@ export default class IdsTab extends Base {
     this.setAttribute(htmlAttributes.ARIA_SELECTED, `${Boolean(this.selected)}`);
     this.setAttribute(htmlAttributes.TABINDEX, stringToBool(this.selected) ? '0' : '-1');
     this.setAttribute(htmlAttributes.ARIA_LABEL, this.#getReadableAriaLabel());
+    this.#detectSwappable();
   }
 
   /**
@@ -132,6 +165,36 @@ export default class IdsTab extends Base {
   }
 
   /**
+   * @param {boolean} isDismissible true if this Tab should contain an "X" icon used for dismissal
+   */
+  set dismissible(isDismissible: boolean | string) {
+    if (stringToBool(isDismissible)) {
+      this.setAttribute(attributes.DISMISSIBLE, '');
+      this.container.classList.add(attributes.DISMISSIBLE);
+      this.insertAdjacentHTML('beforeend', this.#templateDismissible());
+    } else {
+      this.removeAttribute(attributes.DISMISSIBLE);
+      this.container.classList.remove(attributes.DISMISSIBLE);
+      this.dismissibleBtnEl.remove();
+    }
+  }
+
+  /**
+   * @returns {boolean} true if this Tab should contain an "X" icon used for dismissal
+   */
+  get dismissible(): boolean {
+    return this.hasAttribute(attributes.DISMISSIBLE);
+  }
+
+  /**
+   * Provides a reference to a close button, if applicable
+   * @returns {HTMLElement | null} IdsTriggerButton
+   */
+  get dismissibleBtnEl(): any {
+    return this.querySelector('ids-trigger-button');
+  }
+
+  /**
    * @param {boolean | string} isDisabled true if the tab should become disabled
    */
   set disabled(isDisabled: boolean | string) {
@@ -139,9 +202,15 @@ export default class IdsTab extends Base {
     if (newValue) {
       this.setAttribute(attributes.DISABLED, '');
       this.container.classList.add(attributes.DISABLED);
+      if (this.dismissibleBtnEl) {
+        this.dismissibleBtnEl.disabled = true;
+      }
     } else {
       this.removeAttribute(attributes.DISABLED);
       this.container.classList.remove(attributes.DISABLED);
+      if (this.dismissibleBtnEl) {
+        this.dismissibleBtnEl.disabled = false;
+      }
     }
   }
 
@@ -278,9 +347,45 @@ export default class IdsTab extends Base {
     }
   };
 
-  focus() {
+  /**
+   * Sets/removes CSS classes on this tab that control "swappable" display
+   */
+  #detectSwappable(): void {
+    const swappableParent = this.parentElement && this.parentElement.tagName === 'IDS-SWAPPABLE-ITEM';
+    this.container.classList[swappableParent ? 'add' : 'remove']('swappable');
+  }
+
+  /**
+   * Dismisses this tab, if possible
+   */
+  dismiss(): void {
+    if (this.dismissible) {
+      if (!this.triggerVetoableEvent('beforetabremove')) return;
+
+      this.triggerEvent('tabremove', this, {
+        bubbles: true,
+        detail: {
+          elem: this,
+          value: this.value
+        }
+      });
+    }
+  }
+
+  /**
+   * Causes the tab to become focused
+   */
+  focus(): void {
     if (!this.disabled) {
       this.container.focus();
+    }
+  }
+
+  onColorVariantRefresh(): void {
+    const closeBtn = this.dismissibleBtnEl;
+    if (closeBtn) {
+      const target = this.#getDismissibleVariant();
+      closeBtn.colorVariant = target;
     }
   }
 }

--- a/src/components/ids-tabs/ids-tabs-context.ts
+++ b/src/components/ids-tabs/ids-tabs-context.ts
@@ -27,6 +27,13 @@ export default class IdsTabsContext extends Base {
       e.stopPropagation();
       this.value = e.target.value;
     });
+
+    // On `tabremove` events, remove a tab's corresponding content pane
+    this.onEvent('tabremove', this, (e: CustomEvent) => {
+      e.stopPropagation();
+      const content = this.querySelector(`ids-tab-content[value="${e.detail.value}"]`);
+      content?.remove();
+    });
   }
 
   rendered() {

--- a/src/components/ids-tabs/ids-tabs.ts
+++ b/src/components/ids-tabs/ids-tabs.ts
@@ -57,13 +57,6 @@ export default class IdsTabs extends Base {
   }
 
   /**
-   * @returns {Array<string>} Drawer vetoable events
-   */
-  vetoableEventTypes = [
-    'beforetabremove',
-  ];
-
-  /**
    * @returns {string} template for Tab List
    */
   template() {
@@ -265,7 +258,9 @@ export default class IdsTabs extends Base {
       const elem: any = e.target;
       if (elem) {
         if (elem.tagName === 'IDS-TAB') {
-          this.#selectTab(elem);
+          if (!elem.disabled) {
+            this.#selectTab(elem);
+          }
         }
         if (elem.tagName === 'IDS-TRIGGER-BUTTON') {
           e.stopPropagation();
@@ -273,6 +268,11 @@ export default class IdsTabs extends Base {
           this.#dismissTab(tab);
         }
       }
+    });
+
+    // Removes the tab from the list on `tabremove` events
+    this.onEvent('tabremove', this, (e: CustomEvent) => {
+      e.detail.elem.remove();
     });
 
     // Focusing via keyboard on an IdsTab doesn't automatically fire its `focus()` method.
@@ -352,7 +352,7 @@ export default class IdsTabs extends Base {
    * @returns {void}
    */
   #selectTab(tab: any): void {
-    if (!tab || tab.disabled) return;
+    if (!tab) return;
 
     if (tab.actionable) {
       if (typeof tab.onAction === 'function') {
@@ -380,19 +380,9 @@ export default class IdsTabs extends Base {
    */
   #dismissTab(tab: any): void {
     if (!tab) return;
-    if (!this.triggerVetoableEvent('beforetabremove')) return;
 
-    const value = tab.value;
-    tab.remove();
+    tab.dismiss();
     this.#correctSelectedTab();
-
-    this.triggerEvent('tabremove', this, {
-      bubbles: true,
-      detail: {
-        elem: tab,
-        value
-      }
-    });
   }
 
   /**

--- a/src/components/ids-tabs/ids-tabs.ts
+++ b/src/components/ids-tabs/ids-tabs.ts
@@ -313,7 +313,7 @@ export default class IdsTabs extends Base {
     let nextTab: any = currentTab.nextElementSibling;
 
     // If next sibling isn't a tab or is disabled, try this method again on the found sibling
-    if (nextTab && (!nextTab.tagName.includes('IDS-TAB') || nextTab.disabled || nextTab.hasAttribute('overflowed'))) {
+    if (nextTab && (!nextTab.tagName.includes('IDS-TAB') || nextTab.tagName.includes('IDS-TAB-DIVIDER') || nextTab.disabled || nextTab.hasAttribute('overflowed'))) {
       return this.nextTab(nextTab);
     }
 
@@ -334,7 +334,7 @@ export default class IdsTabs extends Base {
     let prevTab: any = currentTab.previousElementSibling;
 
     // If previous sibling isn't a tab or is disabled, try this method again on the found sibling
-    if (prevTab && (!prevTab.tagName.includes('IDS-TAB') || prevTab.disabled || prevTab.hasAttribute('overflowed'))) {
+    if (prevTab && (!prevTab.tagName.includes('IDS-TAB') || prevTab.tagName.includes('IDS-TAB-DIVIDER') || prevTab.disabled || prevTab.hasAttribute('overflowed'))) {
       return this.prevTab(prevTab);
     }
 

--- a/src/components/ids-tabs/ids-tabs.ts
+++ b/src/components/ids-tabs/ids-tabs.ts
@@ -247,6 +247,18 @@ export default class IdsTabs extends Base {
       }
     });
 
+    // Listen for Delete (Mac) or Backspace (PC) for removal events
+    const dismissOnKeystroke = (e: CustomEvent) => {
+      const elem: any = e.target;
+      if (elem) {
+        if (elem.tagName === 'IDS-TAB') {
+          this.#dismissTab(elem);
+        }
+      }
+    };
+    this.listen('Delete', this, dismissOnKeystroke);
+    this.listen('Backspace', this, dismissOnKeystroke);
+
     this.onEvent('tabselect', this, (e: CustomEvent) => {
       const elem: any = e.target;
       if (elem && elem.tagName === 'IDS-TAB') {

--- a/src/components/ids-trigger-field/ids-trigger-button.scss
+++ b/src/components/ids-trigger-field/ids-trigger-button.scss
@@ -77,13 +77,17 @@
   }
 
   // ===================================================
+  // Inherit Color setting
   // Reset themed button colors on Trigger Buttons,
   // which are presumably slotted into another component
   // that should inherit colors from its parent.
-  &:not([mode]),
-  &[mode='light'],
-  &[mode='dark'],
-  &[mode='contrast'] {
-    color: currentColor;
+
+  &.inherit-color {
+    &:not([mode]),
+    &[mode='light'],
+    &[mode='dark'],
+    &[mode='contrast'] {
+      color: currentColor;
+    }
   }
 }

--- a/src/components/ids-trigger-field/ids-trigger-button.scss
+++ b/src/components/ids-trigger-field/ids-trigger-button.scss
@@ -75,4 +75,15 @@
   &.color-variant-alternate-formatter {
     @include p-2();
   }
+
+  // ===================================================
+  // Reset themed button colors on Trigger Buttons,
+  // which are presumably slotted into another component
+  // that should inherit colors from its parent.
+  &:not([mode]),
+  &[mode='light'],
+  &[mode='dark'],
+  &[mode='contrast'] {
+    color: currentColor;
+  }
 }

--- a/src/components/ids-trigger-field/ids-trigger-button.ts
+++ b/src/components/ids-trigger-field/ids-trigger-button.ts
@@ -34,6 +34,7 @@ export default class IdsTriggerButton extends Base {
     return [
       ...super.attributes,
       attributes.INLINE,
+      attributes.INHERIT_COLOR,
       attributes.READONLY,
       attributes.TABBABLE,
     ];
@@ -127,5 +128,26 @@ export default class IdsTriggerButton extends Base {
 
   #removeBorderClass() {
     this.button.classList.remove('style-inline', this.inlineCssClass);
+  }
+
+  /**
+   * @param {boolean} val true if this trigger button should inherit a parent component's text color for use internally
+   */
+  set inheritColor(val: boolean | string) {
+    const inheritColor = stringToBool(val);
+    if (inheritColor) {
+      this.setAttribute(attributes.INHERIT_COLOR, '');
+      this.button.classList.add('inherit-color');
+    } else {
+      this.removeAttribute(attributes.INHERIT_COLOR);
+      this.button.classList.remove('inherit-color');
+    }
+  }
+
+  /**
+   * @returns {string} true if this trigger button inherits a parent component's text color for use internally
+   */
+  get inheritColor(): string {
+    return this.hasAttribute(attributes.INHERIT_COLOR);
   }
 }

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -97,6 +97,7 @@ export const attributes = {
   DISPLAY_TIME: 'display-time',
   DONUT: 'donut',
   DONUT_TEXT: 'donut-text',
+  DRAG_MODE: 'drag-mode',
   DRAGGABLE: 'draggable',
   DRAGGING: 'dragging',
   DROPDOWN_ICON: 'dropdown-icon',

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -152,6 +152,7 @@ export const attributes = {
   ICON_SIZE: 'icon-size',
   ID: 'id',
   INDETERMINATE: 'indeterminate',
+  INHERIT_COLOR: 'inherit-color',
   INITIALS: 'initials',
   INLINE: 'inline',
   IS_CALENDAR_TOOLBAR: 'is-calendar-toolbar',

--- a/test/ids-swappable/ids-swappable-func-test.ts.snap
+++ b/test/ids-swappable/ids-swappable-func-test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`IdsSwappable Component renders correctly 1`] = `
 "<ids-swappable id=\\"swappable-1\\" selection=\\"multiple\\" dropzone=\\"move\\">
-      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" draggable=\\"false\\"></ids-swappable-item>
-      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" draggable=\\"false\\"></ids-swappable-item>
-      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" draggable=\\"false\\"></ids-swappable-item>
-      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" draggable=\\"false\\"></ids-swappable-item>
+      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" drag-mode=\\"select\\" draggable=\\"false\\"></ids-swappable-item>
+      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" drag-mode=\\"select\\" draggable=\\"false\\"></ids-swappable-item>
+      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" drag-mode=\\"select\\" draggable=\\"false\\"></ids-swappable-item>
+      <ids-swappable-item tabbable=\\"true\\" tabindex=\\"0\\" drag-mode=\\"select\\" draggable=\\"false\\"></ids-swappable-item>
     </ids-swappable>"
 `;

--- a/test/ids-tabs/ids-tabs-func-test.ts
+++ b/test/ids-tabs/ids-tabs-func-test.ts
@@ -11,6 +11,7 @@ import '../../src/components/ids-tabs/ids-tabs-context';
 import '../../src/components/ids-tabs/ids-tab-content';
 
 import IdsHeader from '../../src/components/ids-header/ids-header';
+import '../../src/components/ids-swappable/ids-swappable';
 import '../../src/components/ids-text/ids-text';
 import createFromTemplate from '../helpers/create-from-template';
 
@@ -40,6 +41,25 @@ const TAB_CONTEXT_HTML = (
     <ids-tab-content value="b">B</ids-tab-content>
     <ids-tab-content value="c">C</ids-tab-content>
   </ids-tabs-context>`
+);
+
+const TAB_SWAPPABLE_HTML = (
+  `<ids-tabs>
+    <ids-swappable dropzone="move">
+      <ids-swappable-item drag-mode="always">
+        <ids-tab value="contracts">Contracts</ids-tab>
+      </ids-swappable-item>
+      <ids-swappable-item drag-mode="always">
+        <ids-tab value="opportunities">Opportunities</ids-tab>
+      </ids-swappable-item>
+      <ids-swappable-item drag-mode="always">
+        <ids-tab value="attachments" disabled>Attachments</ids-tab>
+      </ids-swappable-item>
+      <ids-swappable-item drag-mode="always">
+        <ids-tab value="notes">Notes</ids-tab>
+      </ids-swappable-item>
+    </ids-swappable>
+  </ids-tabs>`
 );
 
 describe('IdsTabs Tests', () => {
@@ -112,6 +132,18 @@ describe('IdsTabs Tests', () => {
     expect(errors).not.toHaveBeenCalled();
   });
 
+  it('renders a set of swappable tabs with no errors', async () => {
+    const errors = jest.spyOn(global.console, 'error');
+    elem = await createFromTemplate(elem, TAB_SWAPPABLE_HTML);
+
+    const tab1 = elem.querySelector('ids-tab');
+    const swapItem1 = elem.querySelector('ids-swappable-item');
+
+    expect(swapItem1.getAttribute('drag-mode')).toBe('always');
+    expect(tab1.container.classList.contains('swappable')).toBeTruthy();
+    expect(errors).not.toHaveBeenCalled();
+  });
+
   it('creates tabs with vertical orientation, then sets them horizontal', async () => {
     const errors = jest.spyOn(global.console, 'error');
     elem = await createFromTemplate(
@@ -171,7 +203,7 @@ describe('IdsTabs Tests', () => {
 
     expect(elem.outerHTML).toMatchSnapshot();
     expect(errors).not.toHaveBeenCalled();
-    expect(elem.querySelector('ids-tab-divider').getAttribute('role')).toEqual('presentation');
+    expect(elem.querySelector('ids-tab-divider').getAttribute('role')).toEqual('separator');
   });
 
   it('renders with partial counts set, and triggers no error', async () => {

--- a/test/ids-tabs/ids-tabs-func-test.ts.snap
+++ b/test/ids-tabs/ids-tabs-func-test.ts.snap
@@ -28,30 +28,30 @@ exports[`IdsTabs Tests renders correctly 1`] = `
 `;
 
 exports[`IdsTabs Tests renders tab dividers on counts, and has no errors 1`] = `
-"<ids-tabs role=\\"tablist\\">
-        <ids-tab count=\\"20\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"
-        20
-       Pizzas\\">Pizzas</ids-tab>
+"<ids-tabs role=\\"tablist\\" value=\\"null\\">
+        <ids-tab count=\\"20\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"
+          20
+         Pizzas\\" selected=\\"\\">Pizzas</ids-tab>
         <ids-tab count=\\"18\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"
-        18
-       Diet Cokes\\">Diet Cokes</ids-tab>
-        <ids-tab-divider role=\\"presentation\\"></ids-tab-divider>
+          18
+         Diet Cokes\\">Diet Cokes</ids-tab>
+        <ids-tab-divider role=\\"separator\\"></ids-tab-divider>
        <ids-tab count=\\"12\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"
-        12
-       Ginger Ales\\">Ginger Ales</ids-tab>
+          12
+         Ginger Ales\\">Ginger Ales</ids-tab>
       </ids-tabs>"
 `;
 
 exports[`IdsTabs Tests renders with counts, and has no errors 1`] = `
-"<ids-tabs role=\\"tablist\\">
-        <ids-tab count=\\"20\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"
-        20
-       Pizzas\\">Pizzas</ids-tab>
+"<ids-tabs role=\\"tablist\\" value=\\"null\\">
+        <ids-tab count=\\"20\\" role=\\"tab\\" aria-selected=\\"true\\" tabindex=\\"0\\" aria-label=\\"
+          20
+         Pizzas\\" selected=\\"\\">Pizzas</ids-tab>
         <ids-tab count=\\"18\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"
-        18
-       Diet Cokes\\">Diet Cokes</ids-tab>
+          18
+         Diet Cokes\\">Diet Cokes</ids-tab>
         <ids-tab count=\\"12\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\" aria-label=\\"
-        12
-       Ginger Ales\\">Ginger Ales</ids-tab>
+          12
+         Ginger Ales\\">Ginger Ales</ids-tab>
       </ids-tabs>"
 `;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds several more features into the IdsTabs component:
- Adds dismissible tabs (tab content can be closed by clicking the "X" button on a tab)
- Adds IdsSwappable/IdsTabs integration to enable swappable (formerly "sortable") tabs
- Fixes an accessibility issue with IdsTabsDivider
- Add tests/docs where needed

**Related github/jira issue (required)**:
Closes #683 

**Steps necessary to review your pull request (required)**:
Pull/build/run, then:

http://localhost:4300/ids-tabs/dismissible.html
- Try clicking the "X" button on a tab.  It should be removed from the tab list.
- Use dev tools and find the element that contains Tab Panels: `<div class="ids-tabs-content"></div>`.  The tab panel connected to the removed tab should also have been removed.1

http://localhost:4300/ids-tabs/counts.html
- The visual style of these tabs should be unchanged, except for the dismissible ones.
- Try navigating these tabs with the arrow keys.  The arrow keys should not become stuck inside each divided area.  Instead keyboard navigation should wrap around to the first/last tabs if needed.
- Clearing these tabs should act the same as the first example.

http://localhost:4300/ids-tabs/module.html
- Use the "+" actionable tab to add a new tab.  It should have an "X" button
- Clearing these tabs should act the same as the first example.

http://localhost:4300/ids-tabs/swappable.html
- Hovering these tabs should display a "swappable" state with a drag handle
- Dragging/ordering tabs should behave as expected

Also, smoke test the following to ensure no visual/behavioral changes:
- http://localhost:4300/ids-tabs/header-tabs.html
- http://localhost:4300/ids-tabs/vertical.html
- http://localhost:4300/ids-swappable/example.html
- http://localhost:4300/ids-list-builder/example.html

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
