### PR TITLE
1005 - IdsDataGrid links with keyboard

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[DataGrid]` Added `rowclick` and `rowdoubleclick` events. ([#994](https://github.com/infor-design/enterprise-wc/issues/- `[DataGrid]` Added `ids-data-grid-cell`, `ids-data-grid-row` and `ids-data-grid-header` components and better code separation. ([#968](https://github.com/infor-design/enterprise-wc/issues/968))
 - `[DataGrid]` Added rowNavigation functionality. ([#993](https://github.com/infor-design/enterprise-wc/issues/993))
 - `[DataGrid]` Added left and right padding (start and end) for row-heights. ([#996](https://github.com/infor-design/enterprise-wc/issues/996))
+- `[DataGrid]` Fixed click function on columns is not firing when using the keyboard. ([#1005](https://github.com/infor-design/enterprise-wc/issues/1005))
 - `[Icons]` All icons have padding on top and bottom effectively making them 4px smaller by design. This change may require some UI corrections to css. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Over 60 new icons and 126 new industry focused icons. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Added new empty state icons. ([#6934](https://github.com/infor-design/enterprise/issues/6934))

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -448,6 +448,23 @@ export default class IdsDataGrid extends Base {
       row.toggleSelection();
       e.preventDefault();
     });
+
+    // Follow links with keyboard
+    this.listen(['Enter'], this, () => {
+      const hyperlink = this.activeCell.node.querySelector('ids-hyperlink');
+      const button = this.activeCell.node.querySelector('ids-button');
+      const customLink = this.activeCell.node.querySelector('a');
+
+      hyperlink?.container.focus();
+      hyperlink?.click();
+      button?.click();
+      customLink?.click();
+
+      if (customLink) {
+        this.activeCell.node.focus();
+      }
+    });
+
     return this;
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds the Enter key keyboard listener to follow cell links with the keyboard

**Related github/jira issue (required)**:
Closes #1005 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-data-grid/columns-formatters.html
- click in a cell and use the arrow keys to go into the link column(s)
- hit enter on a link or a button
- see console, the enter key should log a console log like it does when it clicks it

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
