### PR TITLE
848 - IdsTag Update icon colors

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[PieChart]` Improved the tooltip placement logic and some cleanup. ([#736](https://github.com/infor-design/enterprise-wc/issues/736))
 - `[PopupMenu]` Added `triggerElem` property for separating the element triggering a Popup from the element in which the Popup aligns against.  ([#769](https://github.com/infor-design/enterprise-wc/issues/769))
 - `[Radio]` Fixed incorrect colors in contrast mode. ([#775](https://github.com/infor-design/enterprise-wc/pull/775))
+- `[Tag]` Updated `x` and `>` icon color on colored tags when dismissible/clickable is true.([#848](https://github.com/infor-design/enterprise-wc/pull/848))
 
 ## 1.0.0-beta.0
 

--- a/src/components/ids-tag/ids-tag.scss
+++ b/src/components/ids-tag/ids-tag.scss
@@ -112,7 +112,11 @@
 }
 
 // Handle white coloring
-.ids-white ::slotted(ids-icon),
+.ids-white ::slotted(ids-icon) {
+  @include text-slate-20();
+}
+
+// Adjust hover state
 .ids-white ::slotted(ids-icon:hover) {
   @include text-white();
 }

--- a/src/components/ids-tag/ids-tag.ts
+++ b/src/components/ids-tag/ids-tag.ts
@@ -89,6 +89,9 @@ export default class IdsTag extends Base {
           this.container.style.borderColor = value;
         } else {
           this.container.classList.add(value);
+          if (value !== 'secondary') {
+            this.container.classList.add('ids-white');
+          }
         }
       }
     }
@@ -168,14 +171,18 @@ export default class IdsTag extends Base {
       this.removeAttribute(attributes.CLICKABLE);
     }
 
-    if (this.container) {
+    const clickableContainer = this.container || this;
+
+    if (clickableContainer) {
       if (isClickable) {
-        this.container.classList.add(attributes.FOCUSABLE);
-        this.container.setAttribute(attributes.TABINDEX, '0');
+        this.#appendIcon('caret-right');
+        clickableContainer.classList.add(attributes.FOCUSABLE);
+        clickableContainer.setAttribute(attributes.TABINDEX, '0');
         this.#attachKeyboardListeners();
       } else {
-        this.container.removeAttribute(attributes.TABINDEX);
-        this.container.classList.remove(attributes.FOCUSABLE);
+        this.#removeIcon('caret-right');
+        clickableContainer.removeAttribute(attributes.TABINDEX);
+        clickableContainer.classList.remove(attributes.FOCUSABLE);
       }
     }
   }

--- a/src/components/ids-tag/ids-tag.ts
+++ b/src/components/ids-tag/ids-tag.ts
@@ -89,7 +89,7 @@ export default class IdsTag extends Base {
           this.container.style.borderColor = value;
         } else {
           this.container.classList.add(value);
-          if (value !== 'secondary') {
+          if (value !== 'secondary' && value !== 'caution') {
             this.container.classList.add('ids-white');
           }
         }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes the issue of the icon colors on colored tags when `dismissible="true"` or `clickable="true"`.

**Related github/jira issue (required)**:
fixes #848 

**Steps necessary to review your pull request (required)**:
1. pull, build, and run
2. go to http://localhost:4300/ids-tag/example.html
3. Add `dismissible="true"` to any of the colored tags (success, info, warning, and error)
4. See error -> the `x` icon is too dark
5. Same for clickable="true" (the `>` icon is too dark)
       - appended icon when it's set to true since it wasn't displaying any icon

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
