### PR TITLE
951 - IdsScrollView Fix buttons do not update after being clicked

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[Icons]` Added feature to add custom icons ([#990](https://github.com/infor-design/enterprise-wc/issues/990))
 - `[ListView]` Fixed a bug where the component is showing errors when changing data by activating an item ([#1036](https://github.com/infor-design/enterprise-wc/issues/1036))
 - `[Lookup]` Fixed dirty tracking in Safari browser. ([#1017](https://github.com/infor-design/enterprise-wc/issues/1017))
+- `[ScrollView]` Fixed buttons do not update after being clicked. ([#951](https://github.com/infor-design/enterprise-wc/issues/951))
 - `[Wizard]` Fixed dark/contrast mode colors. ([#1007](https://github.com/infor-design/enterprise-wc/issues/1007))
 
 ## 1.0.0-beta.2

--- a/src/components/ids-scroll-view/ids-scroll-view.ts
+++ b/src/components/ids-scroll-view/ids-scroll-view.ts
@@ -99,6 +99,12 @@ export default class IdsScrollView extends Base {
       }
     });
 
+    this.offEvent('touchstart.scroll-view-touch');
+    this.onEvent('touchstart.scroll-view-touch', this.container, () => {
+      // Reset the property so the controls can be updated when swipe
+      this.isClick = false;
+    });
+
     // Set selected state on scroll/swipe
     this.querySelectorAll('[slot]').forEach((elem: any, i: any) => {
       const scrollViewIndex = i;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes the issue in `ids-scroll-view` where control buttons do not update on swipe after being clicked

**Related github/jira issue (required)**:
Closes #951 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-scroll-view/example.html
- choose some mobile device in browser's device toolbar
- swipe left and right to scroll see that the buttons update to show which page your on
- click a button to select a page
- swipe left and right to scroll see the buttons update to show which page your on

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.