### PR TITLE
1013 - IdsCheckbox fix Safari issues

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[General]` Fixed a list of issues in Safari browser. ([#956](https://github.com/infor-design/enterprise-wc/issues/956))
 - `[AppMenu]` Updated main example to be consistent with 4.x. ([#852](https://github.com/infor-design/enterprise-wc/issues/852))
 - `[BarChart]` Added support to flip horizontal. ([#963](https://github.com/infor-design/enterprise-wc/issues/893))
+- `[Checkbox]` Fixed validate, dirty tracking and hitbox settings in Safari browser. ([#1013](https://github.com/infor-design/enterprise-wc/issues/1013))
 - `[DataGrid]` Fixed some filter issues with datagrid. ([#932](https://github.com/infor-design/enterprise-wc/issues/932)
 - `[DataGrid]` Added tree grid functionality. ([#737](https://github.com/infor-design/enterprise-wc/issues/737)
 - `[DataGrid]` Added expandable row functionality. ([#737](https://github.com/infor-design/enterprise-wc/issues/737)

--- a/src/components/ids-checkbox/ids-checkbox.ts
+++ b/src/components/ids-checkbox/ids-checkbox.ts
@@ -36,10 +36,6 @@ export default class IdsCheckbox extends Base {
 
   isFormComponent = true;
 
-  input?: HTMLInputElement | null;
-
-  labelEl?: HTMLLabelElement | null;
-
   /**
    * Return the attributes we handle as getters/setters
    * @returns {Array} The attributes in an array
@@ -70,8 +66,6 @@ export default class IdsCheckbox extends Base {
    */
   connectedCallback(): void {
     super.connectedCallback();
-    this.input = this.shadowRoot?.querySelector('input[type="checkbox"]');
-    this.labelEl = this.shadowRoot?.querySelector('label');
     this.#attachEventHandlers();
   }
 
@@ -157,6 +151,22 @@ export default class IdsCheckbox extends Base {
   #attachEventHandlers(): void {
     this.attachCheckboxChangeEvent();
     this.attachNativeEvents();
+  }
+
+  /**
+   * @readonly
+   * @returns {HTMLInputElement} the inner `input` element
+   */
+  get input(): HTMLInputElement | undefined | null {
+    return this.container?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  }
+
+  /**
+   * @readonly
+   * @returns {HTMLLabelElement} the inner `labelEl` element
+   */
+  get labelEl(): HTMLLabelElement | undefined | null {
+    return this.container?.querySelector<HTMLLabelElement>('label');
   }
 
   /**

--- a/src/components/ids-checkbox/ids-checkbox.ts
+++ b/src/components/ids-checkbox/ids-checkbox.ts
@@ -67,6 +67,9 @@ export default class IdsCheckbox extends Base {
   connectedCallback(): void {
     super.connectedCallback();
     this.#attachEventHandlers();
+    if (this.dirtyTracker) {
+      this.handleDirtyTracker();
+    }
   }
 
   /**

--- a/src/mixins/ids-hitbox-mixin/ids-hitbox-mixin.ts
+++ b/src/mixins/ids-hitbox-mixin/ids-hitbox-mixin.ts
@@ -20,6 +20,11 @@ const IdsHitboxMixin = <T extends IdsBaseConstructor>(superclass: T) => class ex
     ];
   }
 
+  connectedCallback(): void {
+    super.connectedCallback?.();
+    this.#setHitbox();
+  }
+
   /**
    * Sets the checkbox to add hitbox style.
    * @param {boolean|string} value If true, it will apply the hitbox stylings.
@@ -28,14 +33,18 @@ const IdsHitboxMixin = <T extends IdsBaseConstructor>(superclass: T) => class ex
     const val = stringToBool(value);
     if (val) {
       this.setAttribute(attributes.HITBOX, val.toString());
-      this.container?.classList.add(attributes.HITBOX);
     } else {
       this.removeAttribute(attributes.HITBOX);
-      this.container?.classList.remove(attributes.HITBOX);
     }
+
+    this.#setHitbox();
   }
 
   get hitbox() { return this.getAttribute(attributes.HITBOX); }
+
+  #setHitbox() {
+    this.container?.classList.toggle(attributes.HITBOX, Boolean(this.hitbox));
+  }
 };
 
 export default IdsHitboxMixin;

--- a/test/ids-checkbox/ids-checkbox-func-test.ts
+++ b/test/ids-checkbox/ids-checkbox-func-test.ts
@@ -259,7 +259,6 @@ describe('IdsCheckbox Component', () => {
   });
 
   it('should remove events', () => {
-    cb.input = null;
     document.body.innerHTML = '';
     const elem: any = new IdsCheckbox();
     document.body.appendChild(elem);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes `validate` and `dirty-tracker` for `ids-checkbox` in Safari browser by adding getters for `input` and `labelEl` properties. Also fixes `hitbox` setting for `ids-checkbox` in Safari by adding connectedCallback to hitbox mixin.

**Related github/jira issue (required)**:
Closes #1013

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-checkbox/example.html in Safari browser
- see Dirty tracking example works
- see Required example works
- see hitbox examples work

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
