### PR TITLE
923 - IdsInput fix show/hide button in Safari

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[DataGrid]` Added checkbox and custom formatter. ([#737](https://github.com/infor-design/enterprise-wc/pull/737))
 - `[Form]` Added new 'IdsForm' component. ([#357](https://github.com/infor-design/enterprise-wc/pull/357))
 - `[Form]` Fixed compact mode was not working with all components. ([#863](https://github.com/infor-design/enterprise-wc/issues/863))
+- `[Input]` Fixed show/hide button for Safari browser. ([#923](https://github.com/infor-design/enterprise-wc/issues/923))
 - `[Lookup]` Fixed the dirty tacker was not able to reset. ([#871](https://github.com/infor-design/enterprise-wc/issues/871))
 - `[Pager]` Fixed the direction of the icons in RTL mode. ([#865](https://github.com/infor-design/enterprise-wc/issues/865))
 

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -713,4 +713,9 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   appearance: none;
   -webkit-appearance: none;
 }
+
+// Remove Safari caps lock icon
+.ids-input-field::-webkit-caps-lock-indicator {
+  visibility: hidden;
+}
 /* stylelint-enable property-no-vendor-prefix */

--- a/test/ids-input/ids-input-func-test.ts.snap
+++ b/test/ids-input/ids-input-func-test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsInput Component renders correctly 1`] = `"<ids-input label=\\"testing input\\" type=\\"text\\"></ids-input>"`;
+exports[`IdsInput Component renders correctly 1`] = `"<ids-input label="testing input" type="text"></ids-input>"`;

--- a/test/ids-input/ids-input-func-test.ts.snap
+++ b/test/ids-input/ids-input-func-test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsInput Component renders correctly 1`] = `"<ids-input label="testing input" type="text"></ids-input>"`;
+exports[`IdsInput Component renders correctly 1`] = `"<ids-input label=\\"testing input\\" type=\\"text\\"></ids-input>"`;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes show/hide button and capslock icon behavior in Safari browser

**Related github/jira issue (required)**:
Closes #923

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-input/example.html in Safari browser
- click show/hide button (password input)
- see it works as expected, shows the text in password field when show button is clicked

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
