### PR TITLE
1061 - Fix placement of empty message with data grid

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[DataGrid]` Fixed a bug that when using disableClientFilter does not emit filtered event when empty. ([#1008](https://github.com/infor-design/enterprise-wc/issues/1008))
 - `[DataGrid]` Fixed a bug that tree/expanded formatters could not be extended as the tree would not expand. ([#1018](https://github.com/infor-design/enterprise-wc/issues/1018))
 - `[DataGrid]` Fixed bug where filtered event fired when calling setFilterCondition() ([#1006](https://github.com/infor-design/enterprise-wc/issues/1006))
+- `[DataGrid]` Fixed placement of empty message was not centered horizontally. ([#1061](https://github.com/infor-design/enterprise-wc/issues/1061))
 - `[DatePicker]` Separated the "picker" portion of IdsDatePicker into its own component, allowing separate usage by other components. ([#958](https://github.com/infor-design/enterprise-wc/issues/958))
 - `[DatePicker/MonthView]` Fixed a circular dependency issue between Date Pickers and Month Views. ([#959](https://github.com/infor-design/enterprise-wc/issues/959))
 - `[DatePicker]` Fixed validation date error message in Safari browser. ([#1015](https://github.com/infor-design/enterprise-wc/issues/1015))

--- a/src/components/ids-data-grid/demos/m3-features.html
+++ b/src/components/ids-data-grid/demos/m3-features.html
@@ -12,7 +12,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-data-grid id="m3-virtual-scroll" suppress-tooltips="true" suppress-empty-message="true" row-selection="multiple" virtual-scroll="true" row-height="md">
+        <ids-data-grid id="m3-virtual-scroll" suppress-tooltips="true" row-selection="multiple" virtual-scroll="true" row-height="md">
         </ids-data-grid>
       </ids-layout-grid-cell>
     </ids-layout-grid>

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -16,7 +16,11 @@ $cell-border-color: var(--ids-color-palette-slate-30);
 .ids-data-grid {
   ids-empty-message,
   ::slotted(ids-empty-message) {
+    left: 50%;
     margin-top: 36px;
+    position: sticky;
+    transform: translateX(-50%);
+    width: fit-content;
   }
 
   // Outside border and Background and sizing

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -616,7 +616,7 @@ export default class IdsDataGrid extends Base {
     this.onEvent('keydown.body', this, (e: KeyboardEvent) => {
       const isPrintableKey = e.key.length === 1;
       if (!this.activeCellEditor && isPrintableKey && e.key !== ' ') {
-        this.activeCell.node.startCellEdit();
+        this.activeCell?.node?.startCellEdit?.();
       }
     });
     return this;

--- a/src/components/ids-empty-message/ids-empty-message.scss
+++ b/src/components/ids-empty-message/ids-empty-message.scss
@@ -30,4 +30,12 @@
     padding: 0 16px 16px;
     text-align: center;
   }
+
+  @media all and (max-width: $breakpoint-sm) {
+    max-width: $breakpoint-xs - 20px;
+  }
+
+  @media all and (max-width: $breakpoint-xs) {
+    max-width: $breakpoint-xs - 100px;
+  }
 }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed placement of empty message was not centered horizontally with data grid.

**Related github/jira issue (required)**:
Closes #1061 

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-data-grid/m3-features.html
- Filter on `xxxxx` something that does not exist and hit enter
- Empty message should show
- Scroll horizontally header columns should scroll but empty message stay centered

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
