### PR TITLE
667 - Fix containment problems with IdsDataGrid filter menus

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[DataGrid]` Fixed issues with virtual scroll and selection (including event data) and keyboard. ([#737](https://github.com/infor-design/enterprise-wc/pull/737))
 - `[DataGrid]` Added checkbox and custom formatter. ([#737](https://github.com/infor-design/enterprise-wc/pull/737))
 - `[DataGrid]` Changed alternate row shading feature's color theming to behave similarly to the 4.x DataGrid's. ([#925](https://github.com/infor-design/enterprise-wc/issues/925))
+- `[Datagrid]` Prevented filter menus from being cut off by Data Grid's container overflow ([#667](https://github.com/infor-design/enterprise-wc/issues/667))
 - `[Editor]` Fixed not readable text in the toolbar in Safari browser. ([#922](https://github.com/infor-design/enterprise-wc/issues/922))
 - `[Form]` Added new 'IdsForm' component. ([#357](https://github.com/infor-design/enterprise-wc/pull/357))
 - `[Form]` Fixed compact mode was not working with all components. ([#863](https://github.com/infor-design/enterprise-wc/issues/863))

--- a/src/components/ids-data-grid/demos/filter-custom.html
+++ b/src/components/ids-data-grid/demos/filter-custom.html
@@ -34,7 +34,7 @@
                 <ids-menu-item value="greater-equals" icon="filter-greater-equals" selected="true">Greater Than Or Equals</ids-menu-item>
                 <ids-menu-item value="less-than" icon="filter-less-than">Less Than</ids-menu-item>
                 <ids-menu-item value="less-equals" icon="filter-less-equals">Less Than Or Equals</ids-menu-item>
-                <ids-menu-item value="start-with" icon="filter-starts-with">Starts With</ids-menu-item>
+                <ids-menu-item value="start-with" icon="filter-start-with">Starts With</ids-menu-item>
               </ids-menu-group>
             </ids-popup-menu>
             <ids-input id="input-filter-product-id" type="text" size="full" placeholder="Slotted product-id" label="Slotted product-id input">

--- a/src/components/ids-data-grid/demos/filter-custom.html
+++ b/src/components/ids-data-grid/demos/filter-custom.html
@@ -34,6 +34,7 @@
                 <ids-menu-item value="greater-equals" icon="filter-greater-equals" selected="true">Greater Than Or Equals</ids-menu-item>
                 <ids-menu-item value="less-than" icon="filter-less-than">Less Than</ids-menu-item>
                 <ids-menu-item value="less-equals" icon="filter-less-equals">Less Than Or Equals</ids-menu-item>
+                <ids-menu-item value="start-with" icon="filter-starts-with">Starts With</ids-menu-item>
               </ids-menu-group>
             </ids-popup-menu>
             <ids-input id="input-filter-product-id" type="text" size="full" placeholder="Slotted product-id" label="Slotted product-id input">

--- a/src/components/ids-data-grid/demos/filter-custom.ts
+++ b/src/components/ids-data-grid/demos/filter-custom.ts
@@ -1,4 +1,5 @@
 import '../ids-data-grid';
+import '../../ids-popup-menu/ids-popup-menu';
 import '../../ids-container/ids-container';
 import productsJSON from '../../../assets/data/products.json';
 

--- a/src/components/ids-data-grid/demos/filter-custom.ts
+++ b/src/components/ids-data-grid/demos/filter-custom.ts
@@ -22,6 +22,7 @@ const myCustomFilter = (opt: any) => {
   if (operator === 'greater-equals') isMatch = (val.data >= val.condition);
   if (operator === 'less-than') isMatch = (val.data < val.condition);
   if (operator === 'less-equals') isMatch = (val.data <= val.condition);
+  if (operator === 'start-with') isMatch = (val.data.toString().startsWith(val.condition.toString()));
 
   return isMatch;
 };

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -685,6 +685,7 @@ export default class IdsDataGridFilters {
           btn.setAttribute('column-id', column.id);
           btn.setAttribute('square', 'true');
         }
+        // Place slotted menus into a special slot placed near internal filter menus
         if (menu) {
           menu.setAttribute('slot', `menu-container`);
         }

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -772,7 +772,7 @@ export default class IdsDataGridFilters {
   #handleMenuButtonSelected(el: IdsMenuItem) {
     const target = el.menu?.target;
     const { value, icon, text: label } = el;
-    if (!icon || target.icon === icon) return;
+    if (!icon || target.icon === icon.replace(/^filter-/g, '')) return;
 
     const columnId = target.getAttribute('column-id');
     const initial = this.#initial[columnId].btn;

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -1,3 +1,4 @@
+import { attributes } from '../../core/ids-attributes';
 import { hasClass } from '../../utils/ids-dom-utils/ids-dom-utils';
 import type { IdsDataGridColumn } from './ids-data-grid-column';
 
@@ -655,11 +656,14 @@ export default class IdsDataGridFilters {
       const datePicker = node.querySelector('ids-date-picker');
       const timePicker = node.querySelector('ids-time-picker');
       const btn = node.querySelector('ids-menu-button');
+      const menu = node.querySelector('ids-popup-menu');
+      let menuAttachment = '.ids-data-grid-wrapper';
 
       // Slotted filter only
       if (slot && (input || dropdown || datePicker || timePicker || btn)) {
         const headerElem = n.closest('.ids-data-grid-header-cell');
         const column = this.root.columnDataByHeaderElem(headerElem);
+        menuAttachment = 'ids-data-grid';
 
         // Slotted initial
         this.#initial[column.id] = this.#initial[column.id] || {};
@@ -679,9 +683,23 @@ export default class IdsDataGridFilters {
           btn.cssClass = [...new Set([...btn.cssClass, 'compact'])];
           btn.setAttribute('color-variant', 'alternate-formatter');
           btn.setAttribute('column-id', column.id);
-          btn.setAttribute('trigger', 'click');
           btn.setAttribute('square', 'true');
         }
+        if (menu) {
+          menu.setAttribute('slot', `menu-container`);
+        }
+      }
+
+      // Connect Popup Menus
+      if (menu) {
+        menu.setAttribute(attributes.TRIGGER_TYPE, 'click');
+        menu.setAttribute(attributes.ATTACHMENT, menuAttachment);
+        menu.onOutsideClick = () => { menu.hide(); };
+
+        // Move/Rebind menu (order of these statements matters)
+        menu.appendToTargetParent();
+        menu.popupOpenEventsTarget = document.body;
+        menu.refreshTriggerEvents();
       }
 
       // Timepicker needs a different element to use for targeting outside clicks

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -772,7 +772,7 @@ export default class IdsDataGridFilters {
   #handleMenuButtonSelected(el: IdsMenuItem) {
     const target = el.menu?.target;
     const { value, icon, text: label } = el;
-    if (!icon || target.icon === icon.replace(/^filter-/g, '')) return;
+    if (!icon || !target || target.icon === icon.replace(/^filter-/g, '')) return;
 
     const columnId = target.getAttribute('column-id');
     const initial = this.#initial[columnId].btn;

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -11,7 +11,8 @@ import '../ids-input/ids-input';
 import '../ids-dropdown/ids-dropdown';
 import '../ids-date-picker/ids-date-picker';
 import '../ids-time-picker/ids-time-picker';
-import IdsMenuItem from '../ids-menu/ids-menu-item';
+
+import type IdsMenuItem from '../ids-menu/ids-menu-item';
 
 // Instance counter
 let instanceCounter = 0;
@@ -763,10 +764,15 @@ export default class IdsDataGridFilters {
     this.setFilterWhenTyping();
   }
 
+  /**
+   * Handles `selected` events from filter menus
+   * @param {IdsMenuItem} el reference to the menu item that triggered the event
+   * @returns {void}
+   */
   #handleMenuButtonSelected(el: IdsMenuItem) {
     const target = el.menu?.target;
     const { value, icon, text: label } = el;
-    if (target.icon === icon) return;
+    if (!icon || target.icon === icon) return;
 
     const columnId = target.getAttribute('column-id');
     const initial = this.#initial[columnId].btn;

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -753,7 +753,7 @@ export default class IdsDataGridFilters {
     });
 
     // Change event for input, dropdown, multiselect, date-picker and time-picker
-    this.root.onEvent(`change.${this.#id()}`, this.root.container, (e: any) => {
+    this.root.onEvent(`change.${this.#id()}`, this.root.header, (e: any) => {
       const nodeName = e.target?.nodeName;
       if (nodeName && /ids-(input|dropdown|multiselect|date-picker|time-picker)/gi.test(nodeName)) {
         this.applyFilter();

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -1,5 +1,6 @@
 @import '../../core/ids-base';
 @import './ids-data-grid-filters';
+@import '../../components/ids-popup-menu/ids-popup-menu';
 @import '../../mixins/sass/ids-checkbox-mixin';
 @import '../../mixins/sass/ids-radio-mixin';
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -8,6 +8,8 @@ import Base from './ids-data-grid-base';
 import IdsDataSource from '../../core/ids-data-source';
 import IdsDataGridFormatters from './ids-data-grid-formatters';
 import IdsDataGridFilters, { IdsDataGridFilterConditions } from './ids-data-grid-filters';
+
+import '../ids-popup-menu/ids-popup-menu';
 import '../ids-virtual-scroll/ids-virtual-scroll';
 
 import styles from './ids-data-grid.scss';
@@ -110,14 +112,13 @@ export default class IdsDataGrid extends Base {
     cssClasses += `${this.listStyle ? ' is-list-style' : ''}`;
 
     const html = `<div class="ids-data-grid-wrapper">
-      <span class="ids-data-grid-sort-arrows"></span>
-      <div class="ids-data-grid${cssClasses}"
-        role="table" part="table" aria-label="${this.label}"
-        data-row-height="${this.rowHeight}"
-        mode="${this.mode}">
-      ${this.headerTemplate()}
-      ${this.bodyTemplate()}
-      </div></div>`;
+        <span class="ids-data-grid-sort-arrows"></span>
+        <div class="ids-data-grid${cssClasses}" role="table" part="table" aria-label="${this.label}" data-row-height="${this.rowHeight}" mode="${this.mode}">
+          ${this.headerTemplate()}
+          ${this.bodyTemplate()}
+        </div>
+        <slot name="menu-container"></slot>
+      </div>`;
 
     return html;
   }

--- a/src/components/ids-menu-button/ids-menu-button.ts
+++ b/src/components/ids-menu-button/ids-menu-button.ts
@@ -1,6 +1,5 @@
 import { customElement, scss } from '../../core/ids-decorators';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
-import { getClosestRootNode } from '../../utils/ids-dom-utils/ids-dom-utils';
 import { attributes, htmlAttributes } from '../../core/ids-attributes';
 
 import Base from './ids-menu-button-base';
@@ -176,9 +175,8 @@ export default class IdsMenuButton extends Base {
     const findPopup = (root: any) => root?.querySelector(`ids-popup-menu[id="${this.menu}"]`)
       || root?.querySelector(`ids-action-sheet[id="${this.menu}"]`);
 
-    let el = findPopup(this.shadowRoot?.host?.parentNode);
-    const thisElem: any = this;
-    if (!el) el = findPopup(getClosestRootNode(thisElem));
+    let el = findPopup(this.parentElement);
+    if (!el) el = findPopup(this.getRootNode());
     return el;
   }
 

--- a/src/components/ids-popup-menu/ids-popup-menu-base.ts
+++ b/src/components/ids-popup-menu/ids-popup-menu-base.ts
@@ -1,10 +1,13 @@
+import IdsAttachmentMixin from '../../mixins/ids-attachment-mixin/ids-attachment-mixin';
 import IdsPopupOpenEventsMixin from '../../mixins/ids-popup-open-events-mixin/ids-popup-open-events-mixin';
 import IdsPopupInteractionsMixin from '../../mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin';
 import IdsMenu from '../ids-menu/ids-menu';
 
 const Base = IdsPopupOpenEventsMixin(
   IdsPopupInteractionsMixin(
-    IdsMenu
+    IdsAttachmentMixin(
+      IdsMenu
+    )
   )
 );
 

--- a/src/components/ids-popup-menu/ids-popup-menu.ts
+++ b/src/components/ids-popup-menu/ids-popup-menu.ts
@@ -34,7 +34,7 @@ export default class IdsPopupMenu extends Base {
    * @returns {string} The template
    */
   template(): string {
-    const menuTemplate = Base.prototype.template.apply(this);
+    const menuTemplate = super.template();
     return `<ids-popup class="ids-popup-menu" type="menu">${menuTemplate}</ids-popup>`;
   }
 

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -25,6 +25,7 @@ export const attributes = {
   APPEARANCE: 'appearance',
   ARROW: 'arrow',
   ARROW_TARGET: 'arrow-target',
+  ATTACHMENT: 'attachment',
   AUDIBLE: 'audible',
   AUTO: 'auto',
   AUTOCOMPLETE: 'autocomplete',

--- a/src/mixins/ids-attachment-mixin/README.md
+++ b/src/mixins/ids-attachment-mixin/README.md
@@ -1,0 +1,3 @@
+# Ids Attachment Mixin
+
+This mixin injects an `attachment` attribute into a component.  This attribute accepts a string that is used as a CSS selector to choose another element within the same document/Shadow root.  If an element reference is connected successfully, this component can be optionally appended to the element by using the provided `appendToTargetParent()` method.  To return the component back to its original element, the provided `appendToOriginalParent()` method can be used.

--- a/src/mixins/ids-attachment-mixin/ids-attachment-mixin.ts
+++ b/src/mixins/ids-attachment-mixin/ids-attachment-mixin.ts
@@ -1,0 +1,90 @@
+import { IdsPopupElementRef } from '../../components/ids-popup/ids-popup-attributes';
+import { attributes } from '../../core/ids-attributes';
+import { getClosestContainerNode } from '../../utils/ids-dom-utils/ids-dom-utils';
+
+/**
+ * A mixin that allows for its component to attach itself to another DOM node when a specified condition occurs.
+ * This mixin provides methods for attaching to the new node, and reattaching to the original node.
+ * @param {any} superclass Accepts a superclass and creates a new subclass from it
+ * @returns {any} The extended object
+ */
+const IdsAttachmentMixin = (superclass: any): any => class extends superclass {
+  constructor() {
+    super();
+  }
+
+  static get attributes() {
+    return [
+      ...super.attributes,
+      attributes.ATTACHMENT,
+    ];
+  }
+
+  /**
+   * Original parent element reference
+   */
+  originalParentElement?: IdsPopupElementRef;
+
+  /**
+   * Attachment behavior's target element reference
+   */
+  attachmentParentElement?: IdsPopupElementRef;
+
+  /**
+   * @param {string | null} val CSS selector string representing a target element
+   */
+  set attachment(val: string | null) {
+    if (val && val.length) {
+      this.setAttribute(attributes.ATTACHMENT, val);
+      this.#setAttachmentParent(val);
+    } else {
+      this.removeAttribute(attributes.ATTACHMENT);
+      this.attachementParentElement = null;
+    }
+  }
+
+  /**
+   * @returns {string | null} CSS selector string representing a target element
+   */
+  get attachment(): string | null {
+    return this.getAttribute(attributes.ATTACHMENT);
+  }
+
+  connectedCallback() {
+    super.connectedCallback?.();
+    this.originalParentElement = this.parentElement;
+    if (this.hasAttribute(attributes.ATTACHMENT)) this.#setAttachmentParent(this.getAttribute(attributes.ATTACHMENT));
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback?.();
+    this.originalParentElement = null;
+    this.attachmentParentElement = null;
+  }
+
+  #setAttachmentParent(val: string): void {
+    const containerNode = getClosestContainerNode(this);
+    const parentElem = containerNode.querySelector<HTMLElement | SVGElement>(`${val}`);
+    this.attachmentParentElement = parentElem;
+  }
+
+  /**
+   * Appends this component to the specified target
+   * @returns {void}
+   */
+  appendToTargetParent(): void {
+    if (!this.attachmentParentElement) return;
+    this.attachmentParentElement.append(this as unknown as Node);
+  }
+
+  /**
+   * Appends this component to the its original parent element
+   * @returns {void}
+   */
+  appendToOriginalParent(): void {
+    if (!this.originalParentElement) return;
+    this.originalParentElement.append(this as unknown as Node);
+  }
+};
+
+export default IdsAttachmentMixin;

--- a/test/ids-data-grid/ids-data-grid-func-test.ts.snap
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts.snap
@@ -9,8 +9,8 @@ exports[`IdsDataGrid Component Paging Tests renders pager 1`] = `
 
 exports[`IdsDataGrid Component Paging Tests renders pager 2`] = `
 "<style nonce="0a59a005">:host { background-color: transparent; }</style><div class="ids-data-grid-wrapper">
-      <span class="ids-data-grid-sort-arrows"></span>
-      <div class="ids-data-grid" role="table" part="table" aria-label="Data Grid" data-row-height="lg" mode="light" style="--ids-data-grid-column-widths: 20px 65px minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) ;">
+        <span class="ids-data-grid-sort-arrows"></span>
+        <div class="ids-data-grid" role="table" part="table" aria-label="Data Grid" data-row-height="lg" mode="light" style="--ids-data-grid-column-widths: 20px 65px minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) minmax(110px, 1fr) ;">
       <div class="ids-data-grid-header" role="rowgroup" part="header">
         <div role="row" class="ids-data-grid-row">
           
@@ -901,5 +901,7 @@ exports[`IdsDataGrid Component Paging Tests renders pager 2`] = `
       <ids-pager-button next="" total="9" page-number="1" page-size="10" nav-disabled=""></ids-pager-button>
       <ids-pager-button last="" total="9" page-number="1" page-size="10" nav-disabled=""></ids-pager-button>
       <ids-pager-dropdown slot="end" page-size="10"></ids-pager-dropdown>
-    </ids-pager></div>"
+    </ids-pager>
+        <slot name="menu-container"></slot>
+      </div>"
 `;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds functionality to IdsPopupMenus that enables their attachment to other elements in the page.  This allows them to be created/appended near their trigger element, but allows them to move around in the DOM and retain their connections to that trigger element:
- A new mixin `IdsAttachmentMixin` has been added which contains the append/revert functionality
- Changes have been made to IdsDataGridFilter/IdsMenuButton to accept the new behavior (menus connected to trigger buttons that are not necessarily adjacent to those trigger buttons)
- Added docs and fixed related tests

Note that this PR doesn't fix the Timepicker/Datepicker fields in filter rows.  Additional work is needed to completely fix the cutoff problem in those specific Popups.

**Related github/jira issue (required)**:
Partially addresses #667 

**Steps necessary to review your pull request (required)**:
Pull/Build/Run, then test the following cases:

"Built in" filters (located in shadow root)
- Open http://localhost:4300/ids-data-grid/filter.html
- Use the Pager's "number of records" button to switch the number of records to 5
- Open the filter menu attached to the "Color" column.  It should escape the data grid's boundaries and be usable.

Custom filters (located in slots/light DOM)
- Open http://localhost:4300/ids-data-grid/filter-custom.html
- Use the Pager's "number of records" button to switch the number of records to 5
- Open the filter menu attached to the "Product Id" column.  It should escape the data grid's boundaries and be usable.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
