### PR TITLE
692 - Add save position with splitter

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[PopupMenu]` Added `triggerElem` property for separating the element triggering a Popup from the element in which the Popup aligns against.  ([#769](https://github.com/infor-design/enterprise-wc/issues/769))
 - `[Lookup]` Added new features showing paging, clearable, filtering and more test coverage and docs.  ([#686](https://github.com/infor-design/enterprise-wc/issues/686))
 - `[Radio]` Fixed incorrect colors in contrast mode. ([#775](https://github.com/infor-design/enterprise-wc/pull/775))
+- `[Splitter]` Added support for save position to local storage. ([#692](https://github.com/infor-design/enterprise-wc/issues/692))
 - `[Tag]` Updated `x` and `>` icon color on colored tags when dismissible/clickable is true.([#848](https://github.com/infor-design/enterprise-wc/pull/848))
 
 ## 1.0.0-beta.0

--- a/src/components/ids-splitter/README.MD
+++ b/src/components/ids-splitter/README.MD
@@ -133,6 +133,15 @@ Splitter set as disabled.
 </ids-splitter>
 ```
 
+Save splitter position to local storage.
+
+```html
+<ids-splitter unique-id="some-uniqueid" save-position>
+  <ids-splitter-pane></ids-splitter-pane>
+  <ids-splitter-pane></ids-splitter-pane>
+</ids-splitter>
+```
+
 ## Settings and Attributes (Splitter)
 
 - `align` {string} Set the split bar align direction to start or end
@@ -140,6 +149,8 @@ Splitter set as disabled.
 - `disabled` {boolean} Sets the splitter to disabled state
 - `label` {string} Set the aria-label text for each split bar
 - `resizeOnDragEnd` {boolean} Sets the splitter to resize on drag end
+- `savePosition` {boolean} Set splitter to save position to local storage.
+- `uniqueId` {string} Set uniqueId to save to local storage, so same saved position can be use for whole app.
 
 ## Settings and Attributes (Splitter Pane)
 
@@ -166,12 +177,18 @@ Splitter set as disabled.
 - `expanded` Fires after the splitter pane get expanded
 - `beforesizechanged` Fires before the splitter pane size changed, you can return false in the response to veto
 - `sizechanged` Fires after the splitter pane size changed
+- `save-position` Fires after the local storage settings changed in some way
+- `clear-position` Fires after clear the saved position from local storage
 
 ## Methods (Splitter)
 
+- `clearPosition(uniqueId: string|undefined)` Clear the saved position from local storage, If uniqueId is undefined will use Internal attached
+- `clearPositionAll()` Clear all splitter related saved position from local storage
 - `collapse(options: { startPane: HTMLElement|string, endPane: HTMLElement|string }): void` Collapse start pane size for given start/end panes or panes CSS selector
 - `expand(options: { startPane: HTMLElement|string, endPane: HTMLElement|string }): void` Expand start pane size for given start/end panes or panes CSS selector
+- `getAllPairs(): Array<object>` Get list of splitter pairs
 - `getPair(options: { startPane: HTMLElement|string, endPane: HTMLElement|string }): object` Get a splitter pair by given start/end panes or panes CSS selector
+- `idTobeUse(uniqueId?: string, suffix?: string, prefix?: string): string` Get the id to be use
 - `isHorizontal(): boolean` Get true if current orientation is horizontal
 - `sizes(): Array<number>` Get list of current sizes
 - `minSizes(): Array<number>` Get list of current minimum sizes

--- a/src/components/ids-splitter/TODO.md
+++ b/src/components/ids-splitter/TODO.md
@@ -5,7 +5,7 @@ Keep this file in sync with #694
 ## Major
 
 - [ ] Does not work on a touch device (iPad/iPhone in chrome dev tools) ([#691](https://github.com/infor-design/enterprise-wc/issues/691))
-- [ ] Save positions to local storage ([#692](https://github.com/infor-design/enterprise-wc/issues/692))
+- [x] Save positions to local storage ([#692](https://github.com/infor-design/enterprise-wc/issues/692))
 - [ ] Add API methods for sizing/expanding/collapsing split panes ([#693](https://github.com/infor-design/enterprise-wc/issues/693))
 - [ ] Add trigger button to toggle collapse/expand to split-bar
 - [ ] Fix aria-controls error for split-bar

--- a/src/components/ids-splitter/demos/sandbox.html
+++ b/src/components/ids-splitter/demos/sandbox.html
@@ -147,10 +147,11 @@
       </div>
     </ids-layout-grid>
 
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12">Disable / Enable</ids-text>
+    </ids-layout-grid>
     <ids-layout-grid>
       <ids-layout-grid-cell>
-        <ids-text font-size="12">Disable / Enable</ids-text>
-        <br />
         <ids-button id="btn-splitter-disable-enable" type="secondary">
           <span slot="text">Enable Splitter</span>
         </ids-button>
@@ -213,6 +214,61 @@
         </ids-splitter>
       </div>
     </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h1">Save Position</ids-text>
+        <ids-text>1. Drag the Splitter Bar to move panes and leave at different position then origin</ids-text>
+        <ids-text>2. At this point it should be saved the current position to local storage</ids-text>
+        <ids-text>3. Refresh or close/open the page, and see the same Splitter</ids-text>
+        <ids-text>4. It should have previously saved positions</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+    <ids-layout-grid>
+      <ids-layout-grid-cell>
+        <ids-menu-button type="secondary" id="btn-splitter-save-clear" menu="menu-splitter-save-clear" trigger-type="click" dropdown-icon>
+          <span slot="text">Clear saved position</span>
+        </ids-menu-button>
+        <ids-popup-menu id="menu-splitter-save-clear" target="#btn-splitter-save-clear">
+          <ids-menu-group>
+            <ids-menu-item id="clear-saved-splitter-1" value="clear-saved-splitter-1">Clear position for saved Splitter(1)</ids-menu-item>
+            <ids-menu-item id="clear-saved-splitter-2" value="clear-saved-splitter-2">Clear position for saved Splitter(2)</ids-menu-item>
+            <ids-menu-item id="clear-saved-splitter-all" value="clear-saved-splitter-all">Clear position for all saved Splitters</ids-menu-item>
+          </ids-menu-group>
+        </ids-popup-menu>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text>1. Choose Splitter(1), Splitter(2) or all saved Splitters to clear from menu button</ids-text>
+        <ids-text>2. Refresh or close/open the page, and see the same Splitter</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-text>Save Position - Splitter(1)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <div class="demo-splitter">
+        <ids-splitter id="splitter-save1" unique-id="some-uniqueid-1" save-position>
+          <ids-splitter-pane></ids-splitter-pane>
+          <ids-splitter-pane></ids-splitter-pane>
+        </ids-splitter>
+      </div>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <ids-text>Save Position - Splitter(2)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <div class="demo-splitter">
+        <ids-splitter id="splitter-save2" unique-id="some-uniqueid-2" save-position>
+          <ids-splitter-pane></ids-splitter-pane>
+          <ids-splitter-pane></ids-splitter-pane>
+        </ids-splitter>
+      </div>
+    </ids-layout-grid>
+
   </ids-container>
 </body>
 </html>

--- a/src/components/ids-splitter/demos/sandbox.ts
+++ b/src/components/ids-splitter/demos/sandbox.ts
@@ -97,4 +97,41 @@ document.addEventListener('DOMContentLoaded', async () => {
       toggleCollapseExpand();
     });
   }
+
+  /*
+   * Save position
+   * apply only when `save-position` set to true
+   *
+   * uniqueId: Use to clear the saved position from storage
+   * if not will use internal auto generated id
+   */
+  const uniqueId1 = 'some-uniqueid-1';
+  const uniqueId2 = 'some-uniqueid-2';
+
+  const splitterSave1: any = document.querySelector('#splitter-save1');
+  const splitterSave2: any = document.querySelector('#splitter-save2');
+  const btnSaveClear: any = document.querySelector('#btn-splitter-save-clear');
+  btnSaveClear.menuEl.addEventListener('selected', (e: any) => {
+    const sel = e.detail.value;
+
+    // Clear position for saved Splitter(1)
+    if (sel === 'clear-saved-splitter-1') {
+      splitterSave1.clearPosition(uniqueId1);
+    }
+
+    // Clear position for saved Splitter(2)
+    if (sel === 'clear-saved-splitter-2') {
+      splitterSave2.clearPosition(uniqueId2);
+    }
+
+    // Clear position for all saved Splitters
+    if (sel === 'clear-saved-splitter-all') {
+      const splitter: any = document.createElement('ids-splitter');
+      /**
+       * To clear all saved positions,
+       * It can run on any IdsSplitter `clearPositionAll()`
+       */
+      splitter.clearPositionAll();
+    }
+  });
 });

--- a/src/components/ids-splitter/ids-splitter-local-storage.ts
+++ b/src/components/ids-splitter/ids-splitter-local-storage.ts
@@ -1,0 +1,170 @@
+import IdsSplitterPane from './ids-splitter-pane';
+
+/**
+ * Saved object type
+ */
+export type IdsSplitterSavedHostProps = 'align' | 'axis' | 'disabled';
+
+/**
+ * Saved object interface
+ */
+export interface IdsSplitterSaved {
+  /** Flag for saved values, can be use or not */
+  canRestore?: boolean;
+  /** The splitter align */
+  align?: string;
+  /** The axis used */
+  axis?: string;
+  /** The disabled state */
+  disabled?: boolean;
+  /** List of pane sizes */
+  sizes?: number[];
+}
+
+/**
+ * IDS Splitter Local Storage
+ * @type {object}
+ */
+export default class IdsSplitterLocalStorage {
+  constructor(root: any) {
+    this.root = root;
+  }
+
+  root: any;
+
+  /**
+   * Returns true if local storage may be used / is available
+   * @private
+   * @returns {boolean} If it can be used.
+   */
+  #canUseLocalStorage(): boolean {
+    try {
+      if (typeof localStorage?.getItem === 'function') return true;
+    } catch (exception) {
+      return false;
+    }
+    return false;
+  }
+
+  /**
+   * Check if save position, is valid.
+   * @private
+   * @returns {boolean} true if is valid.
+   */
+  #canSavePosition(): boolean {
+    return this.root.savePosition && this.#canUseLocalStorage();
+  }
+
+  /**
+   * Save position.
+   * @private
+   * @returns {void}
+   */
+  savePosition(): void {
+    if (this.#canSavePosition()) {
+      const saveObj: IdsSplitterSaved = { sizes: [...this.root.sizes()] };
+      ['align', 'axis', 'disabled'].forEach((key) => {
+        saveObj[key as IdsSplitterSavedHostProps] = this.root[key];
+      });
+
+      // Save to local storage
+      localStorage.setItem(this.idTobeUse(this.root.uniqueId), JSON.stringify(saveObj));
+      this.root.triggerEvent('save-position', this.root, {
+        detail: { elem: this.root, uniqueId: this.root.uniqueId, value: saveObj }
+      });
+    }
+  }
+
+  /**
+   * Restore the saved position from local storage
+   * @private
+   * @returns {IdsSplitterSaved|null} The position
+   */
+  restorePosition(): IdsSplitterSaved | null {
+    if (!this.#canSavePosition()) return null;
+
+    let saveObj: IdsSplitterSaved = {};
+    const savedStr = localStorage.getItem(this.idTobeUse(this.root.uniqueId));
+    if (typeof savedStr === 'string' && savedStr !== '') {
+      saveObj = { ...JSON.parse(savedStr), canRestore: false };
+      const len = saveObj?.sizes?.length;
+      const panes = [...this.root.childNodes].filter((n) => n instanceof IdsSplitterPane);
+      if (len && len === panes?.length) {
+        saveObj.canRestore = true;
+        ['align', 'axis', 'disabled'].forEach((key) => {
+          if (saveObj[key as IdsSplitterSavedHostProps] !== this.root[key]) saveObj.canRestore = false;
+        });
+      }
+    }
+    return saveObj?.canRestore ? saveObj : null;
+  }
+
+  /**
+   * Clear the saved position from local storage
+   * @param {string} uniqueId If undefined, will use Internal attached.
+   * @returns {void}
+   */
+  clearPosition(uniqueId?: string): void {
+    const clearIds = [];
+    if (this.#canUseLocalStorage()) {
+      const removeId = uniqueId || this.root.uniqueId;
+      const savedKay = this.idTobeUse(removeId);
+      const found = Object.keys(localStorage).some((key) => key === savedKay);
+      if (found) {
+        localStorage.removeItem(savedKay);
+        clearIds.push(removeId);
+      }
+    }
+    this.root.triggerEvent('clear-position', this.root, {
+      detail: { elem: this.root, clearIds }
+    });
+  }
+
+  /**
+   * Clear all related saved position from local storage
+   * @returns {void}
+   */
+  clearPositionAll(): void {
+    const clearIds: string[] = [];
+    if (this.#canUseLocalStorage()) {
+      const keys = Object.keys(localStorage);
+      keys.forEach((key) => {
+        const temp = '{idstempclearstorage}';
+        const tempId = this.idTobeUse(temp);
+        // from: 'ids-splitter-{idstempclearstorage}-usersettings-position'
+        // to: '^ids-splitter-(.+)-usersettings-position$'
+        const regexFound = new RegExp(`^${tempId.replace(temp, '(.+)')}$`, 'g');
+        if (regexFound.test(key)) {
+          const parts = tempId.split(temp);
+          // from: ['ids-splitter-', '-usersettings-position']
+          // to: '^ids-splitter-|-usersettings-position$'
+          const regexExtract = new RegExp(`^${parts.join('|')}$`, 'g');
+          const removeId = key.replace(regexExtract, '');
+          localStorage.removeItem(key);
+          clearIds.push(removeId);
+        }
+      });
+    }
+    this.root.triggerEvent('clear-position', this.root, {
+      detail: { elem: this.root, clearIds }
+    });
+  }
+
+  /**
+   * Get the id to be use.
+   * @param {string} uniqueId The uniqueId.
+   * @param {string} suffix Optional suffix string to make the id more unique.
+   * @param {string} prefix Optional prefix string to make the id more unique.
+   * @returns {string} The id.
+   */
+  idTobeUse(uniqueId?: any, suffix?: string, prefix?: string): string {
+    const defaults: any = { uniqueId: '', prefix: 'ids-splitter', suffix: 'usersettings-position' };
+    const hasValue = [uniqueId, suffix, prefix].some((x) => (x !== undefined && x !== null));
+    let returnId = defaults.prefix;
+    if (hasValue) {
+      const use = (key: string, val?: string) => (val ?? defaults[key]);
+      returnId = `${use('prefix', prefix)}-${use('uniqueId', uniqueId)}-${use('suffix', suffix)}`;
+    }
+    return returnId;
+  }
+}

--- a/test/ids-splitter/ids-splitter-e2e-test.ts
+++ b/test/ids-splitter/ids-splitter-e2e-test.ts
@@ -33,7 +33,7 @@ describe('Ids Splitter e2e Tests', () => {
       let widthP2 = await page.evaluate('document.querySelector("#minmax-p2").style.width');
       expect(stringToNumber(widthP1)).toEqual(stringToNumber(widthP2));
       await page.waitForTimeout(200);
-      await page.evaluate('document.querySelector("#splitter-minmax").shadowRoot.querySelector("#split-1").click()');
+      await page.evaluate('document.querySelector("#splitter-minmax").click()');
       await page.keyboard.press('Space');
       await page.keyboard.press('ArrowDown');
       widthP1 = await page.evaluate('document.querySelector("#minmax-p1").style.width');
@@ -66,7 +66,7 @@ describe('Ids Splitter e2e Tests', () => {
       let widthP2 = await page.evaluate('document.querySelector("#minmax-p2").style.width');
       expect(stringToNumber(widthP1)).toEqual(stringToNumber(widthP2));
       await page.waitForTimeout(200);
-      await page.evaluate('document.querySelector("#splitter-minmax").shadowRoot.querySelector("#split-1").click()');
+      await page.evaluate('document.querySelector("#splitter-minmax").click()');
       await page.keyboard.press('Space');
       await page.keyboard.press('ArrowDown');
       widthP1 = await page.evaluate('document.querySelector("#minmax-p1").style.width');

--- a/test/ids-splitter/ids-splitter-func-test.ts
+++ b/test/ids-splitter/ids-splitter-func-test.ts
@@ -3,7 +3,6 @@
  */
 import processAnimFrame from '../helpers/process-anim-frame';
 import '../helpers/resize-observer-mock';
-// import IntersectionObserver from '../helpers/intersection-observer-mock';
 import IdsContainer from '../../src/components/ids-container/ids-container';
 import IdsSplitter from '../../src/components/ids-splitter/ids-splitter';
 
@@ -33,9 +32,6 @@ describe('IdsSplitter Component', () => {
   };
 
   beforeEach(async () => {
-    // Mock IntersectionObserver
-    // (<any>window).IntersectionObserver = IntersectionObserver;
-
     const elem = new IdsSplitter();
     container = new IdsContainer();
     container.appendChild(elem);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added support for save position to local storage with IdsSplitter.

**Related github/jira issue (required)**:
Closes #692

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-splitter/sandbox.html
- Scroll all the way down to `Save Position` examples
- Drag the Splitter Bar to move panes and leave at different position then origin
- At this point it should be saved the current position to local storage
- Refresh or close/open the page, and see the same Splitter
- It should have previously saved positions

See to clear position related to IdsSplitter
- Click on button `Clear saved position`
- Choose Splitter(1), Splitter(2) or all saved Splitters to clear from menu button
- Refresh or close/open the page, and see the same Splitter

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
