### PR TITLE
1044 - IdsButton/IdsTabs Add hide focus mixin

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Breadcrumb]` Fixed popup menu being cutoff in truncated example. ([#906](https://github.com/infor-design/enterprise-wc/issues/906))
 - `[Button]` Removed named `text/icon` slots, re-worked the `iconAlign` setting to use only the default slot, and updated all examples/tests/docs to use only the default slot ([#839](https://github.com/infor-design/enterprise-wc/issues/839))
 - `[Button]` Updated all button style variants to reflect new IDS designs. ([#1046](https://github.com/infor-design/enterprise-wc/issues/1046))
+- `[Button/Tabs]` Added hide focus mixin. ([#1044](https://github.com/infor-design/enterprise-wc/issues/1044))
 - `[Checkbox]` Fixed validate, dirty tracking and hitbox settings in Safari browser. ([#1013](https://github.com/infor-design/enterprise-wc/issues/1013))
 - `[DataGrid]` Added support for empty message. ([#648](https://github.com/infor-design/enterprise-wc/issues/648))
 - `[DataGrid]` Fixed some filter issues with datagrid. ([#932](https://github.com/infor-design/enterprise-wc/issues/932)

--- a/src/components/ids-button/demos/focus-on-click.html
+++ b/src/components/ids-button/demos/focus-on-click.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h2">Ids Button Focus On Click</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid cols="4" gap="md">
+      <ids-layout-grid-cell>
+        <p>
+          <ids-button type="primary" hide-focus="false">
+            <span>Action</span>
+          </ids-button>
+        </p>
+        <p>
+          <ids-button type="primary" hide-focus="false">
+            <ids-icon icon="folder"></ids-icon>
+            <span>Action</span>
+          </ids-button>
+        </p>
+        <p>
+          <ids-button type="secondary" hide-focus="false">
+            <span>Action</span>
+          </ids-button>
+        </p>
+        <p>
+          <ids-button type="secondary" hide-focus="false">
+            <ids-icon icon="folder"></ids-icon>
+            <span>Action</span>
+          </ids-button>
+        </p>
+      </ids-layout-grid-cell>
+
+      <ids-layout-grid-cell>
+        <p>
+          <ids-button type="tertiary" hide-focus="false">
+            <ids-icon icon="folder"></ids-icon>
+            <span>Action</span>
+          </ids-button>
+        </p>
+        <p>
+          <ids-button hide-focus="false">
+            <ids-icon icon="folder"></ids-icon>
+            <span class="audible">Action</span>
+          </ids-button>
+        </p>
+        <p>
+          <ids-button type="primary-destructive" hide-focus="false">
+            <span>Action</span>
+          </ids-button>
+        </p>
+        <p>
+          <ids-button type="tertiary-destructive" hide-focus="false">
+            <ids-icon icon="folder"></ids-icon>
+            <span>Action</span>
+          </ids-button>
+        </p>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-button/demos/index.yaml
+++ b/src/components/ids-button/demos/index.yaml
@@ -17,6 +17,9 @@
   - link: responsive.html
     type: Example
     description: Showing a button width setting
+  - link: focus-on-click.html
+    type: Example
+    description: Showing a button focuses on click
   - link: side-by-side.html
     type: Side By Side
     description: Showing an button with a 4.x button

--- a/src/components/ids-button/ids-button-base.scss
+++ b/src/components/ids-button/ids-button-base.scss
@@ -152,7 +152,7 @@ $ids-button-rounded-size: 8px;
     @include text-slate-60();
 
     &.is-active,
-    &:focus {
+    &:not(.hide-focus):focus {
       @include border-azure-50();
     }
 
@@ -177,7 +177,7 @@ $ids-button-rounded-size: 8px;
       @include text-alert-error();
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include border-ruby-70();
       }
 
@@ -205,7 +205,7 @@ $ids-button-rounded-size: 8px;
       color: var(--ids-color-brand-primary-contrast);
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         border-color: var(--ids-color-brand-primary-base);
       }
 
@@ -234,7 +234,7 @@ $ids-button-rounded-size: 8px;
       @include text-white();
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include border-alert-error();
       }
 
@@ -264,7 +264,7 @@ $ids-button-rounded-size: 8px;
       @include text-azure-70();
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include border-azure-70();
       }
 
@@ -331,7 +331,7 @@ $ids-button-rounded-size: 8px;
       opacity: 0.7;
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include border-white();
 
         opacity: 1;
@@ -363,7 +363,7 @@ $ids-button-rounded-size: 8px;
         opacity: 1;
 
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include border-ruby-30();
         }
 
@@ -395,7 +395,7 @@ $ids-button-rounded-size: 8px;
         opacity: 1;
 
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include border-azure-40();
         }
 
@@ -428,7 +428,7 @@ $ids-button-rounded-size: 8px;
         opacity: 1;
 
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include border-ruby-70();
         }
 
@@ -460,7 +460,7 @@ $ids-button-rounded-size: 8px;
         opacity: 1;
 
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include border-azure-40();
         }
 
@@ -488,7 +488,7 @@ $ids-button-rounded-size: 8px;
       opacity: 0.8;
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         border-color: var(--ids-color-palette-azure-50);
       }
 
@@ -514,7 +514,7 @@ $ids-button-rounded-size: 8px;
     @include text-white();
 
     &.is-active,
-    &:focus {
+    &:not(.hide-focus):focus {
       @include border-azure-50();
     }
 
@@ -539,7 +539,7 @@ $ids-button-rounded-size: 8px;
       @include text-ruby-40();
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include border-ruby-40();
       }
 
@@ -639,7 +639,7 @@ $ids-button-rounded-size: 8px;
       @include text-white();
 
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include border-white();
       }
 
@@ -659,7 +659,7 @@ $ids-button-rounded-size: 8px;
         @include text-ruby-40();
 
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include border-ruby-50();
         }
 
@@ -685,7 +685,7 @@ $ids-button-rounded-size: 8px;
 
       &.btn-primary {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include border-azure-40();
         }
 
@@ -734,7 +734,7 @@ $ids-button-rounded-size: 8px;
         @include text-azure-60();
 
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include border-azure-60();
         }
 
@@ -1063,20 +1063,20 @@ $ids-button-rounded-size: 8px;
     &[mode='light'],
     &:not([mode]) {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include simple-shadow(rgba(0 114 237 / 0.3)); // Azure06
       }
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include simple-shadow(rgba(255 255 255 / 0.7));
         }
       }
 
       &.color-variant-alternate-formatter {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include simple-shadow(simple-shadow(rgba(0 114 237 / 0.3))); // Azure06
         }
       }
@@ -1084,20 +1084,20 @@ $ids-button-rounded-size: 8px;
 
     &[mode='dark'] {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include simple-shadow(rgba(85 163 243 / 0.3)); // Azure04
       }
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include simple-shadow(rgba(255 255 255 / 0.7));
         }
       }
 
       &.color-variant-alternate-formatter {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include shadow();
         }
       }
@@ -1131,14 +1131,14 @@ $ids-button-rounded-size: 8px;
     &[mode='light'],
     &:not([mode]) {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include shadow-error();
       }
 
       &.color-variant-alternate,
       &.color-variant-alternate-formatter {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include simple-shadow(rgba(237 148 149 / 0.3)); // Ruby03
         }
       }
@@ -1146,14 +1146,14 @@ $ids-button-rounded-size: 8px;
 
     &[mode='dark'] {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include simple-shadow(rgba(237 148 149 / 0.3)); // Ruby03
       }
 
       &.color-variant-alternate,
       &.color-variant-alternate-formatter {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include simple-shadow(rgba(237 148 149 / 0.3)); // Ruby03
         }
       }
@@ -1181,7 +1181,7 @@ $ids-button-rounded-size: 8px;
     &[mode='light'],
     &:not([mode]) {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-white),
           var(--ids-color-palette-azure-60)
@@ -1190,7 +1190,7 @@ $ids-button-rounded-size: 8px;
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-70),
             var(--ids-color-palette-white)
@@ -1204,7 +1204,7 @@ $ids-button-rounded-size: 8px;
 
     &[mode='dark'] {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-100),
           var(--ids-color-palette-azure-40)
@@ -1213,7 +1213,7 @@ $ids-button-rounded-size: 8px;
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-black),
             var(--ids-color-palette-white)
@@ -1252,7 +1252,7 @@ $ids-button-rounded-size: 8px;
     &[mode='light'],
     &:not([mode]) {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-white),
           var(--ids-color-palette-ruby-60)
@@ -1261,7 +1261,7 @@ $ids-button-rounded-size: 8px;
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-70),
             var(--ids-color-palette-ruby-30)
@@ -1274,7 +1274,7 @@ $ids-button-rounded-size: 8px;
     // Primary Destructive Dark Mode
     &[mode='dark'] {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-100),
           var(--ids-color-palette-ruby-40)
@@ -1283,7 +1283,7 @@ $ids-button-rounded-size: 8px;
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-100),
             var(--ids-color-palette-ruby-40)
@@ -1321,7 +1321,7 @@ $ids-button-rounded-size: 8px;
     &[mode='light'],
     &:not([mode]) {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-10),
           var(--ids-color-palette-azure-60)
@@ -1330,7 +1330,7 @@ $ids-button-rounded-size: 8px;
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-70),
             var(--ids-color-palette-white)
@@ -1343,7 +1343,7 @@ $ids-button-rounded-size: 8px;
     // Secondary Dark Mode
     &[mode='dark'] {
       &.is-active,
-      &:focus {
+      &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-100),
           var(--ids-color-palette-azure-40)
@@ -1352,7 +1352,7 @@ $ids-button-rounded-size: 8px;
 
       &.color-variant-alternate {
         &.is-active,
-        &:focus {
+        &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-black),
             var(--ids-color-palette-white)

--- a/src/components/ids-button/ids-button-base.scss
+++ b/src/components/ids-button/ids-button-base.scss
@@ -151,7 +151,7 @@ $ids-button-rounded-size: 8px;
     @include border-transparent();
     @include text-slate-60();
 
-    &.is-active,
+    &:not(.hide-focus).is-active,
     &:not(.hide-focus):focus {
       @include border-azure-50();
     }
@@ -176,7 +176,7 @@ $ids-button-rounded-size: 8px;
     &.btn-tertiary-destructive {
       @include text-alert-error();
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include border-ruby-70();
       }
@@ -204,7 +204,7 @@ $ids-button-rounded-size: 8px;
       border-color: var(--ids-color-brand-primary-base);
       color: var(--ids-color-brand-primary-contrast);
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         border-color: var(--ids-color-brand-primary-base);
       }
@@ -233,7 +233,7 @@ $ids-button-rounded-size: 8px;
       @include border-alert-error();
       @include text-white();
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include border-alert-error();
       }
@@ -263,7 +263,7 @@ $ids-button-rounded-size: 8px;
       @include border-azure-70();
       @include text-azure-70();
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include border-azure-70();
       }
@@ -330,7 +330,7 @@ $ids-button-rounded-size: 8px;
 
       opacity: 0.7;
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include border-white();
 
@@ -362,7 +362,7 @@ $ids-button-rounded-size: 8px;
 
         opacity: 1;
 
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include border-ruby-30();
         }
@@ -394,7 +394,7 @@ $ids-button-rounded-size: 8px;
         color: var(--ids-color-brand-primary-contrast);
         opacity: 1;
 
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include border-azure-40();
         }
@@ -427,7 +427,7 @@ $ids-button-rounded-size: 8px;
 
         opacity: 1;
 
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include border-ruby-70();
         }
@@ -459,7 +459,7 @@ $ids-button-rounded-size: 8px;
 
         opacity: 1;
 
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include border-azure-40();
         }
@@ -487,7 +487,7 @@ $ids-button-rounded-size: 8px;
     &.color-variant-alternate-formatter {
       opacity: 0.8;
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         border-color: var(--ids-color-palette-azure-50);
       }
@@ -513,7 +513,7 @@ $ids-button-rounded-size: 8px;
   &[mode='dark'] {
     @include text-white();
 
-    &.is-active,
+    &:not(.hide-focus).is-active,
     &:not(.hide-focus):focus {
       @include border-azure-50();
     }
@@ -538,7 +538,7 @@ $ids-button-rounded-size: 8px;
     &.btn-tertiary-destructive {
       @include text-ruby-40();
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include border-ruby-40();
       }
@@ -638,7 +638,7 @@ $ids-button-rounded-size: 8px;
     &.color-variant-alternate {
       @include text-white();
 
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include border-white();
       }
@@ -658,7 +658,7 @@ $ids-button-rounded-size: 8px;
       &.btn-tertiary-destructive {
         @include text-ruby-40();
 
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include border-ruby-50();
         }
@@ -684,7 +684,7 @@ $ids-button-rounded-size: 8px;
       // Dark Mode Primary Alternate
 
       &.btn-primary {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include border-azure-40();
         }
@@ -733,7 +733,7 @@ $ids-button-rounded-size: 8px;
         @include border-azure-60();
         @include text-azure-60();
 
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include border-azure-60();
         }
@@ -1062,20 +1062,20 @@ $ids-button-rounded-size: 8px;
     // Default/Tertiary Default/Light Mode
     &[mode='light'],
     &:not([mode]) {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include simple-shadow(rgba(0 114 237 / 0.3)); // Azure06
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include simple-shadow(rgba(255 255 255 / 0.7));
         }
       }
 
       &.color-variant-alternate-formatter {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include simple-shadow(simple-shadow(rgba(0 114 237 / 0.3))); // Azure06
         }
@@ -1083,20 +1083,20 @@ $ids-button-rounded-size: 8px;
     }
 
     &[mode='dark'] {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include simple-shadow(rgba(85 163 243 / 0.3)); // Azure04
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include simple-shadow(rgba(255 255 255 / 0.7));
         }
       }
 
       &.color-variant-alternate-formatter {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include shadow();
         }
@@ -1130,14 +1130,14 @@ $ids-button-rounded-size: 8px;
     // Tertiary Destructive Default/Light Mode
     &[mode='light'],
     &:not([mode]) {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include shadow-error();
       }
 
       &.color-variant-alternate,
       &.color-variant-alternate-formatter {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include simple-shadow(rgba(237 148 149 / 0.3)); // Ruby03
         }
@@ -1145,14 +1145,14 @@ $ids-button-rounded-size: 8px;
     }
 
     &[mode='dark'] {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include simple-shadow(rgba(237 148 149 / 0.3)); // Ruby03
       }
 
       &.color-variant-alternate,
       &.color-variant-alternate-formatter {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include simple-shadow(rgba(237 148 149 / 0.3)); // Ruby03
         }
@@ -1180,7 +1180,7 @@ $ids-button-rounded-size: 8px;
     // Primary Default/Light Mode
     &[mode='light'],
     &:not([mode]) {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-white),
@@ -1189,7 +1189,7 @@ $ids-button-rounded-size: 8px;
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-70),
@@ -1203,7 +1203,7 @@ $ids-button-rounded-size: 8px;
     // Primary Dark Mode
 
     &[mode='dark'] {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-100),
@@ -1212,7 +1212,7 @@ $ids-button-rounded-size: 8px;
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-black),
@@ -1251,7 +1251,7 @@ $ids-button-rounded-size: 8px;
     // Primary Destructive Default/Light Mode
     &[mode='light'],
     &:not([mode]) {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-white),
@@ -1260,7 +1260,7 @@ $ids-button-rounded-size: 8px;
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-70),
@@ -1273,7 +1273,7 @@ $ids-button-rounded-size: 8px;
     // ====================================================
     // Primary Destructive Dark Mode
     &[mode='dark'] {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-100),
@@ -1282,7 +1282,7 @@ $ids-button-rounded-size: 8px;
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-100),
@@ -1320,7 +1320,7 @@ $ids-button-rounded-size: 8px;
     // Secondary Default/Light Mode
     &[mode='light'],
     &:not([mode]) {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-10),
@@ -1329,7 +1329,7 @@ $ids-button-rounded-size: 8px;
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-slate-70),
@@ -1342,7 +1342,7 @@ $ids-button-rounded-size: 8px;
     // ====================================================
     // Secondary Dark Mode
     &[mode='dark'] {
-      &.is-active,
+      &:not(.hide-focus).is-active,
       &:not(.hide-focus):focus {
         @include outset-button-shadow(
           var(--ids-color-palette-slate-100),
@@ -1351,7 +1351,7 @@ $ids-button-rounded-size: 8px;
       }
 
       &.color-variant-alternate {
-        &.is-active,
+        &:not(.hide-focus).is-active,
         &:not(.hide-focus):focus {
           @include outset-button-shadow(
             var(--ids-color-palette-black),
@@ -1394,8 +1394,8 @@ $ids-button-rounded-size: 8px;
     background-color: var(--ids-color-brand-primary-contrast);
     color: var(--ids-color-brand-primary-base);
 
-    &.is-active,
-    &:focus {
+    &:not(.hide-focus).is-active,
+    &:not(.hide-focus):focus {
       @include modal-button-shadow();
     }
 
@@ -1422,8 +1422,8 @@ $ids-button-rounded-size: 8px;
     background-color: var(--ids-color-brand-primary-contrast);
     color: var(--ids-color-brand-secondary-contrast);
 
-    &.is-active,
-    &:focus {
+    &:not(.hide-focus).is-active,
+    &:not(.hide-focus):focus {
       @include modal-button-shadow();
     }
 

--- a/src/components/ids-button/ids-button-base.ts
+++ b/src/components/ids-button/ids-button-base.ts
@@ -4,6 +4,7 @@ import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsThemeMixin from '../../mixins/ids-theme-mixin/ids-theme-mixin';
 import IdsTooltipMixin from '../../mixins/ids-tooltip-mixin/ids-tooltip-mixin';
 import IdsRippleMixin from '../../mixins/ids-ripple-mixin/ids-ripple-mixin';
+import IdsHideFocusMixin from '../../mixins/ids-hide-focus-mixin/ids-hide-focus-mixin';
 import IdsElement from '../../core/ids-element';
 
 const Base = IdsTooltipMixin(
@@ -11,8 +12,10 @@ const Base = IdsTooltipMixin(
     IdsLocaleMixin(
       IdsRippleMixin(
         IdsColorVariantMixin(
-          IdsEventsMixin(
-            IdsElement
+          IdsHideFocusMixin(
+            IdsEventsMixin(
+              IdsElement
+            )
           )
         )
       )

--- a/src/components/ids-button/ids-button.ts
+++ b/src/components/ids-button/ids-button.ts
@@ -29,6 +29,7 @@ import type IdsText from '../ids-text/ids-text';
  * @mixes IdsRippleMixin
  * @mixes IdsThemeMixin
  * @mixes IdsTooltipMixin
+ * @mixes IdsHideFocusMixin
  * @part button - the button element
  * @part icon - the icon element
  * @part text - the text element

--- a/src/components/ids-tabs/ids-tab-base.ts
+++ b/src/components/ids-tabs/ids-tab-base.ts
@@ -2,13 +2,16 @@ import IdsEventsMixin from '../../mixins/ids-events-mixin/ids-events-mixin';
 import IdsColorVariantMixin from '../../mixins/ids-color-variant-mixin/ids-color-variant-mixin';
 import IdsOrientationMixin from '../../mixins/ids-orientation-mixin/ids-orientation-mixin';
 import IdsThemeMixin from '../../mixins/ids-theme-mixin/ids-theme-mixin';
+import IdsHideFocusMixin from '../../mixins/ids-hide-focus-mixin/ids-hide-focus-mixin';
 import IdsElement from '../../core/ids-element';
 
 const Base = IdsColorVariantMixin(
   IdsOrientationMixin(
     IdsThemeMixin(
-      IdsEventsMixin(
-        IdsElement
+      IdsHideFocusMixin(
+        IdsEventsMixin(
+          IdsElement
+        )
       )
     )
   )

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -143,9 +143,9 @@ $ids-tab-vertical-height: 42px;
   height: 100%;
   user-select: none;
 
-  &:focus-visible,
-  &:focus,
-  &:focus-within {
+  &:not(.hide-focus):focus-visible,
+  &:not(.hide-focus):focus,
+  &:not(.hide-focus):focus-within {
     @include shadow();
     @include border-solid();
 
@@ -246,7 +246,7 @@ $ids-tab-vertical-height: 42px;
     height: $ids-tab-vertical-height;
 
     &.selected {
-      &:focus {
+      &:not(.hide-focus):focus {
         @include ids-tabs-focus-border();
       }
     }
@@ -312,9 +312,9 @@ $ids-tab-vertical-height: 42px;
       }
     }
 
-    &:focus-visible,
-    &:focus,
-    &:focus-within {
+    &:not(.hide-focus):focus-visible,
+    &:not(.hide-focus):focus,
+    &:not(.hide-focus):focus-within {
       &:not(.disabled) {
         @include ids-tabs-focus-border();
       }
@@ -347,9 +347,9 @@ $ids-tab-vertical-height: 42px;
         @include text-azure-60;
       }
 
-      &:focus-visible,
-      &:focus,
-      &:focus-within {
+      &:not(.hide-focus):focus-visible,
+      &:not(.hide-focus):focus,
+      &:not(.hide-focus):focus-within {
         @include border-azure-60();
       }
 
@@ -380,7 +380,7 @@ $ids-tab-vertical-height: 42px;
           @include bg-azure-60();
           @include text-white();
 
-          &:focus {
+          &:not(.hide-focus):focus {
             @include border-none();
 
             &::before {
@@ -405,9 +405,9 @@ $ids-tab-vertical-height: 42px;
         }
       }
 
-      &:focus-visible,
-      &:focus,
-      &:focus-within {
+      &:not(.hide-focus):focus-visible,
+      &:not(.hide-focus):focus,
+      &:not(.hide-focus):focus-within {
         @include border-white();
       }
 
@@ -472,9 +472,9 @@ $ids-tab-vertical-height: 42px;
         @include text-white();
       }
 
-      &:focus-visible,
-      &:focus,
-      &:focus-within {
+      &:not(.hide-focus):focus-visible,
+      &:not(.hide-focus):focus,
+      &:not(.hide-focus):focus-within {
         @include border-azure-40();
       }
 
@@ -508,7 +508,7 @@ $ids-tab-vertical-height: 42px;
           @include bg-azure-60();
           @include text-white();
 
-          &:focus {
+          &:not(.hide-focus):focus {
             @include border-none();
 
             &::before {
@@ -533,9 +533,9 @@ $ids-tab-vertical-height: 42px;
         }
       }
 
-      &:focus-visible,
-      &:focus,
-      &:focus-within {
+      &:not(.hide-focus):focus-visible,
+      &:not(.hide-focus):focus,
+      &:not(.hide-focus):focus-within {
         @include border-white();
       }
 

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -14,9 +14,12 @@ type IdsTabOnActionCallback = (isSelected: boolean) => void;
  * IDS Tab Component
  * @type {IdsTab}
  * @inherits IdsElement
- * @part container - the tab container itself
+ * @mixes IdsColorVariantMixin
+ * @mixes IdsOrientationMixin
+ * @mixes IdsThemeMixin
+ * @mixes IdsHideFocusMixin
  * @mixes IdsEventsMixin
- * @private
+ * @part container - the tab container itself
  */
 @customElement('ids-tab')
 @scss(styles)

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -166,6 +166,7 @@ export const attributes = {
   HIDDEN_BY_FILTER: 'hidden-by-filter',
   HIDE_CHECKBOXES: 'hide-checkboxes',
   HIDE_DOWN: 'hide-down',
+  HIDE_FOCUS: 'hide-focus',
   HIDE_UP: 'hide-up',
   HIGHLIGHTED: 'highlighted',
   HITBOX: 'hitbox',

--- a/src/mixins/ids-hide-focus-mixin/README.md
+++ b/src/mixins/ids-hide-focus-mixin/README.md
@@ -1,3 +1,17 @@
 # Ids Hide Focus Mixin
 
+Toggles CSS class for a component container depends on how the component receives focus, clicked or on key entry (tabs or arrows).
 
+This mixin adds one observed attribute to a component:
+
+- `hide-focus` {boolean}: Whether or not the mixin should be enabled. Defaults to true
+
+Events:
+- `hidefocusadd` - Fires when the CSS class is added
+- `hidefocusremove` - Fires when the CSS class is removed
+
+To use this mixin in your component:
+
+1. Import `IdsHideFocusMixin` and add to the component base.ts file
+2. Add `IdsHideFocusMixin` to the @mixes comment section
+3. Use `.hide-focus` class in the component styles to adjust focus state

--- a/src/mixins/ids-hide-focus-mixin/README.md
+++ b/src/mixins/ids-hide-focus-mixin/README.md
@@ -1,0 +1,3 @@
+# Ids Hide Focus Mixin
+
+

--- a/src/mixins/ids-hide-focus-mixin/ids-hide-focus-mixin.ts
+++ b/src/mixins/ids-hide-focus-mixin/ids-hide-focus-mixin.ts
@@ -5,6 +5,12 @@ import { EventsMixinInterface } from '../ids-events-mixin/ids-events-mixin';
 
 type Constraints = IdsConstructor<EventsMixinInterface>;
 
+/**
+ * Toggles CSS class for a component container depends on how the component receives focus,
+ * clicked or on key entry (tabs or arrows).
+ * @param {any} superclass Accepts a superclass and creates a new subclass from it
+ * @returns {any} The extended object
+ */
 const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extends superclass {
   constructor(...args: any[]) {
     super(...args);
@@ -17,8 +23,14 @@ const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extend
     ];
   }
 
+  /**
+   * @property {boolean} isClick indicates if the component being clicked
+   */
   #isClick = false;
 
+  /**
+   * @property {boolean} isFocused indicates if the component is focused on key entry
+   */
   #isFocused = false;
 
   connectedCallback() {
@@ -35,6 +47,11 @@ const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extend
     this.#removeHideFocusEvents();
   }
 
+  /**
+   * Set up event listeners
+   * @private
+   * @returns {void}
+   */
   #attachHideFocusEvents() {
     this.#removeHideFocusEvents();
 
@@ -48,10 +65,7 @@ const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extend
     });
     this.onEvent('focusout.hide-focus', this, (e) => {
       this.#addCssClass();
-
-      this.#isClick = false;
       this.#isFocused = false;
-
       this.triggerEvent('hidefocusadd', this, e);
     });
     this.onEvent('mousedown.hide-focus', this, (e) => {
@@ -75,6 +89,10 @@ const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extend
     this.container?.classList.remove('hide-focus');
   }
 
+  /**
+   * Set whether or not the functionality should be enabled. Enabled by default
+   * @param {string|boolean|null} value hide-focus attribute value
+   */
   set hideFocus(value: string | boolean | null) {
     const boolVal = stringToBool(value);
     this.setAttribute(attributes.HIDE_FOCUS, String(boolVal));
@@ -88,6 +106,10 @@ const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extend
     }
   }
 
+  /**
+   * hide-focus attribute
+   * @returns {boolean} hideFocus param converted to boolean from attribute value. Defaults to true
+   */
   get hideFocus(): boolean {
     const attrVal = this.getAttribute(attributes.HIDE_FOCUS);
 

--- a/src/mixins/ids-hide-focus-mixin/ids-hide-focus-mixin.ts
+++ b/src/mixins/ids-hide-focus-mixin/ids-hide-focus-mixin.ts
@@ -1,0 +1,90 @@
+import { attributes } from '../../core/ids-attributes';
+import { IdsConstructor } from '../../core/ids-element';
+import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
+import { EventsMixinInterface } from '../ids-events-mixin/ids-events-mixin';
+
+type Constraints = IdsConstructor<EventsMixinInterface>;
+
+const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extends superclass {
+  constructor(...args: any[]) {
+    super(...args);
+  }
+
+  static get attributes() {
+    return [
+      ...(superclass as any).attributes,
+      attributes.HIDE_FOCUS
+    ];
+  }
+
+  #isClick = false;
+
+  #isFocused = false;
+
+  connectedCallback() {
+    super.connectedCallback?.();
+    this.#attachHideFocusEvents();
+    this.#addCssClass();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback?.();
+    this.#removeHideFocusEvents();
+  }
+
+  #attachHideFocusEvents() {
+    this.#removeHideFocusEvents();
+
+    this.onEvent('focusin.hide-focus', this, (e) => {
+      if (!this.#isClick && !this.#isFocused) {
+        this.#removeCssClass();
+        this.triggerEvent('hidefocusremove', this, e);
+      }
+      this.#isClick = false;
+      this.#isFocused = true;
+    });
+    this.onEvent('focusout.hide-focus', this, (e) => {
+      this.#addCssClass();
+
+      this.#isClick = false;
+      this.#isFocused = false;
+
+      this.triggerEvent('hidefocusadd', this, e);
+    });
+    this.onEvent('mousedown.hide-focus', this, (e) => {
+      this.#isClick = true;
+      this.#addCssClass();
+      this.triggerEvent('hidefocusadd', this, e);
+    });
+  }
+
+  #removeHideFocusEvents() {
+    this.offEvent('focusin.hide-focus');
+    this.offEvent('focusout.hide-focus');
+    this.offEvent('mousedown.hide-focus');
+  }
+
+  #addCssClass() {
+    this.container?.classList.add('hide-focus');
+  }
+
+  #removeCssClass() {
+    this.container?.classList.remove('hide-focus');
+  }
+
+  set hideFocus(value: string | boolean | null) {
+    const boolVal = stringToBool(value);
+    this.setAttribute(attributes.HIDE_FOCUS, String(boolVal));
+  }
+
+  get hideFocus(): boolean {
+    const attrVal = this.getAttribute(attributes.HIDE_FOCUS);
+    if (attrVal) {
+      return stringToBool(attrVal);
+    }
+
+    return true;
+  }
+};
+
+export default IdsHideFocusMixin;

--- a/src/mixins/ids-hide-focus-mixin/ids-hide-focus-mixin.ts
+++ b/src/mixins/ids-hide-focus-mixin/ids-hide-focus-mixin.ts
@@ -23,8 +23,11 @@ const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extend
 
   connectedCallback() {
     super.connectedCallback?.();
-    this.#attachHideFocusEvents();
-    this.#addCssClass();
+
+    if (this.hideFocus) {
+      this.#attachHideFocusEvents();
+      this.#addCssClass();
+    }
   }
 
   disconnectedCallback() {
@@ -75,15 +78,20 @@ const IdsHideFocusMixin = <T extends Constraints>(superclass: T) => class extend
   set hideFocus(value: string | boolean | null) {
     const boolVal = stringToBool(value);
     this.setAttribute(attributes.HIDE_FOCUS, String(boolVal));
+
+    if (boolVal) {
+      this.#addCssClass();
+      this.#attachHideFocusEvents();
+    } else {
+      this.#removeCssClass();
+      this.#removeHideFocusEvents();
+    }
   }
 
   get hideFocus(): boolean {
     const attrVal = this.getAttribute(attributes.HIDE_FOCUS);
-    if (attrVal) {
-      return stringToBool(attrVal);
-    }
 
-    return true;
+    return attrVal ? stringToBool(attrVal) : true;
   }
 };
 

--- a/test/mixins/ids-hide-focus-mixin-func-test.ts
+++ b/test/mixins/ids-hide-focus-mixin-func-test.ts
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import IdsButton from '../../src/components/ids-button/ids-button';
+
+describe('IdsHideFocusMixin Tests', () => {
+  let idsButton: any;
+
+  beforeEach(async () => {
+    // create ids button
+    idsButton = new IdsButton();
+    idsButton.innerHTML = '<span>Default Button</span>';
+    document.body.appendChild(idsButton);
+  });
+
+  afterEach(async () => {
+    // clear body
+    document.body.innerHTML = '';
+  });
+
+  it('should add ripple effect on click.ripple', async () => {
+
+  });
+});

--- a/test/mixins/ids-hide-focus-mixin-func-test.ts
+++ b/test/mixins/ids-hide-focus-mixin-func-test.ts
@@ -4,21 +4,33 @@
 import IdsButton from '../../src/components/ids-button/ids-button';
 
 describe('IdsHideFocusMixin Tests', () => {
-  let idsButton: any;
+  let button: any;
 
-  beforeEach(async () => {
-    // create ids button
-    idsButton = new IdsButton();
-    idsButton.innerHTML = '<span>Default Button</span>';
-    document.body.appendChild(idsButton);
+  beforeEach(() => {
+    button = new IdsButton();
+    button.innerHTML = '<span>Default Button</span>';
+    document.body.appendChild(button);
   });
 
-  afterEach(async () => {
-    // clear body
+  afterEach(() => {
     document.body.innerHTML = '';
   });
 
-  it('should add ripple effect on click.ripple', async () => {
+  it('should add/remove CSS class on property/attribute change', () => {
+    expect(button.hideFocus).toBeTruthy();
+    expect(button.container.classList.contains('hide-focus')).toBeTruthy();
 
+    button.hideFocus = false;
+
+    expect(button.hideFocus).toBeFalsy();
+    expect(button.getAttribute('hide-focus')).toEqual('false');
+    expect(button.container.classList.contains('hide-focus')).toBeFalsy();
+  });
+
+  it('should add/remove CSS class on click/focus', async () => {
+    button.focus();
+    expect(button.container.classList.contains('hide-focus')).toBeFalsy();
+    button.dispatchEvent(new MouseEvent('mousedown'));
+    expect(button.container.classList.contains('hide-focus')).toBeTruthy();
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds `IdsHideFocusMixin` to toggle `hide-focus` CSS class for a component's container depends on how the component receives focus, click or a keyboard key.
The mixin was added to `ids-button` and `ids-tab`.
The mixin was tested on checkbox, radio, switch, input and related components.

Note: it doesn't work in Safari browser same as EP implementation and it looks like there are no workarounds since Safari doesn't focus buttons

**Related github/jira issue (required)**:
Closes #1044

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-button/example.html
- press Tab on your keyboard and see there is visible focus on every non disabled button
- click on a button and see there is no focus (for light and dark mode)
- switch to contrast mode and see the focus is visible on click
- go to http://localhost:4300/ids-button/focus-on-click.html where `hide-focus` is turned off
- see the focus is visible on click
- go to http://localhost:4300/ids-tabs/example.html
- see the focus is visible when tabbing to the active tab and right/left arrow key, the focus is not visible on click on a tab
- compare to EP example https://main-enterprise.demo.design.infor.com/components/button/example-index.html 

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
