### PR TITLE
839 - Remove slot name for IdsClearableMixin clear button icons

### DIFF
--- a/src/mixins/ids-clearable-mixin/ids-clearable-mixin.ts
+++ b/src/mixins/ids-clearable-mixin/ids-clearable-mixin.ts
@@ -62,7 +62,6 @@ const IdsClearableMixin = <T extends Constraints>(superclass: T) => class extend
     const text = document.createElement('ids-text');
     icon.setAttribute('icon', 'close');
     icon.setAttribute('size', 'small');
-    icon.setAttribute('slot', 'icon');
     text.setAttribute('audible', 'true');
     text.textContent = 'clear';
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This is a followup fix for the work done in #1066 to remove named slots from IdsButton -- IdsClearableMixin was still creating icons assigned to a named slot, which was causing them to "disappear".  This PR fixes that issue and makes clearable buttons appear present.

**Related github/jira issue (required)**:
Closes #839 

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-search-field/example.html
- See that the "X" buttons inside the search fields are visible and work as expected
- Should also fix a handful of Percy tests
