### PR TITLE
1136 - Add hidden theme switcher example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "js/ts.implicitProjectConfig.experimentalDecorators": true,
   "editor.tabSize": 2,
-  "files.eol" : "\n"
+  "editor.formatOnSave": false,
+  "files.eol": "\n"
 }

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.7 Fixes
 
 - `[Locale]` Locale information files and messages are now separate from the build. They must be served as assets from the `node_modules/ids-enterprise-wc/locale-data` folder. ([#1107](https://github.com/infor-design/enterprise-wc/issues/1107))
+- `[ThemeSwitcher]` Added ability to hide the theme switcher and still use it. ([#1136](https://github.com/infor-design/enterprise-wc/issues/1136))
 - `[Trigger Field]` Fixed trigger field buttons padding. ([#1091](https://github.com/infor-design/enterprise-wc/issues/1091))
 
 ## 1.0.0-beta.6

--- a/src/components/ids-theme-switcher/demos/hidden.html
+++ b/src/components/ids-theme-switcher/demos/hidden.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="dark" hidden></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Themes</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <ids-tag>Normal Tag</ids-tag>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-theme-switcher/demos/index.yaml
+++ b/src/components/ids-theme-switcher/demos/index.yaml
@@ -8,4 +8,8 @@
   - link: example.html
     type: Main Example
     description: Showing a tag with the switcher
+  - link: hidden.html
+    type: Example
+    description: Showing a switcher that is hidden but still functional
+
 

--- a/src/components/ids-theme-switcher/ids-theme-switcher.scss
+++ b/src/components/ids-theme-switcher/ids-theme-switcher.scss
@@ -9,3 +9,7 @@
   justify-content: flex-end;
   padding: 0;
 }
+
+:host([hidden]) {
+  display: none;
+}

--- a/src/components/ids-theme-switcher/ids-theme-switcher.ts
+++ b/src/components/ids-theme-switcher/ids-theme-switcher.ts
@@ -6,9 +6,10 @@ import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsElement from '../../core/ids-element';
 
 import type IdsText from '../ids-text/ids-text';
+import '../ids-menu-button/ids-menu-button';
 import styles from './ids-theme-switcher.scss';
 import type IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
-import '../ids-menu-button/ids-menu-button';
+import type IdsMenuButton from '../ids-menu-button/ids-menu-button';
 
 const Base = IdsLocaleMixin(
   IdsColorVariantMixin(

--- a/src/components/ids-theme-switcher/ids-theme-switcher.ts
+++ b/src/components/ids-theme-switcher/ids-theme-switcher.ts
@@ -8,7 +8,7 @@ import IdsElement from '../../core/ids-element';
 import type IdsText from '../ids-text/ids-text';
 import styles from './ids-theme-switcher.scss';
 import type IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
-import IdsMenuButton from '../ids-menu-button/ids-menu-button';
+import '../ids-menu-button/ids-menu-button';
 
 const Base = IdsLocaleMixin(
   IdsColorVariantMixin(
@@ -35,7 +35,6 @@ export default class IdsThemeSwitcher extends Base {
   connectedCallback() {
     super.connectedCallback();
     this.popup = this.shadowRoot?.querySelector('ids-popup-menu');
-    this.menuButton = new IdsMenuButton();
     this.menuButton = this.shadowRoot?.querySelector('ids-menu-button');
     this.menuButton?.configureMenu();
     this.#attachEventHandlers();

--- a/src/components/ids-theme-switcher/ids-theme-switcher.ts
+++ b/src/components/ids-theme-switcher/ids-theme-switcher.ts
@@ -37,7 +37,7 @@ export default class IdsThemeSwitcher extends Base {
     super.connectedCallback();
     this.popup = this.shadowRoot?.querySelector('ids-popup-menu');
     this.menuButton = this.shadowRoot?.querySelector('ids-menu-button');
-    this.menuButton?.configureMenu();
+    if (this.menuButton?.configureMenu) this.menuButton?.configureMenu();
     this.#attachEventHandlers();
   }
 

--- a/src/components/ids-theme-switcher/ids-theme-switcher.ts
+++ b/src/components/ids-theme-switcher/ids-theme-switcher.ts
@@ -6,10 +6,9 @@ import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsElement from '../../core/ids-element';
 
 import type IdsText from '../ids-text/ids-text';
-import '../ids-menu-button/ids-menu-button';
 import styles from './ids-theme-switcher.scss';
 import type IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
-import type IdsMenuButton from '../ids-menu-button/ids-menu-button';
+import IdsMenuButton from '../ids-menu-button/ids-menu-button';
 
 const Base = IdsLocaleMixin(
   IdsColorVariantMixin(
@@ -36,8 +35,9 @@ export default class IdsThemeSwitcher extends Base {
   connectedCallback() {
     super.connectedCallback();
     this.popup = this.shadowRoot?.querySelector('ids-popup-menu');
+    this.menuButton = new IdsMenuButton();
     this.menuButton = this.shadowRoot?.querySelector('ids-menu-button');
-    if (this.menuButton?.configureMenu) this.menuButton?.configureMenu();
+    this.menuButton?.configureMenu();
     this.#attachEventHandlers();
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Quick fix for being able to hide a theme switcher. Added a guard and css to hide it. As noted in support chat

**Related github/jira issue (required)**:
Fixes #1136 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-theme-switcher/hidden.html
- theme switcher should be hidden and theme should be set to dark
- try and change the theme to light in the <ids-theme-switcher> in the DOM

**Included in this Pull Request**:
- [x] A note to the change log.

