### PR TITLE
993 - IdsDataGrid row navigation setting

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[DataGrid]` Added suppress row click for selection functionality. ([#737](https://github.com/infor-design/enterprise-wc/issues/737)
 - `[DataGrid]` Added support for context menu. ([#963](https://github.com/infor-design/enterprise-wc/issues/963))
 - `[DataGrid]` Added rowclick and rowdoubleclick events. ([#994](https://github.com/infor-design/enterprise-wc/issues/994))
+- `[DataGrid]` Added rowNavigation functionality. ([#993](https://github.com/infor-design/enterprise-wc/issues/993))
 - `[Icons]` All icons have padding on top and bottom effectively making them 4px smaller by design. This change may require some UI corrections to css. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Over 60 new icons and 126 new industry focused icons. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Added new empty state icons. ([#6934](https://github.com/infor-design/enterprise/issues/6934))

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -217,6 +217,7 @@ When used as an attribute in the DOM the settings are kebab case, when used in J
 - `headerMenuId` {string} ID of the popupmenu to use as context menu for header and header group cells.
 - `menuData` {Array<object>} Dataset to build context menu for body cells.
 - `menuId` {string} ID of the popupmenu to use as context menu for body cells.
+- `rowNavigation` {boolean} If using row navigation, the row will be focused when navigating the data grid via clicks and keyboard events.
 - `rowSelection` {string|boolean} Set the row selection mode between false, 'single', 'multiple' and 'mixed
 - `suppressRowClickSelection` {boolean} If using selection setting this will require clicking a checkbox or radio to select the row. Clicking other cells will not select the row.
 - `suppressRowDeactivation` {boolean} Set to true to prevent rows from being deactivated if clicked. i.e. once a row is activated, it remains activated until another row is activated in its place.

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -1075,6 +1075,7 @@ Set context menu thru ID.
 - Can now be imported as a single JS file and used with encapsulated styles
 - `Drill Down` Formatter is now covered by `Button` formatter with `icon="drilldown"`
 - `textOverflow` setting is now by default
+- `rowNavigation` setting has replaced `cellNavigation`. Cell navigation is the default behavior.
 - `stretchColumn` is now more flexible and can be achieved by setting a column width to `minmax(130px, 4fr)`. I.E. some min width and a `fr` unit equal to the remaining number of columns (or similar variations).
 - split columns are not supported anymore but could be done with a custom formatter if needed
 - `frozenColumns` setting is now set on each column by adding `frozen: 'left'` or `frozen: 'right'` to the column definition.

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -98,6 +98,9 @@
   - link: pagination-standalone.html
     type: Example
     description: Showing a data grid with standalone pagination
+  - link: row-navigation.html
+    type: Example
+    description: Showing a data grid with row navigation
   - link: side-by-side.html
     type: Side by Side
     description: Showing a data grid next to a 4.x data grid

--- a/src/components/ids-data-grid/demos/row-navigation.html
+++ b/src/components/ids-data-grid/demos/row-navigation.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Data Grid</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-data-grid id="data-grid-1" row-selection="multiple" label="Books" row-height="md" row-navigation></ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/row-navigation.ts
+++ b/src/components/ids-data-grid/demos/row-navigation.ts
@@ -1,0 +1,142 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+import booksJSON from '../../../assets/data/books.json';
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-1')!;
+
+if (dataGrid) {
+  (async function init() {
+    // Do an ajax request
+    const url: any = booksJSON;
+    const columns: IdsDataGridColumn[] = [];
+
+    // Set up columns
+    columns.push({
+      id: 'selectionCheckbox',
+      name: 'selection',
+      sortable: false,
+      resizable: false,
+      formatter: dataGrid.formatters.selectionCheckbox,
+      align: 'center'
+    });
+    columns.push({
+      id: 'rowNumber',
+      name: '#',
+      formatter: dataGrid.formatters.rowNumber,
+      sortable: false,
+      readonly: true,
+      width: 65
+    });
+    columns.push({
+      id: 'description',
+      name: 'Description',
+      field: 'description',
+      sortable: true,
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'ledger',
+      name: 'Ledger',
+      field: 'ledger',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'publishDate',
+      name: 'Pub. Date',
+      field: 'publishDate',
+      formatter: dataGrid.formatters.date
+    });
+    columns.push({
+      id: 'publishTime',
+      name: 'Pub. Time',
+      field: 'publishDate',
+      formatter: dataGrid.formatters.time
+    });
+    columns.push({
+      id: 'price',
+      name: 'Price',
+      field: 'price',
+      formatter: dataGrid.formatters.decimal,
+      formatOptions: { locale: 'en-US' } // Data Values are in en-US
+    });
+    columns.push({
+      id: 'bookCurrency',
+      name: 'Currency',
+      field: 'bookCurrency',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'transactionCurrency',
+      name: 'Transaction Currency',
+      field: 'transactionCurrency',
+      formatter: dataGrid.formatters.text,
+    });
+    columns.push({
+      id: 'integer',
+      name: 'Price (Int)',
+      field: 'price',
+      formatter: dataGrid.formatters.integer,
+      formatOptions: { locale: 'en-US' } // Data Values are in en-US
+    });
+    columns.push({
+      id: 'location',
+      name: 'Location',
+      field: 'location',
+      formatter: dataGrid.formatters.hyperlink,
+      href: '#'
+    });
+    columns.push({
+      id: 'postHistory',
+      name: 'Post History',
+      field: 'postHistory',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'active',
+      name: 'Active',
+      field: 'active',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'convention',
+      name: 'Convention',
+      field: 'convention',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'methodSwitch',
+      name: 'Method Switch',
+      field: 'methodSwitch',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'trackDeprecationHistory',
+      name: 'Track Deprecation History',
+      field: 'trackDeprecationHistory',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'useForEmployee',
+      name: 'Use For Employee',
+      field: 'useForEmployee',
+      formatter: dataGrid.formatters.password
+    });
+    columns.push({
+      id: 'deprecationHistory',
+      name: 'Deprecation History',
+      field: 'deprecationHistory',
+      formatter: dataGrid.formatters.text
+    });
+
+    dataGrid.columns = columns;
+    const setData = async () => {
+      const res = await fetch(url);
+      const data = await res.json();
+      dataGrid.data = data;
+    };
+
+    setData();
+  }());
+}

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -421,8 +421,10 @@ $header-bg-color: var(--ids-color-palette-slate-80);
 
   // Row Naviation Styles
   &.row-navigation .ids-data-grid-row {
-    &.is-focused {
-      outline: 1px solid var(--ids-color-palette-azure-80);
+    &:focus-within {
+      @include shadow();
+
+      outline: 1px solid var(--ids-color-palette-azure-60);
       outline-offset: -1px;
     }
 
@@ -786,6 +788,16 @@ table.ids-data-grid {
     }
   }
 
+  // Row Naviation Styles (Dark)
+  &.row-navigation .ids-data-grid-row {
+    &:focus-within {
+      @include shadow();
+
+      outline: 1px solid var(--ids-color-palette-slate-60);
+      outline-offset: -1px;
+    }
+  }
+
   // Selection
   .ids-data-grid-row.selected:not(.mixed) .ids-data-grid-cell,
   .ids-data-grid-row.activated .ids-data-grid-cell {
@@ -932,6 +944,14 @@ table.ids-data-grid {
       @include text-slate-30();
     }
   }
+
+  // Row Naviation Styles (Contrast)
+  &.row-navigation .ids-data-grid-row {
+    &:focus-within {
+      box-shadow: 0 0 0 1px var(--ids-color-palette-azure-80);
+      outline: 1px solid var(--ids-color-palette-azure-80);
+    }
+  }  
 
   .ids-data-grid-radio {
     @include bg-white();

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -419,6 +419,19 @@ $header-bg-color: var(--ids-color-palette-slate-80);
     }
   }
 
+  // Row Naviation Styles
+  &.row-navigation .ids-data-grid-row {
+    &.is-focused {
+      outline: 1px solid var(--ids-color-palette-azure-80);
+      outline-offset: -1px;
+    }
+
+    .ids-data-grid-cell:focus {
+      box-shadow: none;
+      outline: none;
+    }
+  }
+
   // Selection Checkbox
   .ids-data-grid-checkbox-container {
     display: flex;

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -951,7 +951,7 @@ table.ids-data-grid {
       box-shadow: 0 0 0 1px var(--ids-color-palette-azure-80);
       outline: 1px solid var(--ids-color-palette-azure-80);
     }
-  }  
+  }
 
   .ids-data-grid-radio {
     @include bg-white();

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1492,13 +1492,8 @@ export default class IdsDataGrid extends Base {
   #handleRowNavigation(activateRow = false) {
     if (!this.rowNavigation) return;
 
-    const prevIndex = this.state.focusedRow || this.state.activatedRow;
-    const prevElem = this.rowByAriaIndex(prevIndex);
     const currElem = this.activeCell.node?.parentElement;
     const currIndex = Number(currElem?.getAttribute('aria-rowindex'));
-
-    prevElem?.classList.remove('is-focused');
-    currElem?.classList.add('is-focused');
 
     if (activateRow) this.#handleRowActivation(currElem);
 
@@ -1512,15 +1507,6 @@ export default class IdsDataGrid extends Base {
    */
   rowByIndex(index: number) {
     return this.shadowRoot?.querySelector<HTMLElement>(`.ids-data-grid-body .ids-data-grid-row[data-index="${index}"]`);
-  }
-
-  /**
-   * Get the row HTMLElement by aria index
-   * @param {number} index row index
-   * @returns {HTMLElement} Row HTMLElement
-   */
-  rowByAriaIndex(index: number) {
-    return this.shadowRoot?.querySelector<HTMLElement>(`.ids-data-grid-body .ids-data-grid-row[aria-rowindex="${index}"]`);
   }
 
   /**

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -556,9 +556,6 @@ export default class IdsDataGrid extends Base {
       // Focus Cell
       this.setActiveCell(cellNum, rowNum, isHyperlink);
 
-      // Focus Row
-      this.#handleRowNavigation(false);
-
       // Handle click callbacks
       if (isClickable && this.visibleColumns[cellNum].click !== undefined && !e.target?.getAttribute('disabled')) {
         (this.visibleColumns[cellNum] as any).click({
@@ -812,7 +809,9 @@ export default class IdsDataGrid extends Base {
       const rowIndex = key === 'ArrowDown' ? nextRow : prevRow;
 
       this.setActiveCell(Number(this.activeCell?.cell) + cellDiff, rowDiff === 0 ? Number(this.activeCell?.row) : rowIndex);
-      this.#handleRowNavigation(this.rowSelection === 'mixed');
+      if (this.rowSelection === 'mixed') {
+        this.#handleRowActivation(this.activeCell.node.parentElement);
+      }
       e.preventDefault();
       e.stopPropagation();
     });
@@ -1210,7 +1209,6 @@ export default class IdsDataGrid extends Base {
     if (stringToBool(value)) {
       this.setAttribute(attributes.ROW_NAVIGATION, '');
       this.container?.classList.add('row-navigation');
-      this.#handleRowNavigation(this.rowSelection === 'mixed');
     } else {
       this.removeAttribute(attributes.ROW_NAVIGATION);
       this.container?.classList.remove('row-navigation');
@@ -1483,21 +1481,6 @@ export default class IdsDataGrid extends Base {
         row
       }
     });
-  }
-
-  /**
-   * Handle row navigation via click/keyboard
-   * @param {boolean} activateRow flag to activate row when focused
-   */
-  #handleRowNavigation(activateRow = false) {
-    if (!this.rowNavigation) return;
-
-    const currElem = this.activeCell.node?.parentElement;
-    const currIndex = Number(currElem?.getAttribute('aria-rowindex'));
-
-    if (activateRow) this.#handleRowActivation(currElem);
-
-    this.state.focusedRow = currIndex;
   }
 
   /**

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -291,6 +291,7 @@ export const attributes = {
   ROWS: 'rows',
   ROW_END: 'row-end',
   ROW_HEIGHT: 'row-height',
+  ROW_NAVIGATION: 'row-navigation',
   ROW_SELECTION: 'row-selection',
   ROW_SPAN: 'row-span',
   ROW_START: 'row-start',

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -1699,6 +1699,23 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.row).toEqual(8);
     });
 
+    it('can handle keyboard row navigation', () => {
+      // focus on first grid cell
+      expect(dataGrid.activeCell.row).toEqual(0);
+      expect(dataGrid.activeCell.cell).toEqual(0);
+      dataGrid.activeCell.node.focus();
+
+      // dipatch arrow down event
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+      dataGrid.rowNavigation = true;
+      dataGrid.dispatchEvent(event);
+
+      // expect second row to be focused
+      const rowElem = dataGrid.rowByIndex(dataGrid.activeCell.row);
+      expect(rowElem.getAttribute('aria-rowindex')).toEqual('2');
+      expect(rowElem?.classList.contains('is-focused')).toBeTruthy();
+    });
+
     it('can handle errant click', () => {
       const errors = jest.spyOn(global.console, 'error');
       dataGrid.shadowRoot.querySelector('.ids-data-grid-body').dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -1993,14 +2010,14 @@ describe('IdsDataGrid Component', () => {
       expect(mockCallback.mock.calls.length).toBe(1);
     });
 
-    it('handles a deActivateRow method', () => {
-      dataGrid.deActivateRow(1);
+    it('handles a deactivateRow method', () => {
+      dataGrid.deactivateRow(1);
       expect(dataGrid.activatedRow).toBeFalsy();
 
       dataGrid.rowSelection = 'mixed';
       dataGrid.activateRow(1);
       expect(dataGrid.activatedRow).toBeTruthy();
-      dataGrid.deActivateRow(1);
+      dataGrid.deactivateRow(1);
       expect(dataGrid.activatedRow).toBeFalsy();
     });
   });

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -1713,7 +1713,6 @@ describe('IdsDataGrid Component', () => {
       // expect second row to be focused
       const rowElem = dataGrid.rowByIndex(dataGrid.activeCell.row);
       expect(rowElem.getAttribute('aria-rowindex')).toEqual('2');
-      expect(rowElem?.classList.contains('is-focused')).toBeTruthy();
     });
 
     it('can handle errant click', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added a row-navigation setting for data grid. Allows the user to focus the entire, not the just column, when navigating the data grid via keyboard/clicks. Changed naming to `rowNavigation` instead of `cellNavigation` , since cell navigation is the default behavior.

**Related github/jira issue (required)**:
Closes #993 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, `npm install`, `npm run start`
2. Go to http://localhost:4300/ids-data-grid/row-navigation.html
3. Click on any row, ensure entire row has focused styles
4. Navigate the rows via keyboard arrows, ensure the navigated rows have focused styles
5. Hit spacebar on focused rows to select them

Mixed Selection Row Navigation
1. Go to http://localhost:4300/ids-data-grid/mixed-selection.html
2. Add `row-navigation` attribute to <ids-data-grid>,  or run in console `$('ids-data-grid').rowNavigation = true;`
3. Navigated rows should have focused and activated styles

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
