### PR TITLE
778 - IdsDatePicker update keyboard events

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### 1.0.0-beta.1 Fixes
 
-- `[Action Sheet]` Updated `btnText` to `cancelBtnText` and fixed the setter update to update the DOM text when called (which was not working). ([#505](https://github.com/infor-design/enterprise-wc/pull/505))
+- `[ActionSheet]` Updated `btnText` to `cancelBtnText` and fixed the setter update to update the DOM text when called (which was not working). ([#505](https://github.com/infor-design/enterprise-wc/pull/505))
 - `[About]` Fixed scrolling issue with pointer event and adjusted text to screen size. ([#701](https://github.com/infor-design/enterprise-wc/pull/701))
 - `[AppMenu]` Fixed the footer by creating two examples for the app menu, one only including the Infor logo and the other only including the toolbar options. ([#776](https://github.com/infor-design/enterprise-wc/pull/776))
 - `[AxisChart]` Add support for axis labels all around bottom, end, start, top. ([#738](https://github.com/infor-design/enterprise-wc/issues/738))
 - `[Breadcrumb]` Fixed a styling with the focus state and incorrect colors. ([#777](https://github.com/infor-design/enterprise-wc/pull/788))
 - `[Card]` Fixed the `height` setting which was not working. ([#788](https://github.com/infor-design/enterprise-wc/pull/777))
+- `[DatePicker]` Fixed frozen page when "Enter" or "Shift" key is pressed when selecting month and year. ([#778](https://github.com/infor-design/enterprise-wc/issues/778))
 - `[DatePicker]` Fixed keyboard events to accomodate to Firefox browser (which was not working). ([#779](https://github.com/infor-design/enterprise-wc/issues/779))
 - `[PopupMenu]` Added `triggerElem` property for separating the element triggering a Popup from the element in which the Popup aligns against.  ([#769](https://github.com/infor-design/enterprise-wc/issues/769))
 - `[Radio]` Fixed incorrect colors in constrast mode. ([#775](https://github.com/infor-design/enterprise-wc/pull/775))

--- a/src/components/ids-date-picker/ids-date-picker.ts
+++ b/src/components/ids-date-picker/ids-date-picker.ts
@@ -967,6 +967,13 @@ class IdsDatePicker extends Base {
         this.#picklistWeekPaged(true);
       }
 
+      // Enter on selected month/year will switch focus between the two
+      if (key === 13 && monthSelected?.matches(':focus')) {
+        yearSelected?.focus();
+      } else if (key === 13 && yearSelected?.matches(':focus')) {
+        monthSelected?.focus();
+      }
+
       // Arrow Up on picklist month
       if (key === 38 && monthSelected?.matches(':focus')) {
         const month = this.month - 1;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes the issue of the page being static on any of the date fields when "Enter" or "Shift" key is pressed on month/year selector (on all browsers).

**Related github/jira issue (required)**:
fixes #778 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, npm run start
2. Go to http://localhost:4300/ids-date-picker/example.html
3. Open a date fields (where input is not disabled nor readonly)
4. Click the Month OR Year picker/selector
5. Use up/down arrow to move current focus of month/year
6. Press Enter or Shift Key
7. See error ~ nothing is happening (focus state is static)

**Expected behavior**:
- focus state will toggle between month and year when "Enter" key is pressed instead of the focus saying static.
- "Shift" will move the focus around the entire popup modal

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
