### PR TITLE
1073 - Add support for shift click selection with data grid

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[DataGrid]` Fixed a bug that tree/expanded formatters could not be extended as the tree would not expand. ([#1018](https://github.com/infor-design/enterprise-wc/issues/1018))
 - `[DataGrid]` Fixed bug where filtered event fired when calling setFilterCondition() ([#1006](https://github.com/infor-design/enterprise-wc/issues/1006))
 - `[DataGrid]` Fixed placement of empty message was not centered horizontally. ([#1061](https://github.com/infor-design/enterprise-wc/issues/1061))
+- `[DataGrid]` Added support for shift click selection. ([#1073](https://github.com/infor-design/enterprise-wc/issues/1073))
 - `[DatePicker]` Separated the "picker" portion of IdsDatePicker into its own component, allowing separate usage by other components. ([#958](https://github.com/infor-design/enterprise-wc/issues/958))
 - `[DatePicker/MonthView]` Fixed a circular dependency issue between Date Pickers and Month Views. ([#959](https://github.com/infor-design/enterprise-wc/issues/959))
 - `[DatePicker]` Fixed validation date error message in Safari browser. ([#1015](https://github.com/infor-design/enterprise-wc/issues/1015))

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -268,6 +268,7 @@ export default class IdsDataGrid extends Base {
       return;
     }
     if (this.body) this.body.innerHTML = this.virtualScroll ? this.bodyTemplate() : this.bodyInnerTemplate();
+    this.#resetLastSelectedRow();
     this.header?.setHeaderCheckbox();
 
     if (this.virtualScrollContainer) {
@@ -365,6 +366,66 @@ export default class IdsDataGrid extends Base {
   }
 
   /**
+   * Check if row is selected.
+   * @param {number} index The row index
+   * @returns {boolean} True, if row is selected
+   */
+  rowIsSelected(index: number): boolean {
+    return !!this.data[index].rowSelected;
+  }
+
+  /**
+   * Keep flag for last selected row
+   * @private
+   */
+  #lastSelectedRow: number | null = null;
+
+  /**
+   * Reset flag for last selected row
+   * @private
+   * @returns {void}
+   */
+  #resetLastSelectedRow(): void {
+    this.#lastSelectedRow = null;
+  }
+
+  /**
+   * Toggle rows selection between given index and last selected
+   * @private
+   * @param {number} index The row index
+   * @returns {void}
+   */
+  #toggleSelectionInBetween(index: number): void {
+    if (this.#lastSelectedRow === null) return;
+
+    const start = Math.min(index, this.#lastSelectedRow);
+    const end = Math.max(index, this.#lastSelectedRow);
+    const isSelected = this.rowIsSelected(index);
+    for (let i = start; i <= end; i++) {
+      if (isSelected) this.deSelectRow(i);
+      else this.selectRow(i);
+    }
+    this.#getSelection()?.removeAllRanges?.();
+    this.header.setHeaderCheckbox();
+
+    this.triggerEvent('selectionchanged', this, {
+      detail: { elem: this, selectedRows: this.selectedRows }
+    });
+  }
+
+  /**
+   * Get current selection
+   * @private
+   * @returns {Selection|null} The selection
+   */
+  #getSelection(): Selection | null {
+    if (!(this.shadowRoot as any)?.getSelection) {
+      return document.getSelection();
+    }
+    return (this.shadowRoot as any)?.getSelection();
+  }
+
+  /**
    * Handle all triggering and handling of events
    * @private
    */
@@ -405,6 +466,15 @@ export default class IdsDataGrid extends Base {
         }
       });
 
+      // Handle multiple or mixed selection
+      const handleMultipleOrMixedSelection = () => {
+        if ((this.rowSelection === 'multiple') || (this.rowSelection === 'mixed')) {
+          if (e.shiftKey && this.#lastSelectedRow !== null) this.#toggleSelectionInBetween(rowNum);
+          else row.toggleSelection();
+          this.#lastSelectedRow = rowNum;
+        } else row.toggleSelection();
+      };
+
       // Handle Expand/Collapse Clicking
       if (isClickable && isExpandButton) {
         row.toggleExpandCollapse();
@@ -414,7 +484,7 @@ export default class IdsDataGrid extends Base {
       // Handle mixed selection
       if (this.rowSelection === 'mixed') {
         if (cell.children[0]?.classList.contains('ids-data-grid-checkbox-container')) {
-          row.toggleSelection();
+          handleMultipleOrMixedSelection();
         } else {
           row.toggleRowActivation();
         }
@@ -423,12 +493,10 @@ export default class IdsDataGrid extends Base {
 
       // Handle selection if not disabled
       if (this.rowSelection !== false && this.rowSelection !== 'mixed') {
-        if (this.suppressRowClickSelection && cell.children[0]?.classList.contains('is-selection-checkbox')) {
-          row.toggleSelection();
-        }
-        if (!this.suppressRowClickSelection) {
-          row.toggleSelection();
-        }
+        if ((!this.suppressRowClickSelection) || (
+          this.suppressRowClickSelection
+          && cell.children[0]?.classList.contains('is-selection-checkbox')
+        )) handleMultipleOrMixedSelection();
       }
 
       // Handle Editing

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -2112,6 +2112,27 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.selectedRows.length).toBe(0);
     });
 
+    it('can shift click to select in between', () => {
+      const newColumns = deepClone(columns());
+      newColumns[0].id = 'selectionCheckbox';
+      newColumns[0].formatter = formatters.selectionCheckbox;
+      dataGrid.rowSelection = 'multiple';
+      dataGrid.columns = newColumns;
+      dataGrid.redraw();
+
+      expect(dataGrid.selectedRows.length).toBe(0);
+      dataGrid.shadowRoot.querySelector('.ids-data-grid-body .ids-data-grid-row:nth-child(2) .ids-data-grid-cell:nth-child(1)').click();
+      expect(dataGrid.selectedRows.length).toBe(1);
+      let event = new MouseEvent('click', { bubbles: true, shiftKey: true });
+      dataGrid.shadowRoot.querySelector('.ids-data-grid-body .ids-data-grid-row:nth-child(7) .ids-data-grid-cell:nth-child(1)').dispatchEvent(event);
+      expect(dataGrid.selectedRows.length).toBe(6);
+      dataGrid.shadowRoot.querySelector('.ids-data-grid-body .ids-data-grid-row:nth-child(6) .ids-data-grid-cell:nth-child(1)').click();
+      expect(dataGrid.selectedRows.length).toBe(5);
+      event = new MouseEvent('click', { bubbles: true, shiftKey: true });
+      dataGrid.shadowRoot.querySelector('.ids-data-grid-body .ids-data-grid-row:nth-child(4) .ids-data-grid-cell:nth-child(1)').dispatchEvent(event);
+      expect(dataGrid.selectedRows.length).toBe(3);
+    });
+
     it('can select the row ui via the row element', () => {
       const newColumns = deepClone(columns());
       newColumns[0].id = 'selectionCheckbox';


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added support for shift click selection with data grid.

**Related github/jira issue (required)**:
Closes #1073 

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-data-grid/multiple-selection.html
- Click on any row to select
- Hold shift key and click on any other row
- It should select all rows in between

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
