### PR TITLE
925 - Change alternate row shading color order, fix dark mode colors

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[DataGrid]` Escaped datagrid data to avoid xss issues. ([#899](https://github.com/infor-design/enterprise-wc/pull/899))
 - `[DataGrid]` Fixed issues with virtual scroll and selection (including event data) and keyboard. ([#737](https://github.com/infor-design/enterprise-wc/pull/737))
 - `[DataGrid]` Added checkbox and custom formatter. ([#737](https://github.com/infor-design/enterprise-wc/pull/737))
+- `[DataGrid]` Changed alternate row shading feature's color theming to behave similarly to the 4.x DataGrid's. ([#925](https://github.com/infor-design/enterprise-wc/issues/925))
 - `[Form]` Added new 'IdsForm' component. ([#357](https://github.com/infor-design/enterprise-wc/pull/357))
 - `[Form]` Fixed compact mode was not working with all components. ([#863](https://github.com/infor-design/enterprise-wc/issues/863))
 - `[Input]` Fixed show/hide button for Safari browser. ([#923](https://github.com/infor-design/enterprise-wc/issues/923))

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -68,7 +68,7 @@ $header-bg-color: var(--ids-color-palette-slate-80);
   }
 
   // Row Alternate Row Setting Feature
-  &.alt-row-shading .ids-data-grid-body [role='row']:nth-child(odd) {
+  &.alt-row-shading .ids-data-grid-body [role='row']:nth-child(even) {
     @include bg-slate-10();
   }
 
@@ -602,7 +602,7 @@ table.ids-data-grid {
 
 // Dark Theme
 .ids-data-grid[mode='dark'] {
-  @include bg-slate-90();
+  @include bg-slate-100();
   @include border-slate-60();
 
   .ids-data-grid-header-cell {
@@ -638,6 +638,11 @@ table.ids-data-grid {
     @include text-slate-100();
   }
 
+  // Row Alternate Row Setting Feature
+  &.alt-row-shading .ids-data-grid-body [role='row']:nth-child(even) {
+    @include bg-slate-80();
+  }
+
   .ids-data-grid-cell {
     @include border-slate-60();
     @include text-white();
@@ -647,7 +652,7 @@ table.ids-data-grid {
     }
 
     &.frozen {
-      @include bg-slate-90();
+      @include bg-slate-100();
     }
 
     .ids-data-grid-checkbox {
@@ -721,8 +726,8 @@ table.ids-data-grid {
       @include bg-slate-60();
 
       &::after {
-        @include border-slate-90();
-        @include bg-slate-90();
+        @include border-slate-100();
+        @include bg-slate-100();
       }
     }
   }
@@ -730,7 +735,7 @@ table.ids-data-grid {
   .ids-data-grid-header-text .ids-data-grid-checkbox-container {
     .ids-data-grid-checkbox:not(.checked):not(.indeterminate) {
       @include bg-transparent();
-      @include border-slate-90();
+      @include border-slate-100();
     }
   }
 }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes some small adjustments to IdsDataGrid's row shading colors.  The `nth-child(odd)` that dictates the alternate color has been switched to `even` to match the shading more closely to the 4.x DataGrid's style.  Also, the Data Grid's Dark mode background color has been changed to its original 4.x color, making the text legible.

**Related github/jira issue (required)**:
Closes #925

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4300/ids-data-grid/alternate-row-shading.html
- Use the theme switch to change Mode to "Dark"
- Compare the Data Grid colors on this page to [our 4.x DataGrid demo page](https://main-enterprise.demo.design.infor.com/components/datagrid/example-alternate-row-shading.html?theme=new&mode=dark&layout=nofrills) and ensure they match

**Included in this Pull Request**:
- [x] A note to the change log.
