### PR TITLE
906 - IdsBreadcrumb Fix popup menu being cutoff in the truncated example

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[General]` Fixed a list of issues in Safari browser. ([#956](https://github.com/infor-design/enterprise-wc/issues/956))
 - `[AppMenu]` Updated main example to be consistent with 4.x. ([#852](https://github.com/infor-design/enterprise-wc/issues/852))
 - `[BarChart]` Added support to flip horizontal. ([#963](https://github.com/infor-design/enterprise-wc/issues/893))
+- `[Breadcrumb]` Fixed popup menu being cutoff in truncated example. ([#906](https://github.com/infor-design/enterprise-wc/issues/906))
 - `[DataGrid]` Fixed some filter issues with datagrid. ([#932](https://github.com/infor-design/enterprise-wc/issues/932)
 - `[DataGrid]` Added tree grid functionality. ([#737](https://github.com/infor-design/enterprise-wc/issues/737)
 - `[DataGrid]` Added expandable row functionality. ([#737](https://github.com/infor-design/enterprise-wc/issues/737)

--- a/src/components/ids-breadcrumb/ids-breadcrumb.scss
+++ b/src/components/ids-breadcrumb/ids-breadcrumb.scss
@@ -45,7 +45,6 @@ $header-gradient-transparent-classic-contrast: rgb(0 74 153 / 0);
   }
 
   &.can-truncate {
-    overflow: hidden;
     white-space: nowrap;
 
     nav {

--- a/src/components/ids-breadcrumb/ids-breadcrumb.ts
+++ b/src/components/ids-breadcrumb/ids-breadcrumb.ts
@@ -162,7 +162,7 @@ export default class IdsBreadcrumb extends Base {
             <ids-icon slot="icon" icon="more"></ids-icon>
             <span class="audible">Icon Only Button</span>
           </ids-menu-button>
-          <ids-popup-menu id="icon-menu" target="icon-button" trigger-type="click">
+          <ids-popup-menu id="icon-menu" target="#icon-button" trigger-type="click">
             <ids-menu-group>
             </ids-menu-group>
           </ids-popup-menu>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes `ids-breadcrumb` truncated popup menu being cutoff

**Related github/jira issue (required)**:
Closes #906

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-breadcrumb/truncated.html
- shrink the browser window
- click on the '...' menu button
- see the popup is not cutoff

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
