### PR TITLE
878/880 - Improve IdsPopup memory leak changes

### DIFF
--- a/src/components/ids-popup/ids-popup-attributes.ts
+++ b/src/components/ids-popup/ids-popup-attributes.ts
@@ -1,5 +1,7 @@
 import { attributes } from '../../core/ids-attributes';
 
+export type IdsPopupElementRef = HTMLElement | SVGElement | null;
+
 const CENTER = 'center';
 
 // Locations in which a parent-positioned Popup can be located

--- a/src/components/ids-popup/ids-popup.ts
+++ b/src/components/ids-popup/ids-popup.ts
@@ -12,6 +12,8 @@ import {
 
 import Base from './ids-popup-base';
 
+import type { IdsPopupElementRef } from './ids-popup-attributes';
+
 import {
   CENTER,
   ALIGNMENT_EDGES,
@@ -68,9 +70,9 @@ export default class IdsPopup extends Base {
       this.#mo?.disconnect();
       this.#mo = undefined;
     }
-    this.alignTarget = null;
-    this.arrowTarget = null;
-    this.containingElem = null;
+    this.#alignTarget = null;
+    this.#arrowTarget = null;
+    this.#containingElem = null;
   }
 
   /**
@@ -200,15 +202,15 @@ export default class IdsPopup extends Base {
   }
 
   /**
-   * @property {HTMLElement} alignTarget acts as the target element to be used for offset placement
+   * @property {IdsPopupElementRef} alignTarget acts as the target element to be used for offset placement
    */
-  #alignTarget: HTMLElement | SVGElement | null = null;
+  #alignTarget: IdsPopupElementRef = null;
 
   /**
    * Sets the element to align with via a css selector
-   * @param {HTMLElement | SVGElement | null | string} val a CSS selector string
+   * @param {IdsPopupElementRef | string} val a CSS selector string
    */
-  set alignTarget(val: HTMLElement | SVGElement | null | string) {
+  set alignTarget(val: IdsPopupElementRef | string) {
     const isString = typeof val === 'string' && val.length;
     const isElem = val instanceof HTMLElement || val instanceof SVGElement;
 
@@ -221,7 +223,7 @@ export default class IdsPopup extends Base {
       return;
     }
 
-    let elem: HTMLElement | SVGElement | null = null;
+    let elem: IdsPopupElementRef = null;
     if (isString) {
       // @TODO Harden for security (XSS)
       const rootNode = getClosestRootNode((this as any));
@@ -241,10 +243,10 @@ export default class IdsPopup extends Base {
   }
 
   /**
-   * @returns {HTMLElement | SVGElement | null} the element in the page that the Popup will take
+   * @returns {IdsPopupElementRef} the element in the page that the Popup will take
    * coordinates from for relative placement
    */
-  get alignTarget(): HTMLElement | SVGElement | null {
+  get alignTarget(): IdsPopupElementRef {
     return this.#alignTarget;
   }
 
@@ -604,14 +606,14 @@ export default class IdsPopup extends Base {
   }
 
   /**
-   * @property {HTMLElement | SVGElement | null} containingElem the element to use for containment of the Popup
+   * @property {IdsPopupElementRef} containingElem the element to use for containment of the Popup
    */
-  #containingElem: HTMLElement | SVGElement | null = document.body;
+  #containingElem: IdsPopupElementRef = document.body;
 
   /**
-   * @param {HTMLElement | SVGElement | null} val an element that will appear to "contain" the Popup
+   * @param {HdsPopupElementRef} val an element that will appear to "contain" the Popup
    */
-  set containingElem(val: HTMLElement | SVGElement | null) {
+  set containingElem(val: IdsPopupElementRef) {
     if (!(val instanceof HTMLElement || val instanceof SVGElement)) {
       return;
     }
@@ -622,9 +624,9 @@ export default class IdsPopup extends Base {
   }
 
   /**
-   * @returns {HTMLElement | SVGElement | null} the element currently appearing to "contain" the Popup
+   * @returns {IdsPopupElementRef} the element currently appearing to "contain" the Popup
    */
-  get containingElem(): HTMLElement | SVGElement | null {
+  get containingElem(): IdsPopupElementRef {
     return this.#containingElem;
   }
 
@@ -696,15 +698,15 @@ export default class IdsPopup extends Base {
   }
 
   /**
-   * @param {HTMLElement | SVGElement | null} arrowTarget
+   * @param {IdsPopupElementRef} arrowTarget
    */
-  #arrowTarget: HTMLElement | SVGElement | null = null;
+  #arrowTarget: IdsPopupElementRef = null;
 
   /**
    * Sets the element to align with via a css selector
-   * @param {HTMLElement | SVGElement | null} val a CSS selector string
+   * @param {IdsPopupElementRef} val a CSS selector string
    */
-  set arrowTarget(val: HTMLElement | SVGElement | null | string) {
+  set arrowTarget(val: IdsPopupElementRef | string) {
     const isString = typeof val === 'string' && val.length;
     const isElem = val instanceof HTMLElement || val instanceof SVGElement;
 
@@ -716,7 +718,7 @@ export default class IdsPopup extends Base {
       return;
     }
 
-    let elem: HTMLElement | SVGElement | null = null;
+    let elem: IdsPopupElementRef = null;
     if (isString) {
       // @TODO Harden for security (XSS)
       const rootNode = getClosestRootNode((this as any));
@@ -736,10 +738,10 @@ export default class IdsPopup extends Base {
   }
 
   /**
-   * @returns {HTMLElement | SVGElement | null} the element in the page that the Popup will take
+   * @returns {IdsPopupElementRef} the element in the page that the Popup will take
    * coordinates from for relative placement
    */
-  get arrowTarget(): HTMLElement | SVGElement | null {
+  get arrowTarget(): IdsPopupElementRef {
     return this.#arrowTarget || this.alignTarget;
   }
 

--- a/src/mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin.ts
+++ b/src/mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin.ts
@@ -1,6 +1,8 @@
 import { attributes } from '../../core/ids-attributes';
 import '../ids-events-mixin/ids-events-mixin';
 
+import type { IdsPopupElementRef } from '../../components/ids-popup/ids-popup-attributes';
+
 const POPUP_TRIGGER_TYPES = [
   'contextmenu',
   'click',
@@ -94,17 +96,17 @@ const IdsPopupInteractionsMixin = (superclass: any) => class extends superclass 
   }
 
   /**
-   * @returns {any} [HTMLElement|undefined] reference to a target element, if applicable
+   * @returns {IdsPopupElementRef} reference to a target element, if applicable
    */
   get target() {
     return this.popup?.alignTarget;
   }
 
   /**
-   * @param {any} val [HTMLElement|string] reference to an element, or a string that will be used
+   * @param {IdsPopupElementRef} val reference to an element, or a string that will be used
    * as a CSS Selector referencing an element, that the Popupmenu will align against.
    */
-  set target(val: string | HTMLElement) {
+  set target(val: IdsPopupElementRef | string) {
     if (this.popup && val !== this.popup.alignTarget) {
       this.removeTriggerEvents();
       if (typeof val === typeof '') {
@@ -118,14 +120,14 @@ const IdsPopupInteractionsMixin = (superclass: any) => class extends superclass 
   /**
    * @returns {string} the type of action that will trigger this Popupmenu
    */
-  get triggerType(): HTMLElement {
+  get triggerType(): string {
     return this.state.triggerType;
   }
 
   /**
    * @param {string} val a valid trigger type
    */
-  set triggerType(val: string | HTMLElement) {
+  set triggerType(val: string) {
     const current = this.state.triggerType;
     let trueTriggerType = val;
     if (!POPUP_TRIGGER_TYPES.includes(val as string)) {
@@ -140,16 +142,16 @@ const IdsPopupInteractionsMixin = (superclass: any) => class extends superclass 
 
   /**
    * Gets the alternatively-defined triggering element, if applicable
-   * @returns {HTMLElement} reference to an optional trigger element, if one is set
+   * @returns {IdsPopupElementRef} reference to an optional trigger element, if one is set
    */
-  get triggerElem(): HTMLElement {
+  get triggerElem(): IdsPopupElementRef {
     return this.state.triggerElem;
   }
 
   /**
    * @param {string} val a valid trigger type
    */
-  set triggerElem(val: string | HTMLElement) {
+  set triggerElem(val: IdsPopupElementRef | string) {
     if (typeof val === typeof '') {
       const trueTriggerElem = this.parentNode.querySelector(val);
       if (trueTriggerElem) {
@@ -173,7 +175,7 @@ const IdsPopupInteractionsMixin = (superclass: any) => class extends superclass 
     //   This is only defined when the triggering element is different from the alignment target.
     // - `target`: used for Popup positioning when aligned against a "parent" element, can also be the triggering element.
     // - `window`: default, generally used for coordinate-based placement or `contextmenu` events.
-    const targetElem: HTMLElement | Window = this.triggerElem || this.target || window;
+    const targetElem: HTMLElement | Window = (this.triggerElem as HTMLElement) || this.target || window;
     this.state.currentTriggerElem = targetElem;
 
     // Based on the trigger type, bind new events

--- a/src/mixins/ids-popup-open-events-mixin/ids-popup-open-events-mixin.ts
+++ b/src/mixins/ids-popup-open-events-mixin/ids-popup-open-events-mixin.ts
@@ -1,3 +1,5 @@
+import type { IdsPopupElementRef } from '../../components/ids-popup/ids-popup-attributes';
+
 /**
  * This mixin can be used with the IdsPopup component to provide event handling in some scenarios:
  * - When clicking outside the Popup occurs, an event handler at the document level hides the Popup.
@@ -17,6 +19,7 @@ const IdsPopupOpenEventsMixin = (superclass: any) => class extends superclass {
   disconnectedCallback() {
     super.disconnectedCallback?.();
     this.removeOpenEvents();
+    this.popupOpenEventsTarget = null;
   }
 
   /**
@@ -25,17 +28,17 @@ const IdsPopupOpenEventsMixin = (superclass: any) => class extends superclass {
   hasOpenEvents = false;
 
   /**
-   * @property {HTMLElement} popupOpenEventsTarget receives the top-level event listener
+   * @property {IdsPopupElementRef} popupOpenEventsTarget receives the top-level event listener
    *  that will cause the `onOutsideClick` callback to fire
    */
-  popupOpenEventsTarget = document.body;
+  popupOpenEventsTarget: IdsPopupElementRef = document.body;
 
   /**
-   * @property {HTMLElement|null} currentPopupOpenEventsTarget stores a reference to the event
+   * @property {IdsPopupElementRef} currentPopupOpenEventsTarget stores a reference to the event
    *  target to be used for unbinding events (prevents memory leaks if the
    *  event target changes while the Popup is open)
    */
-  #currentPopupOpenEventsTarget: any = null;
+  #currentPopupOpenEventsTarget: IdsPopupElementRef = null;
 
   /**
    * Attaches some events when the Popupmenu is opened.


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR follows up #890 and slightly improves the changes:
- Adds back a type `IdsPopupElementRef` that replaces `HTMLElement | SVGElement | null` usage everywhere
- Uses this type in the Popup mixins

**Related github/jira issue (required)**:
Related to #878 
Closes #880 

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run.  All existing tests should pass, and no behavior changes should be present.
- When performing memory leak tests as outlined in [this article](https://addyosmani.com/blog/taming-the-unicorn-easing-javascript-memory-profiling-in-devtools/), there should be no element references stuck in the profiler tied to `#containingElem`, `#popupOpenEventsTarget`, `#alignTarget` or `#arrowTarget`
