### PR TITLE
1008 - IdsDataGrid fix disableClientFilter does not emit filtered event when empty

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[DataGrid]` Added `rowclick` and `rowdoubleclick` events. ([#994](https://github.com/infor-design/enterprise-wc/issues/- `[DataGrid]` Added `ids-data-grid-cell`, `ids-data-grid-row` and `ids-data-grid-header` components and better code separation. ([#968](https://github.com/infor-design/enterprise-wc/issues/968))
 - `[DataGrid]` Added rowNavigation functionality. ([#993](https://github.com/infor-design/enterprise-wc/issues/993))
 - `[DataGrid]` Added left and right padding (start and end) for row-heights. ([#996](https://github.com/infor-design/enterprise-wc/issues/996))
+- `[DataGrid]` Fixed a bug that when using disableClientFilter does not emit filtered event when empty. ([#1008](https://github.com/infor-design/enterprise-wc/issues/1008))
 - `[Icons]` All icons have padding on top and bottom effectively making them 4px smaller by design. This change may require some UI corrections to css. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Over 60 new icons and 126 new industry focused icons. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Added new empty state icons. ([#6934](https://github.com/infor-design/enterprise/issues/6934))

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -419,15 +419,15 @@ export default class IdsDataGridFilters {
     }
     this.#conditions = conditions;
 
-    // No need to go further, if no condition/s to filter
-    if ((!conditions?.length && !this.root.datasource.filtered) || !conditions) {
+    // Client filter
+    if (this.root.disableClientFilter) {
+      this.root.triggerEvent('filtered', this.root, { bubbles: true, detail: { elem: this.root, conditions } });
       this.#filterIsProcessing = false;
       return;
     }
 
-    // Client filter
-    if (this.root.disableClientFilter) {
-      this.root.triggerEvent('filtered', this.root, { bubbles: true, detail: { elem: this.root, conditions } });
+    // No need to go further, if no condition/s to filter
+    if ((!conditions?.length && !this.root.datasource.filtered) || !conditions) {
       this.#filterIsProcessing = false;
       return;
     }

--- a/test/ids-data-grid/ids-data-grid-func-filters-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-filters-test.ts
@@ -974,4 +974,15 @@ describe('IdsDataGrid Component Filter Tests', () => {
 
     expect(mockCallback.mock.calls.length).toBe(2);
   });
+
+  it('fires filtered event when disableClientFilter with empty values', () => {
+    const mockCallback = jest.fn();
+
+    dataGrid.disableClientFilter = true;
+    dataGrid.addEventListener('filtered', mockCallback);
+    dataGrid.container.querySelector('ids-input[data-filter-type="text"]').value = '';
+    dataGrid.applyFilter();
+
+    expect(mockCallback).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes `disableClientFilter` does not emit filtered event when filter value is empty. Adds functional test.

**Related github/jira issue (required)**:
Closes #1008

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-data-grid/disable-client-filter.html
- enter a value to the filter input and press enter to run the filter
- see the event in the console
- clear the value and press enter
- see the event in the console

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.