### PR TITLE
Proposal: Change IdsCheckbox `checked` behavior to be more like an HTML checkbox

### DIFF
--- a/src/components/ids-checkbox/ids-checkbox.ts
+++ b/src/components/ids-checkbox/ids-checkbox.ts
@@ -209,7 +209,7 @@ export default class IdsCheckbox extends Base {
     this.#triggeredChange = false;
   }
 
-  get checked(): boolean | string { return this.hasAttribute(attributes.CHECKED); }
+  get checked(): boolean { return stringToBool(this.getAttribute(attributes.CHECKED)); }
 
   /**
    *  Sets the checkbox color to one of the colors in our color palette for example emerald07

--- a/src/components/ids-checkbox/ids-checkbox.ts
+++ b/src/components/ids-checkbox/ids-checkbox.ts
@@ -209,7 +209,7 @@ export default class IdsCheckbox extends Base {
     this.#triggeredChange = false;
   }
 
-  get checked(): boolean | string { return this.getAttribute(attributes.CHECKED); }
+  get checked(): boolean | string { return this.hasAttribute(attributes.CHECKED); }
 
   /**
    *  Sets the checkbox color to one of the colors in our color palette for example emerald07

--- a/test/ids-block-grid/ids-block-grid-func-test.ts
+++ b/test/ids-block-grid/ids-block-grid-func-test.ts
@@ -115,7 +115,7 @@ describe('IdsBlockgridItem Component', () => {
     expect(blockgridItemEl.selected).toBe('false');
   });
 
-  it('support block grid selection multiple', () => {
+  it('supports block grid multiple selection', () => {
     const blockgridItemEl2 = new IdsBlockgridItem();
     blockgridEl.appendChild(blockgridItemEl2);
     blockgridItemEl2.selection = 'multiple';
@@ -127,12 +127,12 @@ describe('IdsBlockgridItem Component', () => {
     const checkboxEl2 = blockgridItemEl2.shadowRoot.querySelector('ids-checkbox');
 
     blockgridItemEl.dispatchEvent(clickEvent);
-    expect(checkboxEl.checked).toBe('true');
-    expect(checkboxEl2.checked).not.toBe('true');
+    expect(checkboxEl.checked).toBeTruthy();
+    expect(checkboxEl2.checked).toBeFalsy();
 
     blockgridItemEl2.dispatchEvent(clickEvent);
-    expect(checkboxEl.checked).toBe('true');
-    expect(checkboxEl2.checked).toBe('true');
+    expect(checkboxEl.checked).toBeTruthy();
+    expect(checkboxEl2.checked).toBeTruthy();
   });
 
   it('support block grid selection multiple keyboard', () => {

--- a/test/ids-card/ids-card-func-test.ts
+++ b/test/ids-card/ids-card-func-test.ts
@@ -118,17 +118,19 @@ describe('IdsCard Component', () => {
     // when user click card container
     card.dispatchEvent(clickEvent);
     expect(card.selected).toBe('true');
-    expect(checkboxElem.checked).toBe('true');
+    expect(checkboxElem.checked).toBeTruthy();
 
     card.dispatchEvent(clickEvent);
     expect(card.selected).toBe('false');
+    expect(checkboxElem.checked).toBeFalsy();
 
     checkboxElem.dispatchEvent(clickEvent);
     expect(card.selected).toBe('true');
-    expect(checkboxElem.checked).toBe('true');
+    expect(checkboxElem.checked).toBeTruthy();
 
     checkboxElem.dispatchEvent(clickEvent);
     expect(card.selected).toBe('false');
+    expect(checkboxElem.checked).toBeFalsy();
   });
 
   it('should fire selectionchanged event', async () => {

--- a/test/ids-checkbox-group/ids-checkbox-group-func-test.ts.snap
+++ b/test/ids-checkbox-group/ids-checkbox-group-func-test.ts.snap
@@ -4,4 +4,4 @@ exports[`IdsCheckboxGroup Component renders correctly 1`] = `"<ids-checkbox-grou
 
 exports[`IdsCheckboxGroup Component renders correctly 2`] = `"<ids-checkbox-group label=\\"Label Test\\"></ids-checkbox-group>"`;
 
-exports[`IdsCheckboxGroup Component renders correctly 3`] = `"<ids-checkbox-group label=\\"Label Test\\"><ids-checkbox label=\\"Option 1\\"></ids-checkbox></ids-checkbox-group>"`;
+exports[`IdsCheckboxGroup Component renders correctly 3`] = `"<ids-checkbox-group label=\\"Label Test\\"><ids-checkbox label=\\"Option 1\\" checked=\\"false\\"></ids-checkbox></ids-checkbox-group>"`;

--- a/test/ids-checkbox/ids-checkbox-func-test.ts
+++ b/test/ids-checkbox/ids-checkbox-func-test.ts
@@ -29,10 +29,24 @@ describe('IdsCheckbox Component', () => {
     expect(errors).not.toHaveBeenCalled();
   });
 
-  it('should renders checked', () => {
-    cb.checked = 'true';
-    expect(cb.getAttribute('checked')).toEqual('true');
-    expect(cb.checked).toEqual('true');
+  it('should render a checked checkbox', () => {
+    expect(cb.checked).toBe(false);
+
+    cb.checked = true;
+    expect(cb.checked).toEqual(true);
+    expect(cb.getAttribute('checked')).toBeDefined();
+
+    cb.checked = false;
+    expect(cb.checked).toEqual(false);
+    expect(cb.getAttribute('checked')).toBe(null);
+
+    cb.setAttribute('checked', true);
+    expect(cb.checked).toEqual(true);
+    expect(cb.getAttribute('checked')).toBeDefined();
+
+    cb.removeAttribute('checked');
+    expect(cb.checked).toEqual(false);
+    expect(cb.getAttribute('checked')).toBe(null);
   });
 
   it('should dirty tracking', () => {

--- a/test/ids-editor/ids-editor-func-test.ts
+++ b/test/ids-editor/ids-editor-func-test.ts
@@ -425,7 +425,7 @@ describe('IdsEditor Component', () => {
     expect(elems.btnSource.hidden).toEqual(false);
   });
 
-  it('should sets default value to each element in modals', () => {
+  it('should set default value on each element in modals', () => {
     const modals = {
       hyperlink: {
         url: 'http://www.test.com',
@@ -451,7 +451,7 @@ describe('IdsEditor Component', () => {
     let elems = getElems();
     expect(elems.linkUrl.value).toEqual('http://www.example.com');
     expect(elems.linkClasses.value).toEqual('hyperlink');
-    expect(elems.linkCbClickable.checked).toEqual(null);
+    expect(elems.linkCbClickable.checked).toBeFalsy();
     expect(elems.imgUrl.value).toEqual('');
     expect(elems.imgAlt.value).toEqual('');
 
@@ -459,7 +459,7 @@ describe('IdsEditor Component', () => {
     elems = getElems();
     expect(elems.linkUrl.value).toEqual('http://www.test.com');
     expect(elems.linkClasses.value).toEqual('test');
-    expect(elems.linkCbClickable.checked).toEqual('true');
+    expect(elems.linkCbClickable.checked).toBeTruthy();
     expect(elems.imgUrl.value).toEqual('/img/test.jpg');
     expect(elems.imgAlt.value).toEqual('image test title text');
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
I discovered when working in the Svelte examples that when I switched some old code from an `HTMLInputElement[type="checkbox"]`  to an IdsCheckbox, the change events were no longer responding the same way anywhere a checkbox was bound.  

After some digging, I discovered IdsCheckbox was doing the following:  When using the `checked` property of an IdsCheckbox in JS or the dev tools console, it was returning `"true"` (read: string true) when checked, and `null` when unchecked.  This is different from the behavior of an HTML checkbox, which returns a boolean in either case (See MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-checked)

In the interests of making our components act as closely to native components as possible, I'm proposing we change the current behavior.  This PR changes the following:

- IdsCheckbox's checked property type to a boolean when accessed via its JS property.  `checkbox.checked` now returns `true` / `false` 
- When using `checkbox.getAttribute('checked')` on IdsCheckbox, the attribute will still return a string if true, and `null` if false per our current `stringToBool()` behavior.
- Tests that depend on IdsCheckbox have been updated

**Related github/jira issue (required)**:
Related to #792 

**Steps necessary to review your pull request (required)**:
Smoke test http://localhost:4300/ids-checkbox, and make sure all tests pass

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
