### PR TITLE
865 - IdsPager icons in RTL mode

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Calendar]` Added calendar event add/update/remove via modal/API feature to calendar. ([#757](https://github.com/infor-design/enterprise-wc/pull/795))
 - `[Charts]` Added the ability to rotate x axis labels in axis charts like line and bar. ([#738](https://github.com/infor-design/enterprise-wc/pull/738))
 - `[Form]` Added new 'IdsForm' component. ([#357](https://github.com/infor-design/enterprise-wc/pull/357))
+- `[Pager]` Fixed the direction of the icons in RTL mode ([#865](https://github.com/infor-design/enterprise-wc/issues/865))
 
 ## 1.0.0-beta.1
 

--- a/src/components/ids-icon/ids-icon.ts
+++ b/src/components/ids-icon/ids-icon.ts
@@ -5,6 +5,7 @@ import { attributes } from '../../core/ids-attributes';
 import { customElement, scss } from '../../core/ids-decorators';
 import { sizes } from './ids-icon-attributes';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
+import { getClosest } from '../../utils/ids-dom-utils/ids-dom-utils';
 
 import Base from './ids-icon-base';
 import styles from './ids-icon.scss';
@@ -56,7 +57,7 @@ export default class IdsIcon extends Base {
    */
   #attachEventHandlers() {
     this.offEvent('languagechange.icon-container');
-    this.onEvent('languagechange.icon-container', this.closest('ids-container'), () => {
+    this.onEvent('languagechange.icon-container', getClosest(this, 'ids-container'), () => {
       if (this.isMirrored(this.icon)) {
         this.container?.classList.add('mirrored');
       } else {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds ability for `ids-icon` to respond to language change by finding the closest `ids-container` reference to a parent node. What fixes `ids-pager` icons in RTL mode and possibly other RTL cases where `ids-icon` is located inside a component.

**Related github/jira issue (required)**:
Closes #865 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-pager/example.html
- change locale to Arabic (ar-EG)
- see the icons have right direction

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.