### PR TITLE
1015 - IdsDatePicker fix validation date error message in Safari

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[DataGrid]` Fixed bug where filtered event fired when calling setFilterCondition() ([#1006](https://github.com/infor-design/enterprise-wc/issues/1006))
 - `[DatePicker]` Separated the "picker" portion of IdsDatePicker into its own component, allowing separate usage by other components. ([#958](https://github.com/infor-design/enterprise-wc/issues/958))
 - `[DatePicker/MonthView]` Fixed a circular dependency issue between Date Pickers and Month Views. ([#959](https://github.com/infor-design/enterprise-wc/issues/959))
+- `[DatePicker]` Fixed validation date error message in Safari browser. ([#1015](https://github.com/infor-design/enterprise-wc/issues/1015))
 - `[Icons]` All icons have padding on top and bottom effectively making them 4px smaller by design. This change may require some UI corrections to css. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Over 60 new icons and 126 new industry focused icons. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Added new empty state icons. ([#6934](https://github.com/infor-design/enterprise/issues/6934))

--- a/src/components/ids-date-picker/ids-date-picker.ts
+++ b/src/components/ids-date-picker/ids-date-picker.ts
@@ -214,6 +214,7 @@ class IdsDatePicker extends Base {
             ${this.label ? `label="${this.label}"` : ''}
             placeholder="${this.placeholder}"
             size="${this.size}"
+            format="${this.format}"
             ${this.validate ? `validate="${this.validate}"` : ''}
             validation-events="${this.validationEvents}"
             value="${this.value}"
@@ -318,7 +319,6 @@ class IdsDatePicker extends Base {
     // Respond to container changing language
     this.offEvent('languagechange.date-picker-container');
     this.onEvent('languagechange.date-picker-container', getClosest(this, 'ids-container'), () => {
-      this.#setDateValidation();
       this.#setAvailableDateValidation();
     });
 
@@ -569,29 +569,6 @@ class IdsDatePicker extends Base {
       this.#triggerField.mask = this.useRange ? 'rangeDate' : 'date';
       this.#triggerField.maskOptions = { format: this.format, delimeter: this.rangeSettings.separator };
       this.#triggerField.value = this.value;
-    }
-  }
-
-  /**
-   * Valid date validation extend validation mixin
-   */
-  #setDateValidation(): void {
-    if (this.validate?.includes('date')) {
-      this.#triggerField?.addValidationRule({
-        id: 'date',
-        type: 'error',
-        message: this.locale?.translate('InvalidDate'),
-        check: (input: any) => {
-          if (!input.value) return true;
-
-          const date = this.locale.parseDate(
-            input.value,
-            this.format
-          );
-
-          return isValidDate(date);
-        }
-      });
     }
   }
 
@@ -876,7 +853,6 @@ class IdsDatePicker extends Base {
       this.#triggerField?.handleValidation();
     }
 
-    this.#setDateValidation();
     this.#setAvailableDateValidation();
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes validation date error message appears in Safari for valid dates by adding `format` for the `ids-trigger-field` and removing extra validation rule in date picker since the validation mixin has one already

**Related github/jira issue (required)**:
Closes #1015

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-date-picker/example.html in Safari
- check `Date Field (required)` example
- change the date, see no `Invalid Date` appears, enter invalid date see the message appears

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
