### PR TITLE
BugFix: Card Height Bug

### DIFF
--- a/src/components/ids-card/demos/height.html
+++ b/src/components/ids-card/demos/height.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Card Fixed Height (and actionable)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <ids-card actionable="true" height="100" href="#" target="_self">
+            <div slot="card-content">
+             <ids-text type="h2" font-size="16" font-weight="bold" color="slate-100">Card Title</ids-text>
+              <ids-text type="h2" font-size="16" color="slate-60">Additional Card Info</ids-text>
+          </div>
+        </ids-card>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-card/demos/height.ts
+++ b/src/components/ids-card/demos/height.ts
@@ -1,0 +1,7 @@
+import css from '../../../assets/css/ids-card/auto-fit.css';
+
+const cssLink = `<link href="${css}" rel="stylesheet">`;
+const head = document.querySelector('head');
+if (head) {
+  head.insertAdjacentHTML('afterbegin', cssLink);
+}

--- a/src/components/ids-card/demos/index.yaml
+++ b/src/components/ids-card/demos/index.yaml
@@ -14,6 +14,9 @@
   - link: auto-fit.html
     type: Example
     description: Shows a size the fits to the bottom of the page
+  - link: height.html
+    type: Example
+    description: Shows a fixed height card
   - link: single-selection.html
     type: Example
     description: Showing cards with single selection

--- a/src/components/ids-card/ids-card.ts
+++ b/src/components/ids-card/ids-card.ts
@@ -211,6 +211,9 @@ export default class IdsCard extends Base {
     });
   }
 
+  /**
+   * Redraw the template when some properties change.
+   */
   redraw() {
     const template = document.createElement('template');
     const html = this.template();
@@ -221,6 +224,19 @@ export default class IdsCard extends Base {
     this.appendStyles();
     template.innerHTML = html;
     this.shadowRoot.appendChild(template.content.cloneNode(true));
+    this.container = this.shadowRoot.querySelector('.ids-card');
+
+    if (this.height) {
+      const link = this.container.querySelector('ids-hyperlink')?.container;
+      this.setAttribute(attributes.HEIGHT, this.height);
+      this.container.style.height = `${this.height}px`;
+      if (link) link.style.height = `${this.height}px`;
+      this.querySelector('[slot]').classList.add('fixed-height');
+    }
+
+    if (this.actionable && this.href) {
+      this.setupRipple();
+    }
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Found that the cards on https://main.wc.design.infor.com/ where not rendering at the right height setting after a recent. change I made. Correcting this.

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-card/height.html 
- the height should be 100px, should be clickable and with a ripple effect
- go to http://localhost:4300. each card should be 100px
