### PR TITLE
1075 - IdsHyperlink Add option to show styling when no href

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[DatePicker]` Separated the "picker" portion of IdsDatePicker into its own component, allowing separate usage by other components. ([#958](https://github.com/infor-design/enterprise-wc/issues/958))
 - `[DatePicker/MonthView]` Fixed a circular dependency issue between Date Pickers and Month Views. ([#959](https://github.com/infor-design/enterprise-wc/issues/959))
 - `[DatePicker]` Fixed validation date error message in Safari browser. ([#1015](https://github.com/infor-design/enterprise-wc/issues/1015))
+- `[Hyperlink]` Added option to show styling when no href. ([#1075](https://github.com/infor-design/enterprise-wc/issues/1075))
 - `[Icons]` All icons have padding on top and bottom effectively making them 4px smaller by design. This change may require some UI corrections to css. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Over 60 new icons and 126 new industry focused icons. ([#6868](https://github.com/infor-design/enterprise/issues/6868))
 - `[Icons]` Added new empty state icons. ([#6934](https://github.com/infor-design/enterprise/issues/6934))

--- a/src/components/ids-hyperlink/README.MD
+++ b/src/components/ids-hyperlink/README.MD
@@ -34,6 +34,7 @@ A Disabled appearing hyperlink element.
 - `disabled` {boolean} Set the link to disabled
 - `href` {string} Set the links href to a url or file
 - `target` {string} Set the links target attribute. Valid values are '_blank' | '_self' | '_parent' | '_top' | frame name.
+- `allow-empty-href` {boolean} Allows underline and styling of the link when href attribute is empty
 - `mode` {string} Set the theme mode
 - `version` {string} Set the theme version
 

--- a/src/components/ids-hyperlink/README.MD
+++ b/src/components/ids-hyperlink/README.MD
@@ -34,7 +34,7 @@ A Disabled appearing hyperlink element.
 - `disabled` {boolean} Set the link to disabled
 - `href` {string} Set the links href to a url or file
 - `target` {string} Set the links target attribute. Valid values are '_blank' | '_self' | '_parent' | '_top' | frame name.
-- `allow-empty-href` {boolean} Allows underline and styling of the link when href attribute is empty
+- `allow-empty-href` {boolean} Allows underline and styling of the link when href attribute is empty. Defaults to true.
 - `mode` {string} Set the theme mode
 - `version` {string} Set the theme version
 

--- a/src/components/ids-hyperlink/demos/example.html
+++ b/src/components/ids-hyperlink/demos/example.html
@@ -34,6 +34,15 @@
         <ids-hyperlink href="http://www.example.com" tabindex="-1">Not Tabbable Link</ids-hyperlink>
       </ids-layout-grid-cell>
     </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Hyperlink (no href)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-hyperlink id="link-no-href">No Href Link</ids-hyperlink>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
   </ids-container>
 </body>
 </html>

--- a/src/components/ids-hyperlink/demos/example.ts
+++ b/src/components/ids-hyperlink/demos/example.ts
@@ -1,0 +1,8 @@
+import '../ids-hyperlink';
+import type IdsHyperlink from '../ids-hyperlink';
+
+const link = document.querySelector<IdsHyperlink>('#link-no-href');
+
+link?.addEventListener('click', (e) => {
+  console.info('No href link has been clicked', e);
+});

--- a/src/components/ids-hyperlink/ids-hyperlink.scss
+++ b/src/components/ids-hyperlink/ids-hyperlink.scss
@@ -230,7 +230,13 @@
 .ids-text-decoration-hover {
   text-decoration: none;
 
-  &[href]:hover {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+:host(:not([allow-empty-href='false'])) {
+  .ids-hyperlink:not(.ids-text-decoration-none):not(.ids-text-decoration-hover) {
     text-decoration: underline;
   }
 }

--- a/src/components/ids-hyperlink/ids-hyperlink.ts
+++ b/src/components/ids-hyperlink/ids-hyperlink.ts
@@ -34,11 +34,12 @@ export default class IdsHyperlink extends Base {
   static get attributes() {
     return [
       ...super.attributes,
+      attributes.ALLOW_EMPTY_HREF,
       attributes.COLOR,
       attributes.DISABLED,
-      attributes.HREF,
       attributes.FONT_SIZE,
       attributes.FONT_WEIGHT,
+      attributes.HREF,
       attributes.MODE,
       attributes.TARGET,
       attributes.TEXT_DECORATION
@@ -216,5 +217,23 @@ export default class IdsHyperlink extends Base {
 
   get fontWeight(): string | null {
     return this.getAttribute(attributes.FONT_WEIGHT);
+  }
+
+  /**
+   * Allows underline and styling of the link when href attribute is empty
+   * @param {string | boolean | null} value whether or not to allow underline when href attribute is empty
+   */
+  set allowEmptyHref(value: string | boolean | null) {
+    const boolVal = stringToBool(value);
+    this.setAttribute(attributes.ALLOW_EMPTY_HREF, String(boolVal));
+  }
+
+  get allowEmptyHref(): boolean {
+    const attrVal = this.getAttribute(attributes.ALLOW_EMPTY_HREF);
+    if (attrVal) {
+      return stringToBool(attrVal);
+    }
+
+    return true;
   }
 }

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -15,6 +15,7 @@ export const attributes = {
   ALIGN_X_LABELS: 'align-x-labels',
   ALIGN_Y: 'align-y',
   ALLOW_BLANK: 'allow-blank',
+  ALLOW_EMPTY_HREF: 'allow-empty-href',
   ALLOW_LINK: 'allow-link',
   ALLOW_ONE_PANE: 'allow-one-pane',
   ALT: 'alt',

--- a/test/ids-hyperlink/ids-hyperlink-func-test.ts
+++ b/test/ids-hyperlink/ids-hyperlink-func-test.ts
@@ -136,6 +136,15 @@ describe('IdsHyperlink Component', () => {
     expect(elem.fontWeight).toEqual(null);
   });
 
+  it('should handle allow-empty-href setting', () => {
+    expect(elem.allowEmptyHref).toBeTruthy();
+
+    elem.allowEmptyHref = false;
+
+    expect(elem.getAttribute('allow-empty-href')).toEqual('false');
+    expect(elem.allowEmptyHref).toBeFalsy();
+  });
+
   /* To do */
   // it('doesn\'t set the role attribute if one already exists', () => {
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds option to show styling when no href to `ids-hyperlink` component

**Related github/jira issue (required)**:
Closes #1075 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-hyperlink/example.html
- check No Href Link example
- see the underline and  logging to the console of the click event

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
