### PR TITLE
7067 - Fix about version

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.3 Fixes
 
 - `[General]` Fixed a list of issues in Safari browser. ([#956](https://github.com/infor-design/enterprise-wc/issues/956))
+- `[About]` Chrome no longer shows minor version on the about info so this has been removed. ([#7067](https://github.com/infor-design/enterprise/issues/7067))
 - `[AppMenu]` Updated main example to be consistent with 4.x. ([#852](https://github.com/infor-design/enterprise-wc/issues/852))
 - `[BarChart]` Added support to flip horizontal. ([#963](https://github.com/infor-design/enterprise-wc/issues/893))
 - `[Breadcrumb]` Fixed popup menu being cutoff in truncated example. ([#906](https://github.com/infor-design/enterprise-wc/issues/906))

--- a/src/utils/ids-device-env-specs-utils/ids-device-env-specs-utils.ts
+++ b/src/utils/ids-device-env-specs-utils/ids-device-env-specs-utils.ts
@@ -39,7 +39,10 @@ export function getSpecs() {
   } else if (nUAgent.indexOf('Chrome') !== -1) {
     verOffset = nUAgent.indexOf('Chrome');
     browser = 'Chrome';
-    appVersion = nUAgent.substring(verOffset + 7).substring(0, 3);
+    appVersion = nUAgent.substring(verOffset + 7);
+    if (Number(appVersion.substring(0, 3)) >= 108) {
+      appVersion = appVersion.substring(0, 3);
+    }
   } else if (nUAgent.indexOf('Safari') !== -1) {
     verOffset = nUAgent.indexOf('Safari');
     browser = 'Safari';

--- a/src/utils/ids-device-env-specs-utils/ids-device-env-specs-utils.ts
+++ b/src/utils/ids-device-env-specs-utils/ids-device-env-specs-utils.ts
@@ -39,7 +39,7 @@ export function getSpecs() {
   } else if (nUAgent.indexOf('Chrome') !== -1) {
     verOffset = nUAgent.indexOf('Chrome');
     browser = 'Chrome';
-    appVersion = nUAgent.substring(verOffset + 7);
+    appVersion = nUAgent.substring(verOffset + 7).substring(0, 3);
   } else if (nUAgent.indexOf('Safari') !== -1) {
     verOffset = nUAgent.indexOf('Safari');
     browser = 'Safari';


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
The version chrome gives no longer contains this info https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome.

Added this PR with 7067 to keep code bases in sync.


**Related github/jira issue (required)**:
Fixes #7067

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-about/example.html in chrome
- check browser version is only 108 with no additional info..

**Included in this Pull Request**:
- [x] A note to the change log.
