### PR TITLE
1027 - IdsSearchfield change clearable-forced in the main exampe

### DIFF
--- a/src/components/ids-search-field/demos/example.html
+++ b/src/components/ids-search-field/demos/example.html
@@ -15,7 +15,7 @@
     <ids-layout-grid cols="3" gap="xl">
       <ids-layout-grid-cell>
         <ids-search-field clearable dirty-tracker label="Products" value="Anti-virus Software" validate="required"></ids-search-field>
-        <ids-search-field clearable-forced readonly label="Read-only Search Bar" value="Cellphone"></ids-search-field>
+        <ids-search-field clearable readonly label="Read-only Search Bar" value="Cellphone"></ids-search-field>
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
         <ids-search-field clearable label="Search Field with Hidden Label" label-state="hidden" placeholder="Custom placeholder text"></ids-search-field>

--- a/test/ids-search-field/ids-search-field-func-test.ts
+++ b/test/ids-search-field/ids-search-field-func-test.ts
@@ -147,4 +147,20 @@ describe('IdsSearchField Component', () => {
     results = await s.search('f');
     expect(results.length).toBe(2);
   });
+
+  it('readonly/disabled should be clearable with clearable-forced setting', async () => {
+    s = await createFromTemplate(s, HTMLSnippets.DISABLED_SEARCH_FIELD);
+    s.clearable = true;
+    expect(s.container.querySelector('.btn-clear')).toBeNull();
+
+    s.clearable = false;
+    s.clearableForced = true;
+    expect(s.container.querySelector('.btn-clear')).not.toBeNull();
+
+    s = await createFromTemplate(s, HTMLSnippets.READONLY_SEARCH_FIELD);
+    s.clearable = true;
+    expect(s.container.querySelector('.btn-clear')).toBeNull();
+    s.clearableForced = true;
+    expect(s.container.querySelector('.btn-clear')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR changes `clearable-forced` to `clearable` setting in the main `ids-search-field` example and adds func test for the setting.

**Related github/jira issue (required)**:
Closes #1027

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-search-field/example.html
- check `Read-only Search Bar` example
- see there is no the X button and the field can't be cleared
- run func tests

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
~- [ ] A note to the change log.~
