### PR TITLE
778 - IdsDatePicker keyboard events

### DIFF
--- a/src/components/ids-date-picker/ids-date-picker.ts
+++ b/src/components/ids-date-picker/ids-date-picker.ts
@@ -967,13 +967,6 @@ class IdsDatePicker extends Base {
         this.#picklistWeekPaged(true);
       }
 
-      // Enter on selected month/year will switch focus between the two
-      if (key === 13 && monthSelected?.matches(':focus')) {
-        yearSelected?.focus();
-      } else if (key === 13 && yearSelected?.matches(':focus')) {
-        monthSelected?.focus();
-      }
-
       // Arrow Up on picklist month
       if (key === 38 && monthSelected?.matches(':focus')) {
         const month = this.month - 1;
@@ -1250,6 +1243,19 @@ class IdsDatePicker extends Base {
 
           this.#changeDate('previous-day');
         }
+      }
+
+      const btnApply = this.container.querySelector('.popup-btn-apply');
+      const yearState = this.#monthView.container?.querySelector('ids-date-picker').shadowRoot?.querySelector('.is-year.is-selected');
+      const monthState = this.#monthView.container?.querySelector('ids-date-picker').shadowRoot?.querySelector('.is-month.is-selected');
+
+      // Enter on selected month will move focus to picklist year
+      // Enter on selected year will move focus to Apply button
+      if (key === 13 && monthState?.matches(':focus')) {
+        yearState?.focus();
+      } else if (key === 13 && yearState?.matches(':focus')) {
+        stopEvent();
+        btnApply?.focus();
       }
     }
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes the issue of the page being static on any of the date fields when "Enter" or "Shift" key is pressed on month/year selector (on all browsers).

**Related github/jira issue (required)**:
fixes #778 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, npm run start
2. Go to http://localhost:4300/ids-date-picker/example.html
3. Open a date fields (where input is not disabled nor readonly)
4. Click the Month OR Year picker/selector
5. Use up/down arrow to move current focus of month/year
6. Press Enter or Shift Key
7. See error ~ nothing is happening (focus state is static)

**Expected behavior**:
- if "Enter" key is pressed on selected month, focus will switch to year selection.
- if "Enter" key is pressed on selected year, focus will switch to apply button.
- "Shift" will move the focus around the entire popup modal

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
