### PR TITLE
989 - IdsDataGrid: Allow custom selected cell colors

### DIFF
--- a/src/assets/css/ids-data-grid/custom-css.css
+++ b/src/assets/css/ids-data-grid/custom-css.css
@@ -15,13 +15,12 @@ ids-data-grid::part(custom-cell-selected-1) {
 }
 
 ids-data-grid::part(custom-cell-selected-2) {
-  background-color: #e2e2e2;
+  background-color: #c0cfde;
 }
 
 /**
  * Tooltip styles
  */
-
 ids-data-grid::part(custom-turquoise-tooltip-arrow-top)::after {
   border-top-color: #2f8d8e;
 }

--- a/src/assets/css/ids-data-grid/custom-css.css
+++ b/src/assets/css/ids-data-grid/custom-css.css
@@ -2,8 +2,20 @@ ids-data-grid::part(cell) {
   background-color: #ebf9f1;
 }
 
+ids-data-grid::part(cell-selected) {
+  background-color: #c9dad0;
+}
+
 ids-data-grid::part(custom-cell) {
   background-color: #e6f1fd;
+}
+
+ids-data-grid::part(custom-cell-selected-1) {
+  background-color: #c0cfde;
+}
+
+ids-data-grid::part(custom-cell-selected-2) {
+  background-color: #e2e2e2;
 }
 
 /**

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -31,6 +31,7 @@ A Read-Only data grid uses "Formatters" to render cell content. A number of thes
 - `headerCell` allows you to further style the header cells
 - `row` allows you to further style the rows
 - `cell` allows you to further style the row cells
+- `cell-selected` allows you to further style row cells that are selected (in mixed-selection mode, activated cells are also styled)
 - `tooltip-popup` allows you to further style or adjust the outer tooltip popup element
 - `tooltip-arrow` allows you to adjust the tooltip arrow element
 
@@ -258,6 +259,7 @@ When used as an attribute in the DOM the settings are kebab case, when used in J
 |`headerTooltipCssPart` | {string} | Allows you to sets the header tooltip css part.
 |`headerIconTooltipCssPart` | {string} | Allows you to sets the header icon tooltip css part.
 |`filterButtonTooltipCssPart` | {string} | Allows you to sets the filter button tooltip css part.
+|`cellSelectedCssPart` | {string} | Allows customization of a selected cell's background color.
 
 ## Column Settings (Specific)
 
@@ -749,6 +751,68 @@ The following events are relevant to data-grid filters.
 - `filteroperatorchanged` Fires once a filter operator changed.
 - `filterrowopened` Fires after the filter row is opened by the user.
 - `filterrowclosed` Fires after the filter row is closed by the user.
+
+## Custom cell colors
+
+In some cases, it may be desirable to customize the background color of cells.  This can be done with the `cssPart` column setting:
+
+```js
+const columns = [];
+columns.push({
+  id: 'text',
+  name: 'Text',
+  field: 'description',
+  cssPart: 'custom-cell'
+});
+```
+
+The `cssPart` property is translated into a `part` attribute that is applied to every cell in the column.  In the event the color needs to be conditional based on the row index or other logic, a function can be used:
+
+```js
+columns.push({
+  // ...
+  cssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell-1' : 'custom-cell-2')
+  // ...
+});
+```
+
+After this is defined, accompanying CSS can be written to target the parts `custom-cell`, `custom-cell-1`, and `custom-cell-2` to change background color or other CSS properties of the cell:
+
+```css
+ids-data-grid::part(cell) {
+  background-color: #ebf9f1;
+}
+
+ids-data-grid::part(cell-selected) {
+  background-color: #c9dad0;
+}
+```
+
+### Changing selected cell colors
+
+Another column setting, `cellSelectedCssPart` can be used alongside `cssPart` to customize the selected color of the row in a similar way.  When using `mixed` selection, this color is also applied to activated rows:
+
+```js
+const columns = [];
+columns.push({
+  id: 'text',
+  name: 'Text',
+  field: 'description',
+  cssPart: 'custom-cell',
+  cellSelectedCssPart: 'custom-cell-selected'
+});
+```
+
+This column setting can also be a function, just like `cssPart`:
+
+```js
+columns.push({
+  // ...
+  cssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell-1' : 'custom-cell-2'),
+  cellSelectedCssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell-selected-1' : 'custom-cell-selected-2')
+  // ...
+});
+```
 
 ## Tooltip Code Examples
 

--- a/src/components/ids-data-grid/demos/columns-custom-css.html
+++ b/src/components/ids-data-grid/demos/columns-custom-css.html
@@ -12,7 +12,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-data-grid id="data-grid-custom-css" label="Books"></ids-data-grid>
+        <ids-data-grid id="data-grid-custom-css" label="Books" row-selection="mixed"></ids-data-grid>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-data-grid/demos/columns-custom-css.ts
+++ b/src/components/ids-data-grid/demos/columns-custom-css.ts
@@ -3,9 +3,10 @@ import '../ids-data-grid';
 import type { IdsDataGridColumn } from '../ids-data-grid-column';
 import booksJSON from '../../../assets/data/books.json';
 
-import css from '../../../assets/css/ids-data-grid/custom-css.css';
 import { IdsDataGridTooltipCallback } from '../ids-data-grid-column';
 
+// Custom Datagrid Cell Colors are defined in this file:
+import css from '../../../assets/css/ids-data-grid/custom-css.css';
 const cssLink = `<link href="${css}" rel="stylesheet">`;
 document.querySelector('head')?.insertAdjacentHTML('afterbegin', cssLink);
 
@@ -31,6 +32,14 @@ if (dataGrid) {
     const columns: IdsDataGridColumn[] = [];
 
     // Set up columns
+    columns.push({
+      id: 'selectionCheckbox',
+      name: 'selection',
+      sortable: false,
+      resizable: false,
+      formatter: dataGrid.formatters.selectionCheckbox,
+      align: 'center'
+    });
     columns.push({
       id: 'description',
       name: 'Description',
@@ -67,6 +76,7 @@ if (dataGrid) {
       field: 'publishDate',
       formatter: dataGrid.formatters.date,
       cssPart: 'custom-cell',
+      cellSelectedCssPart: 'custom-cell-selected-1'
     });
     columns.push({
       id: 'price',
@@ -74,7 +84,8 @@ if (dataGrid) {
       field: 'price',
       formatter: dataGrid.formatters.decimal,
       formatOptions: { locale: 'en-US' },
-      cssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell' : '')
+      cssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell' : ''),
+      cellSelectedCssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell-selected-1' : 'custom-cell-selected-2')
     });
 
     dataGrid.columns = columns;

--- a/src/components/ids-data-grid/demos/columns-custom-css.ts
+++ b/src/components/ids-data-grid/demos/columns-custom-css.ts
@@ -7,6 +7,7 @@ import { IdsDataGridTooltipCallback } from '../ids-data-grid-column';
 
 // Custom Datagrid Cell Colors are defined in this file:
 import css from '../../../assets/css/ids-data-grid/custom-css.css';
+
 const cssLink = `<link href="${css}" rel="stylesheet">`;
 document.querySelector('head')?.insertAdjacentHTML('afterbegin', cssLink);
 

--- a/src/components/ids-data-grid/ids-data-grid-column.ts
+++ b/src/components/ids-data-grid/ids-data-grid-column.ts
@@ -194,4 +194,6 @@ export interface IdsDataGridColumn {
   headerIconTooltipCssPart?: string;
   /** Sets the header filter button tooltip css part */
   filterButtonTooltipCssPart?: string;
+  /** Sets the cell activation color css part */
+  cellSelectedCssPart?: string | ((rowIndex: number, cellIndex: number) => string);
 }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1498,7 +1498,10 @@ export default class IdsDataGrid extends Base {
 
     this.state.selectedRows.push(index);
     this.updateDataRow(Number(row?.getAttribute('data-index')), { rowSelected: true });
-    if (row) this.updateRowCells(index, row);
+
+    if (this.rowSelection === 'single' || this.rowSelection === 'multiple') {
+      if (row) this.updateRowCells(index, row);
+    }
 
     this.triggerEvent('rowselected', this, {
       detail: {
@@ -1655,7 +1658,10 @@ export default class IdsDataGrid extends Base {
         let cssPart = columnData.cssPart || 'cell';
 
         // Updates selected rows to display the correct CSS part (also activated rows in mixed-selection mode)
-        if (row.classList.contains('selected') || row.classList.contains('activated')) {
+        if (
+          (this.rowSelection === 'mixed' && row.classList.contains('activated'))
+          || ((this.rowSelection === 'single' || this.rowSelection === 'multiple') && row.classList.contains('selected'))
+        ) {
           if (columnData.cellSelectedCssPart) cssPart = columnData.cellSelectedCssPart;
           else cssPart = 'cell-selected';
         }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -493,8 +493,8 @@ export default class IdsDataGrid extends Base {
    */
   #cssPart(column: IdsDataGridColumn, rowIndex: number, cellIndex: number) {
     const cssPart = column.cssPart || 'cell';
-    if (typeof column.cssPart === 'function') {
-      return column.cssPart(rowIndex, cellIndex);
+    if (typeof cssPart === 'function') {
+      return cssPart(rowIndex, cellIndex);
     }
     return cssPart;
   }
@@ -1495,8 +1495,10 @@ export default class IdsDataGrid extends Base {
     if (this.rowSelection === 'mixed') {
       row?.classList.add('mixed');
     }
+
     this.state.selectedRows.push(index);
     this.updateDataRow(Number(row?.getAttribute('data-index')), { rowSelected: true });
+    if (row) this.updateRowCells(index, row);
 
     this.triggerEvent('rowselected', this, {
       detail: {
@@ -1535,6 +1537,7 @@ export default class IdsDataGrid extends Base {
 
     this.state.selectedRows = this.state.selectedRows.filter((rowNumber: any) => rowNumber.toString() !== index.toString());
     this.updateDataRow(Number(row?.getAttribute('data-index')), { rowSelected: undefined });
+    if (row) this.updateRowCells(index, row);
 
     this.triggerEvent('rowdeselected', this, {
       detail: {
@@ -1562,6 +1565,7 @@ export default class IdsDataGrid extends Base {
     (row as any).classList.add('activated');
     this.state.activatedRow = index;
     (this.data[index] as any).rowActivated = true;
+    if (row) this.updateRowCells(index, row);
 
     this.triggerEvent('rowactivated', this, {
       detail: {
@@ -1590,6 +1594,7 @@ export default class IdsDataGrid extends Base {
     row.classList.remove('activated');
     this.state.activatedRow = null;
     (this.data[index] as any).rowActivated = undefined;
+    if (row) this.updateRowCells(index, row);
 
     this.triggerEvent('rowdeactivated', this, {
       detail: {
@@ -1632,6 +1637,35 @@ export default class IdsDataGrid extends Base {
       });
     }
     this.#setHeaderCheckbox();
+  }
+
+  /**
+   * Updates some attributes/classes on a single row's cells
+   * @private
+   * @param {number} index the row index
+   * @param {HTMLElement} row the row HTML element (previously captured)
+   */
+  private updateRowCells(index: number, row: HTMLElement) {
+    if (!row) return;
+
+    const cells = row.querySelectorAll('.ids-data-grid-cell');
+    if (cells?.length) {
+      [...cells].forEach((cell: Element, columnIndex: number) => {
+        const columnData = this.columns[columnIndex];
+        let cssPart = columnData.cssPart || 'cell';
+
+        // Updates selected rows to display the correct CSS part (also activated rows in mixed-selection mode)
+        if (row.classList.contains('selected') || row.classList.contains('activated')) {
+          if (columnData.cellSelectedCssPart) cssPart = columnData.cellSelectedCssPart;
+          else cssPart = 'cell-selected';
+        }
+
+        if (typeof cssPart === 'function') {
+          cssPart = cssPart(index, columnIndex);
+        }
+        cell.setAttribute('part', cssPart);
+      });
+    }
   }
 
   /**

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -479,6 +479,31 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.shadowRoot.querySelectorAll('[part="custom-cell"]').length).toEqual(14);
     });
 
+    it('supports setting cellSelectedCssPart', () => {
+      dataGrid.columns = [{
+        id: 'price',
+        name: 'Price',
+        field: 'price',
+        cssPart: 'custom-cell',
+        cellSelectedCssPart: 'custom-cell-selected'
+      },
+      {
+        id: 'bookCurrency',
+        name: 'Currency',
+        field: 'bookCurrency'
+      },
+      {
+        id: 'transactionCurrency',
+        name: 'Transaction Currency',
+        field: 'transactionCurrency',
+        cssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell' : ''),
+        cellSelectedCssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell-selected' : '')
+      }];
+
+      dataGrid.selectAllRows();
+      expect(dataGrid.shadowRoot.querySelectorAll('[part="custom-cell-selected"]').length).toEqual(14);
+    });
+
     it('supports setting frozen columns', () => {
       expect(dataGrid.hasFrozenColumns).toEqual(false);
       dataGrid.columns = [{

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -479,31 +479,6 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.shadowRoot.querySelectorAll('[part="custom-cell"]').length).toEqual(14);
     });
 
-    it('supports setting cellSelectedCssPart', () => {
-      dataGrid.columns = [{
-        id: 'price',
-        name: 'Price',
-        field: 'price',
-        cssPart: 'custom-cell',
-        cellSelectedCssPart: 'custom-cell-selected'
-      },
-      {
-        id: 'bookCurrency',
-        name: 'Currency',
-        field: 'bookCurrency'
-      },
-      {
-        id: 'transactionCurrency',
-        name: 'Transaction Currency',
-        field: 'transactionCurrency',
-        cssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell' : ''),
-        cellSelectedCssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell-selected' : '')
-      }];
-
-      dataGrid.selectAllRows();
-      expect(dataGrid.shadowRoot.querySelectorAll('[part="custom-cell-selected"]').length).toEqual(14);
-    });
-
     it('supports setting frozen columns', () => {
       expect(dataGrid.hasFrozenColumns).toEqual(false);
       dataGrid.columns = [{
@@ -1860,12 +1835,17 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.getAttribute('row-selection')).toBeFalsy();
     });
 
-    it('keeps selections on sort for single selection', () => {
+    it('keeps selections on sort for single selection', async () => {
+      dataGrid.deSelectAllRows();
+      dataGrid.data = deepClone(dataset);
+
       const newColumns = deepClone(columns());
       newColumns[0].id = 'selectionRadio';
       newColumns[0].formatter = formatters.selectionRadio;
       dataGrid.rowSelection = 'single';
       dataGrid.columns = newColumns;
+
+      await processAnimFrame();
 
       expect(dataGrid.selectedRows.length).toBe(0);
       dataGrid.shadowRoot.querySelector('.ids-data-grid-body .ids-data-grid-row:nth-child(2) .ids-data-grid-cell:nth-child(1)').click();
@@ -2501,27 +2481,6 @@ describe('IdsDataGrid Component', () => {
 
       dataGrid.idColumn = '';
       expect(dataGrid.getAttribute('id-column')).toBeFalsy();
-    });
-  });
-
-  describe('Events Tests', () => {
-    it('should fire rowclick and rowdoubleclick events', () => {
-      const clickCallback = jest.fn((e) => {
-        expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
-      });
-      const dblClickCallback = jest.fn((e) => {
-        expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
-      });
-
-      dataGrid.addEventListener('rowclick', clickCallback);
-      dataGrid.addEventListener('rowdoubleclick', dblClickCallback);
-
-      const firstCellInRow = dataGrid.container.querySelector('.ids-data-grid-body .ids-data-grid-cell');
-      const clickEvent = new MouseEvent('click', { bubbles: true });
-      const dblClickEvent = new MouseEvent('dblclick', { bubbles: true });
-
-      firstCellInRow.dispatchEvent(clickEvent);
-      firstCellInRow.dispatchEvent(dblClickEvent);
     });
   });
 });

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -479,6 +479,31 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.shadowRoot.querySelectorAll('[part="custom-cell"]').length).toEqual(14);
     });
 
+    it('supports setting cellSelectedCssPart', () => {
+      dataGrid.columns = [{
+        id: 'price',
+        name: 'Price',
+        field: 'price',
+        cssPart: 'custom-cell',
+        cellSelectedCssPart: 'custom-cell-selected'
+      },
+      {
+        id: 'bookCurrency',
+        name: 'Currency',
+        field: 'bookCurrency'
+      },
+      {
+        id: 'transactionCurrency',
+        name: 'Transaction Currency',
+        field: 'transactionCurrency',
+        cssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell' : ''),
+        cellSelectedCssPart: (row: number) => ((row % 2 === 0) ? 'custom-cell-selected' : '')
+      }];
+
+      dataGrid.selectAllRows();
+      expect(dataGrid.shadowRoot.querySelectorAll('[part="custom-cell-selected"]').length).toEqual(14);
+    });
+
     it('supports setting frozen columns', () => {
       expect(dataGrid.hasFrozenColumns).toEqual(false);
       dataGrid.columns = [{
@@ -2481,6 +2506,27 @@ describe('IdsDataGrid Component', () => {
 
       dataGrid.idColumn = '';
       expect(dataGrid.getAttribute('id-column')).toBeFalsy();
+    });
+  });
+
+  describe('Events Tests', () => {
+    it('should fire rowclick and rowdoubleclick events', () => {
+      const clickCallback = jest.fn((e) => {
+        expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
+      });
+      const dblClickCallback = jest.fn((e) => {
+        expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
+      });
+
+      dataGrid.addEventListener('rowclick', clickCallback);
+      dataGrid.addEventListener('rowdoubleclick', dblClickCallback);
+
+      const firstCellInRow = dataGrid.container.querySelector('.ids-data-grid-body .ids-data-grid-cell');
+      const clickEvent = new MouseEvent('click', { bubbles: true });
+      const dblClickEvent = new MouseEvent('dblclick', { bubbles: true });
+
+      firstCellInRow.dispatchEvent(clickEvent);
+      firstCellInRow.dispatchEvent(dblClickEvent);
     });
   });
 });

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -480,6 +480,7 @@ describe('IdsDataGrid Component', () => {
     });
 
     it('supports setting cellSelectedCssPart', () => {
+      dataGrid.rowSelection = 'multiple';
       dataGrid.columns = [{
         id: 'price',
         name: 'Price',


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds a new IdsDataGridColumn setting, `cellSelectedCssPart`, which optionally allows a column to provide a dynamic [CSS part]() name that can be used to provide a custom background color -- or other CSS -- to selected/activated grid cells.

**Related github/jira issue (required)**:
Closes #989

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/columns-custom-css.html
- Click a cell without selecting the row (using the checkbox).  When the row is activated, slightly darker custom colors should appear on the cell.
- Select some rows using the checkboxes.   When the rows are selected, the same darker background colors are applied.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
