### PR TITLE
994 - IdsDataGrid rowclick and rowdoubleclick events

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[DataGrid]` Added expandable row functionality. ([#737](https://github.com/infor-design/enterprise-wc/issues/737)
 - `[DataGrid]` Added suppress row click for selection functionality. ([#737](https://github.com/infor-design/enterprise-wc/issues/737)
 - `[DataGrid]` Added support for context menu. ([#963](https://github.com/infor-design/enterprise-wc/issues/963))
+- `[DataGrid]` Added rowclick and rowdoubleclick events. ([#994](https://github.com/infor-design/enterprise-wc/issues/994))
 - `[Icons]` All icons have padding on top and bottom effectively making them 4px smaller by design. This change may require some UI corrections to css. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Over 60 new icons and 126 new industry focused icons. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Added new empty state icons. ([#6934](https://github.com/infor-design/enterprise/issues/6934))

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -349,12 +349,13 @@ The formatter is then linked via the column on the formatter setting. When the g
 - `rowdeselected` Fires for each row that is deselected.
 - `rowactivated` Fires for each row that is activated.
 - `rowdeactivated` Fires for each row that is deactivated.
+- `rowclick` Fires for each row that is clicked.
+- `rowdoubleclick` Fires for each row that is double clicked.
 - `filtered` Fires after a filter action occurs, clear or apply filter condition.
 - `filteroperatorchanged` Fires once a filter operator changed.
 - `filterrowopened` Fires after the filter row is opened by the user.
 - `filterrowclosed` Fires after the filter row is closed by the user.
 - `columnresized` Fires when a column is resized or setColumnWidth is called.
-<<<<<<< HEAD
 - `columnmoved` Fires when a column is moved / reordered or moveColumn is called
 - `beforetooltipshow` Fires before tooltip show, you can return false in the response to veto
 - `rowExpanded` Fires when a tree or expandable row is expanded or collapsed

--- a/src/components/ids-data-grid/demos/suppress-row-click-selection.ts
+++ b/src/components/ids-data-grid/demos/suppress-row-click-selection.ts
@@ -90,4 +90,12 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-multi')!;
   dataGrid.addEventListener('selectionchanged', (e: Event) => {
     console.info(`Selection Changed`, (<CustomEvent>e).detail);
   });
+
+  dataGrid.addEventListener('rowclick', (e: Event) => {
+    console.info(`Row Clicked`, (<CustomEvent>e).detail);
+  });
+
+  dataGrid.addEventListener('rowdoubleclick', (e: Event) => {
+    console.info(`Row Double Clicked`, (<CustomEvent>e).detail);
+  });
 }());

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -564,6 +564,13 @@ export default class IdsDataGrid extends Base {
         });
       }
 
+      // Fires for each row that is clicked
+      this.triggerEvent('rowclick', this, {
+        detail: {
+          elem: this, row, data: this.data[rowNum]
+        }
+      });
+
       // Handle Expand/Collapse Clicking
       if (isClickable && (this.visibleColumns[cellNum]?.formatter?.name === 'tree'
         || this.visibleColumns[cellNum]?.formatter?.name === 'expander')) {
@@ -590,6 +597,22 @@ export default class IdsDataGrid extends Base {
           this.#handleRowSelection(row);
         }
       }
+    });
+
+    // Add double click to the table body
+    this.offEvent('dblclick.body', body);
+    this.onEvent('dblclick.body', body, (e: MouseEvent) => {
+      const row = (e.target as HTMLElement)?.closest('.ids-data-grid-row');
+      const rowIndex: string | null | undefined = row?.getAttribute('data-index');
+
+      if (!rowIndex) return;
+
+      // Fires for each row that is double clicked
+      this.triggerEvent('rowdoubleclick', this, {
+        detail: {
+          elem: this, row, data: this.data[Number(rowIndex)]
+        }
+      });
     });
 
     // Add a click to the table header

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -2478,4 +2478,25 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.getAttribute('id-column')).toBeFalsy();
     });
   });
+
+  describe('Events Tests', () => {
+    it('should fire rowclick and rowdoubleclick events', () => {
+      const clickCallback = jest.fn((e) => {
+        expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
+      });
+      const dblClickCallback = jest.fn((e) => {
+        expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
+      });
+
+      dataGrid.addEventListener('rowclick', clickCallback);
+      dataGrid.addEventListener('rowdoubleclick', dblClickCallback);
+
+      const firstCellInRow = dataGrid.container.querySelector('.ids-data-grid-body .ids-data-grid-cell');
+      const clickEvent = new MouseEvent('click', { bubbles: true });
+      const dblClickEvent = new MouseEvent('dblclick', { bubbles: true });
+
+      firstCellInRow.dispatchEvent(clickEvent);
+      firstCellInRow.dispatchEvent(dblClickEvent);
+    });
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds new `rowclick` and `rowdoubleclick` events to `ids-data-grid` component

**Related github/jira issue (required)**:
Closes #994 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-data-grid/suppress-row-click-selection.html
- click on a table row
- check browser's console
- double click on a table row
- check browser's console

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
