### PR TITLE
Chore: Fix IdsMask example pages

### DIFF
--- a/src/components/ids-input/README.md
+++ b/src/components/ids-input/README.md
@@ -74,9 +74,9 @@ Set the Text Align to Text Input this way:
 
 ```html
 <ids-input label="Default align (left)" value="Default align"></ids-input>
-<ids-input label="Left align" value="Left align" text-align="left"></ids-input>
+<ids-input label="Left align" value="Left align" text-align="start"></ids-input>
 <ids-input label="Center align" value="Center align" text-align="center"></ids-input>
-<ids-input label="Right align" value="Right align" text-align="right"></ids-input>
+<ids-input label="Right align" value="Right align" text-align="end"></ids-input>
 ```
 
 Set the caps lock alert indicator this way:

--- a/src/components/ids-input/demos/example.html
+++ b/src/components/ids-input/demos/example.html
@@ -64,7 +64,7 @@
         <ids-text font-size="12" type="h2">Ids Input - Phone/Number</ids-text>
         <br>
         <ids-input id="phone-input" type="phone" label="Phone Number" mask="number" placeholder="(###) ###-####"></ids-input>
-        <ids-input id="number-input" type="number" label="Number" mask="number" placeholder="1000.00" text-align="right"></ids-input>
+        <ids-input id="number-input" label="Number" mask="number" placeholder="1000.00" text-align="end"></ids-input>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-mask/demos/example.html
+++ b/src/components/ids-mask/demos/example.html
@@ -24,7 +24,7 @@
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
         <ids-input id="mask-number" label="Formatted Number"
-          placeholder="-1,000,000.00" text-align="right"></ids-input>
+          placeholder="-1,000,000.00" text-align="end"></ids-input>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-mask/demos/localized-dates.html
+++ b/src/components/ids-mask/demos/localized-dates.html
@@ -2,9 +2,8 @@
 <html lang="en">
 
 <head>
-  <title>
-    <%= htmlWebpackPlugin.options.title %>
-  </title>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
 </head>
 
 <body>
@@ -13,24 +12,6 @@
     <ids-layout-grid cols="3" gap="md">
       <ids-layout-grid-cell>
         <ids-text font-size="12" type="h1">Masked Inputs (Localized Dates)</ids-text>
-      </ids-layout-grid-cell>
-    </ids-layout-grid>
-
-    <ids-layout-grid cols="1" gap="md">
-      <ids-layout-grid-cell>
-        <ids-dropdown id="locales" size="sm" label="Choose Locale" dirty-tracker="true" value="en-US">
-          <ids-list-box>
-            <ids-list-box-option value="en-US">en-US</ids-list-box-option>
-            <ids-list-box-option value="de-DE">de-DE</ids-list-box-option>
-            <ids-list-box-option value="ru-RU">ru-RU</ids-list-box-option>
-            <ids-list-box-option value="bg-BG">bg-BG</ids-list-box-option>
-            <ids-list-box-option value="he-IL">he-IL</ids-list-box-option>
-            <ids-list-box-option value="hr-HR">hr-HR</ids-list-box-option>
-            <ids-list-box-option value="ar-EG">ar-EG</ids-list-box-option>
-            <ids-list-box-option value="th-TH">th-TH</ids-list-box-option>
-            <ids-list-box-option value="zh-TW">zh-TW</ids-list-box-option>
-          </ids-list-box>
-        </ids-dropdown>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 

--- a/src/components/ids-mask/demos/localized-dates.ts
+++ b/src/components/ids-mask/demos/localized-dates.ts
@@ -4,7 +4,6 @@ import '../../ids-dropdown/ids-dropdown';
 
 document.addEventListener('DOMContentLoaded', () => {
   const pageContainer: any = document.querySelector('ids-container');
-  const dropdown: any = document.querySelector('ids-dropdown');
   let calendar = pageContainer.locale.calendar();
 
   // Configure Short Date input
@@ -20,11 +19,6 @@ document.addEventListener('DOMContentLoaded', () => {
     format: calendar.dateFormat.timestamp
   };
   dateInputTime.placeholder = dateInputTime.maskOptions.format;
-
-  // Change the IdsContainer's locale setting when the dropdown is modified
-  dropdown.addEventListener('change', async (e: any) => {
-    await pageContainer.setLocale(e.target.value);
-  });
 
   // Change locale on the date input when the Page container's locale changes
   pageContainer.addEventListener('localechange', () => {

--- a/src/components/ids-mask/demos/localized-numbers.html
+++ b/src/components/ids-mask/demos/localized-numbers.html
@@ -2,9 +2,8 @@
 <html lang="en">
 
 <head>
-  <title>
-    <%= htmlWebpackPlugin.options.title %>
-  </title>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
 </head>
 
 <body>
@@ -13,24 +12,6 @@
     <ids-layout-grid cols="3" gap="md">
       <ids-layout-grid-cell>
         <ids-text font-size="12" type="h1">Masked Inputs (Localized Numbers)</ids-text>
-      </ids-layout-grid-cell>
-    </ids-layout-grid>
-
-    <ids-layout-grid cols="1" gap="md">
-      <ids-layout-grid-cell>
-        <ids-dropdown id="locales" size="sm" label="Choose Locale" dirty-tracker="true" value="en-US">
-          <ids-list-box>
-            <ids-list-box-option value="en-US">en-US</ids-list-box-option>
-            <ids-list-box-option value="de-DE">de-DE</ids-list-box-option>
-            <ids-list-box-option value="ru-RU">ru-RU</ids-list-box-option>
-            <ids-list-box-option value="bg-BG">bg-BG</ids-list-box-option>
-            <ids-list-box-option value="he-IL">he-IL</ids-list-box-option>
-            <ids-list-box-option value="hr-HR">hr-HR</ids-list-box-option>
-            <ids-list-box-option value="ar-EG">ar-EG</ids-list-box-option>
-            <ids-list-box-option value="th-TH">th-TH</ids-list-box-option>
-            <ids-list-box-option value="zh-TW">zh-TW</ids-list-box-option>
-          </ids-list-box>
-        </ids-dropdown>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 

--- a/src/components/ids-mask/demos/localized-numbers.ts
+++ b/src/components/ids-mask/demos/localized-numbers.ts
@@ -5,7 +5,6 @@ import { deepClone } from '../../../utils/ids-deep-clone-utils/ids-deep-clone-ut
 
 document.addEventListener('DOMContentLoaded', () => {
   const pageContainer: any = document.querySelector('ids-container');
-  const dropdown: any = document.querySelector('ids-dropdown');
 
   // Uses the defined integer/decimal limits to create an IdsInput
   // `placeholder` definition based on the actual length of the mask.
@@ -98,12 +97,6 @@ document.addEventListener('DOMContentLoaded', () => {
       input.maskOptions.decimalLimit = 6;
     }
     createPlaceholder(input);
-  });
-
-  // ===================================================
-  // Change the IdsContainer's locale setting when the dropdown is modified
-  dropdown.addEventListener('change', async (e: any) => {
-    await pageContainer.setLocale(e.target.value);
   });
 
   // Change localized strings on all number inputs when the Page container's locale changes

--- a/src/components/ids-slider/demos/update-value.html
+++ b/src/components/ids-slider/demos/update-value.html
@@ -20,7 +20,7 @@
         <ids-slider id="slider-bound" type="single" value="50" label="Bound"></ids-slider>
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
-        <ids-input id="slider-value" value="50" size="sm" text-align="right" label="Slider Value"></ids-input>
+        <ids-input id="slider-value" value="50" size="sm" text-align="end" label="Slider Value"></ids-input>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-textarea/README.md
+++ b/src/components/ids-textarea/README.md
@@ -92,9 +92,9 @@ Set the Text Align to Text Textarea this way:
 
 ```html
 <ids-textarea label="Default align (left)">Default align</ids-textarea>
-<ids-textarea label="Left align" text-align="left">Left align</ids-textarea>
+<ids-textarea label="Left align" text-align="start">Left align</ids-textarea>
 <ids-textarea label="Center align" text-align="center">Center align</ids-textarea>
-<ids-textarea label="Right align" text-align="right">Right align</ids-textarea>
+<ids-textarea label="Right align" text-align="end">Right align</ids-textarea>
 ```
 
 Set the sizes, available sizes are `'sm'|'md'|'lg'|'full'` and default type is `size="md"`.

--- a/src/components/ids-textarea/demos/example.html
+++ b/src/components/ids-textarea/demos/example.html
@@ -71,9 +71,9 @@
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
         <ids-textarea label="Default align (left)">Default align</ids-textarea>
-        <ids-textarea label="Left align" text-align="left">Left align</ids-textarea>
+        <ids-textarea label="Left align" text-align="start">Left align</ids-textarea>
         <ids-textarea label="Center align" text-align="center">Center align</ids-textarea>
-        <ids-textarea label="Right align" text-align="right">Right align</ids-textarea>
+        <ids-textarea label="Right align" text-align="end">Right align</ids-textarea>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Realized while working through examples that the current Mask component pages are a bit off:
- https://main.wc.design.infor.com/ids-mask/example.html the number field was misaligned
- https://main.wc.design.infor.com/ids-mask/localized-dates.html was missing the font
- https://main.wc.design.infor.com/ids-mask/localized-numbers.html was missing the font and the number fields were misaligned

Turns out a handful of input pages and the docs missed the `text-align` setting change from "right" to "end", so just pushing a quick fix for those

**Related github/jira issue (required)**:
Related to #792 

**Steps necessary to review your pull request (required)**:
Pull/Build/Run, then review the changes to the README.md along with these pages:
- http://localhost:4300/ids-input/example.html
- http://localhost:4300/ids-mask/example.html
- http://localhost:4300/ids-mask/localized-numbers.html
- http://localhost:4300/ids-mask/localized-dates.html

On the localized date/number pages, the in-page Locale swapper component has been removed in favor of the Theme Switcher's locale menu
