### PR TITLE
1017 - IdsLookup fix dirty tracking in Safari

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Icons]` Added new empty state icons. ([#6934](https://github.com/infor-design/enterprise/issues/6934))
 - `[Icons]` Added feature to add custom icons ([#990](https://github.com/infor-design/enterprise-wc/issues/990))
 - `[ListView]` Fixed a bug where the component is showing errors when changing data by activating an item ([#1036](https://github.com/infor-design/enterprise-wc/issues/1036))
+- `[Lookup]` Fixed dirty tracking in Safari browser. ([#1017](https://github.com/infor-design/enterprise-wc/issues/1017))
 - `[Wizard]` Fixed dark/contrast mode colors. ([#1007](https://github.com/infor-design/enterprise-wc/issues/1007))
 
 ## 1.0.0-beta.2

--- a/src/components/ids-lookup/ids-lookup.ts
+++ b/src/components/ids-lookup/ids-lookup.ts
@@ -138,6 +138,7 @@ export default class IdsLookup extends Base {
       ${this.clearable ? ' clearable="true"' : ''}
       ${this.disabled ? ' disabled="true"' : ''}
       ${this.readonly ? ' readonly="true"' : ''}
+      ${this.dirtyTracker ? ' dirty-tracker="true"' : ''}
       ${this.compact ? ' compact' : ''}
       ${this.size ? ` size="${this.size}"` : ''}
       ${this.fieldHeight ? ` field-height="${this.fieldHeight}"` : ''}


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes dirty tracking for `ids-lookup` in Safari browser by adding `dirty-tracker` attribute for `ids-trigger-field` in the template

**Related github/jira issue (required)**:
Closes #1017 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-lookup/example.html in Safari
- check the `Normal Lookup (dirty-tracker)` example
- clear the input or change the input's value and see the dirty tracker icon appears

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
