### PR TITLE
674 - IdsDropdown Sizes

### DIFF
--- a/src/components/ids-color-picker/ids-color-picker.scss
+++ b/src/components/ids-color-picker/ids-color-picker.scss
@@ -38,7 +38,7 @@
   }
 
   &.full {
-    max-width: $border-input-size-full;
+    max-width: $input-size-full;
   }
 }
 

--- a/src/components/ids-dropdown/demos/index.yaml
+++ b/src/components/ids-dropdown/demos/index.yaml
@@ -8,6 +8,9 @@
   - link: example.html
     type: Main Example
     description: Shows basic dropdown with states
+  - link: sizes.html
+    type: Example
+    description: Showing width and height size variations
   - link: side-by-side.html
     type: Side by Side
     description: Showing a dropdown side by side with a 4.x dropdown

--- a/src/components/ids-dropdown/demos/sizes.html
+++ b/src/components/ids-dropdown/demos/sizes.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid>
+      <ids-text font-size="12" type="h1">Dropdown Sizes</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid cols="2" gap="sm">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h1">Width</ids-text>
+        <br/>
+        <ids-dropdown label="Default" value="opt3">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Extra Small" value="opt3" size="xs">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Small" value="opt3" size="sm">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Small - Medium" value="opt3" size="mm">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Medium" value="opt3" size="md">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Large" value="opt3" size="lg">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Full" value="opt3" size="full">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+      </ids-layout-grid-cell>
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h1">Height</ids-text>
+        <br/>
+        <ids-dropdown label="Compact" value="opt3" compact>
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Extra Small" value="opt3" field-height="xs">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Small" value="opt3" field-height="sm">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Medium" value="opt3" field-height="md">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown label="Large" value="opt3" field-height="lg">
+          <ids-list-box>
+            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-dropdown/demos/sizes.html
+++ b/src/components/ids-dropdown/demos/sizes.html
@@ -22,11 +22,11 @@
             <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
           </ids-list-box>
         </ids-dropdown>
-        <ids-dropdown label="Extra Small" value="opt3" size="xs">
+        <ids-dropdown label="Extra Small" value="1" size="xs">
           <ids-list-box>
-            <ids-list-box-option value="opt1">Option One</ids-list-box-option>
-            <ids-list-box-option value="opt2">Option Two</ids-list-box-option>
-            <ids-list-box-option value="opt3">Option Three</ids-list-box-option>
+            <ids-list-box-option value="1">1</ids-list-box-option>
+            <ids-list-box-option value="2">2</ids-list-box-option>
+            <ids-list-box-option value="3">3</ids-list-box-option>
           </ids-list-box>
         </ids-dropdown>
         <ids-dropdown label="Small" value="opt3" size="sm">

--- a/src/components/ids-dropdown/ids-dropdown.scss
+++ b/src/components/ids-dropdown/ids-dropdown.scss
@@ -24,7 +24,10 @@ ids-trigger-button {
 }
 
 :host([size='full']) {
-  @include w-full();
+  &,
+  ids-popup {
+    @include w-full();
+  }
 }
 
 :host([dir='rtl']) .icon-container {

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -101,9 +101,12 @@ export default class IdsDropdown extends Base {
     if (val) {
       const attr = val === 'compact' ? { name: 'compact', val: '' } : { name: 'field-height', val };
       this.input.setAttribute(attr.name, attr.val);
+      this.listBox?.setAttribute(attr.name, attr.val);
     } else {
       this.input.removeAttribute('compact');
       this.input.removeAttribute('field-height');
+      this.listBox?.removeAttribute('compact');
+      this.listBox?.removeAttribute('field-height');
     }
   }
 

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -817,8 +817,10 @@ export default class IdsDropdown extends Base {
   set size(value: string) {
     if (value) {
       this.setAttribute(attributes.SIZE, value);
+      this.listBox?.setAttribute(attributes.SIZE, value);
     } else {
       this.removeAttribute(attributes.SIZE);
+      this.listBox?.removeAttribute(attributes.SIZE);
     }
     this.input.setAttribute(attributes.SIZE, this.size);
   }

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -16,7 +16,6 @@ $border-input-size-sm: $input-size-sm - 2;
 $border-input-size-md: $input-size-md - 2;
 $border-input-size-mm: $input-size-mm - 2;
 $border-input-size-lg: $input-size-lg - 2;
-$border-input-size-full: $input-size-full - 2;
 $border-input-field-height-compact: $input-compact-height - 2;
 $border-input-field-height-xs: $input-field-height-xs - 2;
 $border-input-field-height-sm: $input-field-height-sm - 2;
@@ -308,7 +307,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   }
 
   &.full .field-container {
-    max-width: $border-input-size-full;
+    max-width: $input-size-full;
   }
 
   // input field-heights: [xs, sm, md, lg]

--- a/src/components/ids-list-box/ids-list-box.scss
+++ b/src/components/ids-list-box/ids-list-box.scss
@@ -1,6 +1,13 @@
 /* Styling for Dropdown List Options */
 @import '../../core/ids-base';
 
+// These input field sizes come from the design tokens and are adjusted
+// here to account for 1px border size on top/bottom or left/right in some calculations.
+$border-input-size-xs: $input-size-xs - 2;
+$border-input-size-sm: $input-size-sm - 2;
+$border-input-size-md: $input-size-md - 2;
+$border-input-size-mm: $input-size-mm - 2;
+$border-input-size-lg: $input-size-lg - 2;
 :host {
   display: block;
   overflow-x: hidden;
@@ -9,4 +16,47 @@
   scroll-behavior: smooth;
   min-width: $input-size-xs - 2;
   width: 298px;
+}
+
+// Sizes
+:host([size='xs']) {
+  &,
+  ::slotted(ids-list-box-option) {
+    width: $border-input-size-xs;
+  }
+}
+
+:host([size='sm']) {
+  &,
+  ::slotted(ids-list-box-option) {
+    width: $border-input-size-sm;
+  }
+}
+
+:host([size='md']) {
+  &,
+  ::slotted(ids-list-box-option) {
+    width: $border-input-size-md;
+  }
+}
+
+:host([size='mm']) {
+  &,
+  ::slotted(ids-list-box-option) {
+    width: $border-input-size-mm;
+  }
+}
+
+:host([size='lg']) {
+  &,
+  ::slotted(ids-list-box-option) {
+    width: $border-input-size-lg;
+  }
+}
+
+:host([size='full']) {
+  &,
+  ::slotted(ids-list-box-option) {
+    width: $input-size-full;
+  }
 }

--- a/src/components/ids-list-box/ids-list-box.scss
+++ b/src/components/ids-list-box/ids-list-box.scss
@@ -8,6 +8,12 @@ $border-input-size-sm: $input-size-sm - 2;
 $border-input-size-md: $input-size-md - 2;
 $border-input-size-mm: $input-size-mm - 2;
 $border-input-size-lg: $input-size-lg - 2;
+$border-input-field-height-compact: $input-field-height-xs - 2;
+$border-input-field-height-xs: $input-field-height-xs - 2;
+$border-input-field-height-sm: $input-field-height-sm - 2;
+$border-input-field-height-md: $input-field-height-md - 2;
+$border-input-field-height-lg: $input-field-height-lg - 2;
+
 :host {
   display: block;
   overflow-x: hidden;
@@ -18,7 +24,7 @@ $border-input-size-lg: $input-size-lg - 2;
   width: 298px;
 }
 
-// Sizes
+// Width Sizes
 :host([size='xs']) {
   &,
   ::slotted(ids-list-box-option) {
@@ -58,5 +64,37 @@ $border-input-size-lg: $input-size-lg - 2;
   &,
   ::slotted(ids-list-box-option) {
     width: $input-size-full;
+  }
+}
+
+// Height Sizes
+:host([compact]),
+:host([field-height='xs']) {
+  ::slotted(ids-list-box-option) {
+    @include text-14();
+
+    min-height: $border-input-field-height-compact;
+    line-height: $border-input-field-height-compact;
+  }
+}
+
+:host([field-height='sm']) {
+  ::slotted(ids-list-box-option) {
+    min-height: $border-input-field-height-sm;
+    line-height: $border-input-field-height-sm;
+  }
+}
+
+:host([field-height='md']) {
+  ::slotted(ids-list-box-option) {
+    min-height: $border-input-field-height-md;
+    line-height: $border-input-field-height-md;
+  }
+}
+
+:host([field-height='lg']) {
+  ::slotted(ids-list-box-option) {
+    min-height: $border-input-field-height-lg;
+    line-height: $border-input-field-height-lg;
   }
 }

--- a/test/ids-dropdown/ids-dropdown-func-test.ts
+++ b/test/ids-dropdown/ids-dropdown-func-test.ts
@@ -675,6 +675,7 @@ describe('IdsDropdown Component', () => {
 
       expect(dropdown.getAttribute('size')).toEqual(size);
       expect(dropdown.input.getAttribute('size')).toEqual(size);
+      expect(dropdown.listBox.getAttribute('size')).toEqual(size);
     };
 
     expect(dropdown.getAttribute('size')).toEqual(null);
@@ -684,6 +685,7 @@ describe('IdsDropdown Component', () => {
 
     expect(dropdown.getAttribute('size')).toEqual(null);
     expect(dropdown.input.getAttribute('size')).toEqual(defaultSize);
+    expect(dropdown.listBox.getAttribute('size')).toEqual(null);
   });
 
   it('should set no margins', () => {
@@ -716,6 +718,7 @@ describe('IdsDropdown Component', () => {
     expect(dropdown.colorVariant).toEqual('alternate-formatter');
     expect(dropdown.labelState).toEqual('collapsed');
     expect(dropdown.compact).toEqual(true);
+    expect(dropdown.listBox.getAttribute('compact')).not.toBeNull();
     expect(dropdown.noMargins).toEqual(true);
 
     dropdown.compact = false;
@@ -723,6 +726,7 @@ describe('IdsDropdown Component', () => {
     dropdown.template();
 
     expect(dropdown.fieldHeight).toEqual('lg');
+    expect(dropdown.listBox.getAttribute('field-height')).toEqual('lg');
   });
 
   it('fixes itself with an empty container', () => {

--- a/test/ids-dropdown/ids-dropdown-percy-test.ts
+++ b/test/ids-dropdown/ids-dropdown-percy-test.ts
@@ -2,6 +2,7 @@ import percySnapshot from '@percy/puppeteer';
 
 describe('Ids Dropdown Percy Tests', () => {
   const url = 'http://localhost:4444/ids-dropdown/example.html';
+  const urlSizes = 'http://localhost:4444/ids-dropdown/sizes.html';
 
   it('should not have visual regressions in new light theme (percy)', async () => {
     await page.goto(url, { waitUntil: ['networkidle2', 'load'] });
@@ -22,5 +23,10 @@ describe('Ids Dropdown Percy Tests', () => {
       document.querySelector('ids-theme-switcher')?.setAttribute('mode', 'contrast');
     });
     await percySnapshot(page, 'ids-dropdown-new-contrast');
+  });
+
+  it('should not have visual regressions on Sizes example in light theme (percy)', async () => {
+    await page.goto(urlSizes, { waitUntil: ['networkidle2', 'load'] });
+    await percySnapshot(page, 'ids-dropdown-sizes-light');
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds sizes example page and adds adjustments for any slotted `ids-list-box` `ids-list-box-option` to be the same width/height as the trigger field

**Related github/jira issue (required)**:
Closes #674 

**Steps necessary to review your pull request (required)**:
- pull, build and run
- go to http://localhost:4300/ids-dropdown/sizes.html
- check `ids-list-box` same width as the trigger field in the width example column
- check `ids-list-box-option` same height as the trigger field in the height example column

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
~- [ ] A note to the change log.~

<!-- After submitting your PR, please check back to make sure checks on the PR -->
