### PR TITLE
776 app menu example

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 1.0.0-beta.1 Fixes
 
-- `[App Meny]` Fixed the footer by creating two examples for the app menu, one only including the Infor logo and the other only including the toolbar options. ([#776](https://github.com/infor-design/enterprise-wc/pull/776))
+- `[App Menu]` Fixed the footer by creating two examples for the app menu, one only including the Infor logo and the other only including the toolbar options. ([#776](https://github.com/infor-design/enterprise-wc/pull/776))
 - `[Breadcrumb]` Fixed a styling with the focus state and incorrect colors. ([#777](https://github.com/infor-design/enterprise-wc/pull/788))
 - `[Card]` Fixed the `height` setting which was not working. ([#788](https://github.com/infor-design/enterprise-wc/pull/777))
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.1 Fixes
 
+- `[App Meny]` Fixed the footer by creating two examples for the app menu, one only including the Infor logo and the other only including the toolbar options. ([#776](https://github.com/infor-design/enterprise-wc/pull/776))
 - `[Breadcrumb]` Fixed a styling with the focus state and incorrect colors. ([#777](https://github.com/infor-design/enterprise-wc/pull/788))
 - `[Card]` Fixed the `height` setting which was not working. ([#788](https://github.com/infor-design/enterprise-wc/pull/777))
 

--- a/src/components/ids-app-menu/demos/example-footer.html
+++ b/src/components/ids-app-menu/demos/example-footer.html
@@ -27,7 +27,7 @@
       <!-- Header Toolbar -->
       <ids-toolbar slot="header">
         <ids-toolbar-section align="center-even" type="fluid">
-          <ids-button id="header-btn-download" icon="download">
+          <ids-button id="header-btn-download" icon="download" padding="16px">
             <ids-text slot="text" audible>Download</ids-text>
           </ids-button>
           <ids-button id="header-btn-print" icon="print">
@@ -131,7 +131,25 @@
         </ids-accordion-panel>
       </ids-accordion>
 
-      <ids-icon slot="icon" icon="logo" viewbox="0 0 35 34" size="large" no-margins></ids-icon>
+      <!-- Footer Toolbar -->
+      <ids-toolbar slot="footer">
+        <ids-toolbar-section align="center-even">
+          <ids-button id="footer-btn-settings">
+            <ids-icon slot="icon" icon="settings"></ids-icon>
+            <span slot="text">Settings</span>
+          </ids-button>
+          <ids-button id="footer-btn-proxy" icon="employee-directory">
+            <ids-text slot="text" audible>Proxy as User</ids-text>
+          </ids-button>
+          <ids-button id="footer-btn-about" icon="info-linear">
+            <ids-text slot="text" audible>About This Application</ids-text>
+          </ids-button>
+          <ids-button id="footer-btn-logout" icon="logout">
+            <ids-text slot="text" audible>Logout</ids-text>
+          </ids-button>
+        </ids-toolbar-section>
+      </ids-toolbar>
+
 
     </ids-app-menu>
 

--- a/src/components/ids-app-menu/demos/example-footer.ts
+++ b/src/components/ids-app-menu/demos/example-footer.ts
@@ -1,0 +1,22 @@
+import avatarPlaceholder from '../../../assets/images/avatar-placeholder.jpg';
+
+const avatarImg: any = window.document.getElementById('avatar');
+avatarImg.src = avatarPlaceholder;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const appMenuDrawer: any = document.querySelector('#app-menu');
+  const appMenuTriggerBtn: any = document.querySelector('#app-menu-trigger');
+
+  appMenuDrawer.target = appMenuTriggerBtn;
+  appMenuTriggerBtn.addEventListener('click', () => {
+    appMenuTriggerBtn.disabled = true;
+  });
+
+  appMenuDrawer.addEventListener('hide', () => {
+    appMenuTriggerBtn.disabled = false;
+  });
+
+  appMenuDrawer.addEventListener('selected', (e: CustomEvent) => {
+    console.info(`Header "${(e.target as any).textContent.trim()}" was selected.`);
+  });
+});

--- a/src/components/ids-app-menu/demos/index.yaml
+++ b/src/components/ids-app-menu/demos/index.yaml
@@ -8,6 +8,9 @@
   - link: example.html
     type: Main Example
     description: Shows a basic app menu
+  - link: example-footer.html
+    type: Main Example
+    description: Shows a basic app menu with the old footer design
   - link: sandbox.html
     type: Sandbox
     description: Shows miscellaneous app menu features

--- a/src/components/ids-app-menu/ids-app-menu.scss
+++ b/src/components/ids-app-menu/ids-app-menu.scss
@@ -47,7 +47,7 @@
 
 .ids-app-menu-branding {
   // Specific Infor Logo sizing (@TODO: maybe make this its own component)
-  ids-icon[icon='logo'] {
+  ::slotted(ids-icon[icon='logo']) {
     @include p-8();
   }
 }

--- a/src/components/ids-app-menu/ids-app-menu.ts
+++ b/src/components/ids-app-menu/ids-app-menu.ts
@@ -62,7 +62,7 @@ export default class IdsAppMenu extends Base {
         <slot name="footer"></slot>
       </div>
       <div class="ids-app-menu-branding">
-        <ids-icon icon="logo" viewbox="0 0 35 34" size="large"></ids-icon>
+        <slot name="icon"></slot>
       </div>
     </div>`;
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed footer in the app-menu (toolbar was above the infor logo).

**Related github/jira issue (required)**:
part of #776

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-app-menu/example.html
- check the misaligned footer
- example.html changes:
  - changed the Infor logo from a div to a slot element 
  - removed the toolbar footer and replaced it with the slot's name for the logo
- created another demo called example-footer.html
  - this demo only includes the toolbar footer so I removed the infor logo
  - removed type='fluid' and align='center-even' since it was pushed to the right.


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

Original demo (example.html) which only includes the Infor logo.
<img width="302" alt="example" src="https://user-images.githubusercontent.com/105875239/179282405-6992c7da-5bf6-49b9-9077-742b660d9448.png">

New demo (example-footer.html) which only includes the toolbar footer.
<img width="299" alt="example-footer" src="https://user-images.githubusercontent.com/105875239/179282570-58389b96-330d-4ad4-aa5b-d5f683b840a7.png">

