### PR TITLE
1138 - Add alert colors/custom icons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "js/ts.implicitProjectConfig.experimentalDecorators": true,
   "editor.tabSize": 2,
-  "files.eol" : "\n"
+  "files.eol": "\n",
+  "editor.formatOnSave": false
 }

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.7 Fixes
 
+- `[Alert]` Added the ability to use any icon and set any alert color on the alerts. ([#1138](https://github.com/infor-design/enterprise-wc/issues/1138))
 - `[Locale]` Locale information files and messages are now separate from the build. They must be served as assets from the `node_modules/ids-enterprise-wc/locale-data` folder. ([#1107](https://github.com/infor-design/enterprise-wc/issues/1107))
 - `[Trigger Field]` Fixed trigger field buttons padding. ([#1091](https://github.com/infor-design/enterprise-wc/issues/1091))
 

--- a/src/components/ids-alert/README.md
+++ b/src/components/ids-alert/README.md
@@ -6,16 +6,17 @@ The IDS Alert component used to communicate as part of a display message that gi
 
 ## Use Cases
 
-Typically, these alerts are mostly effective to gain attention of the status of your application.
+Typically, these alerts are mostly effective to gain attention of the status of your application. Try to use text along with the alert so that users that cant understand the color difference get the important alert information.
 
 ## Terminology
 
 - **Type**: Type is basically the status of an alert.
 - **Icon**: Icon is the symbol of the alert.
+- **Color**: The type of alert color.
 
 ## Feature (With the Code Examples)
 
-An alert is created by using the `ids-alert`. It has a `type` property to set the desire alert icon.
+An alert is created by using the `ids-alert` html custom element. It has a `icon` property to set the desire alert icon to use.
 
 ```html
 <ids-alert icon="info"></ids-alert>
@@ -32,7 +33,19 @@ An alert can be used in a disabled situation so comes with a disabled style
 An alert can have a tooltip
 
 ```html
-<ids-alert icon="errorr" tooltip="Info about the error"></ids-alert>
+<ids-alert icon="error" tooltip="Info about the error"></ids-alert>
+```
+
+An alert can use any icon, use the color setting with it to control the icon color
+
+```html
+<ids-alert icon="calendar" color="info" tooltip="Calendar Alert"></ids-alert
+```
+
+An alert can use any icon size
+
+```html
+<ids-alert icon="error" tooltip="Info about the error"  size="small"></ids-alert>
 ```
 
 ## Class Hierarchy
@@ -45,9 +58,10 @@ An alert can have a tooltip
 
 ## Settings (Attributes)
 
-- `icon` {boolean} Set the type of icon / alert to show options include  'alert' | 'success' | 'dirty' | 'error' | 'info' |'pending' | 'new' | 'in-progress'
+- `icon` {boolean} Set the type of icon / alert to show options include  'alert' | 'success' | 'dirty' | 'error' | 'info' |'pending' | 'new' | 'in-progress' or any other icon in the icon set. For these other icons set the color property as well
 - `disabled` {boolean} Set alert to disabled
-- `tooltip` {string} Sets the string content for a tooltip
+- `tooltip` {string} Sets the string content for a tooltip, for error, success, info, alert the color of the tooltip will change
+- `color` {string} Sets the icon color between error, success, info, alert, amber, amethyst
 
 ## Themeable Parts
 
@@ -67,21 +81,13 @@ Alert icons do not have tab stops or keyboard interaction on their own. However,
 
 - Flows within its parent/placement and is usually centered vertically.
 
-## Alternate Designs
-
-Icons differ in the two provided theme/icon versions.
-
 ## Accessibility
 
-The traffic light colors are accessibility violations for contrast, however, the high contrast theme provides an alternative that passes. In addition, in context text should be used as color alone cannot provide the meaning.
-
-## Regional Considerations
-
-Some icons that indicate direction will be flipped when in Right-To-Left languages. This is a TODO still.
+The traffic light colors are accessibility violations for contrast, however, the high contrast theme provides an alternative that passes. In addition, in context text should be used as color alone cannot provide the meaning. i.e. Do not use color alone to indicate a state.
 
 ## Converting from Previous Versions (Breaking Changes)
 
 **4.x to 5.x**
-- About now uses all new markup and classes for web components (see above)
+- Alert now uses all new markup and classes for web components (see above)
 - The yellow alert is no longer available due to having poor contrast with the background.
 - The names of some alerts (icon setting) have changed

--- a/src/components/ids-alert/demos/example.html
+++ b/src/components/ids-alert/demos/example.html
@@ -21,7 +21,9 @@
       <ids-layout-grid-cell><ids-alert icon="empty-circle" tooltip="Empty"></ids-alert></ids-layout-grid-cell>
       <ids-layout-grid-cell><ids-alert icon="half-empty-circle" tooltip="Half Empty"></ids-alert></ids-layout-grid-cell>
       <ids-layout-grid-cell><ids-alert icon="new" tooltip="New"></ids-alert></ids-layout-grid-cell>
-   </ids-layout-grid>
+      <ids-layout-grid-cell><ids-alert icon="calendar" color="info" tooltip="Calendar Alert"></ids-alert></ids-layout-grid-cell>
+      <ids-layout-grid-cell><ids-alert icon="blood" color="error" tooltip="Blood Alert" size="small"></ids-alert></ids-layout-grid-cell>
+    </ids-layout-grid>
   </ids-container>
 </body>
 </html>

--- a/src/components/ids-alert/ids-alert.scss
+++ b/src/components/ids-alert/ids-alert.scss
@@ -6,6 +6,7 @@
 
   &.success,
   &.success-solid,
+  [color='success'],
   [icon='success'],
   [icon='success-solid'] {
     @include text-alert-success();
@@ -17,6 +18,7 @@
 
   &.alert,
   &.alert-solid,
+  [color='alert'],
   [icon='alert'],
   [icon='alert-solid'] {
     @include text-alert-warning();
@@ -28,6 +30,7 @@
 
   &.info,
   &.info-solid,
+  [color='info'],
   [icon='info'],
   [icon='info-solid'] {
     @include text-alert-info();
@@ -39,6 +42,7 @@
 
   &.error,
   &.error-solid,
+  [color='error'],
   [icon='error'],
   [icon='error-solid'] {
     @include text-alert-error();
@@ -50,6 +54,7 @@
 
   &.new,
   &.new-solid,
+  [color='amber'],
   [icon='new'],
   [icon='new-solid'] {
     color: var(--ids-color-palette-amber-70);
@@ -61,6 +66,7 @@
 
   &.in-progress,
   &.in-progress-solid,
+  [color='amethyst'],
   [icon='in-progress'],
   [icon='in-progress-solid'] {
     color: var(--ids-color-palette-amethyst-70);

--- a/src/components/ids-alert/ids-alert.ts
+++ b/src/components/ids-alert/ids-alert.ts
@@ -38,7 +38,8 @@ export default class IdsAlert extends IdsTooltipMixin(IdsThemeMixin(IdsEventsMix
   beforeTooltipShow(tooltip?: any) {
     // Color the tooltip
     if (tooltip.popup) {
-      tooltip.popup?.container?.classList.add(`${this.toolTipTarget.getAttribute('icon')}-color`);
+      const hasColor = this.toolTipTarget.getAttribute('color');
+      tooltip.popup?.container?.classList.add(`${hasColor || this.toolTipTarget.getAttribute('icon')}-color`);
       tooltip.popup.y = 12;
     }
   }
@@ -50,6 +51,7 @@ export default class IdsAlert extends IdsTooltipMixin(IdsThemeMixin(IdsEventsMix
   static get attributes() {
     return [
       ...super.attributes,
+      attributes.COLOR,
       attributes.DISABLED,
       attributes.ICON,
       attributes.TOOLTIP,
@@ -64,6 +66,23 @@ export default class IdsAlert extends IdsTooltipMixin(IdsThemeMixin(IdsEventsMix
   template(): string {
     const cssClass = stringToBool(this.disabled) ? ' class="disabled"' : '';
     return `<ids-icon size="${this.size}"${cssClass} icon="${this.icon}" part="icon"></ids-icon>`;
+  }
+
+  /**
+   * Set the alert color
+   * @param {string|null} value The color to use between: error, success, info, alert, amber, amethyst
+   */
+  set color(value: string | null) {
+    if (value) {
+      this.setAttribute(attributes.COLOR, value);
+      this.shadowRoot?.querySelector('ids-icon')?.setAttribute(attributes.COLOR, value);
+    } else {
+      this.removeAttribute(attributes.COLOR);
+    }
+  }
+
+  get color(): string | null {
+    return this.getAttribute(attributes.COLOR);
   }
 
   /**

--- a/src/components/ids-tag/ids-tag.ts
+++ b/src/components/ids-tag/ids-tag.ts
@@ -70,7 +70,7 @@ export default class IdsTag extends Base {
 
   /**
    * Set the tag color
-   * @param {string|null} value The color value, this can be not provided,
+   * @param {string|null} value The color to use between
    * secondary (white), error, success, danger, caution or a hex code with the #
    */
   set color(value: string | null) {

--- a/test/ids-alert/ids-alert-func-test.ts
+++ b/test/ids-alert/ids-alert-func-test.ts
@@ -105,4 +105,13 @@ describe('IdsAlert Component', () => {
     el.size = '';
     expect(el.size).toEqual('normal');
   });
+
+  it('supports setting color', () => {
+    expect(el.color).toEqual(null);
+    el.color = 'error';
+    expect(el.color).toEqual('error');
+    expect(el.container?.getAttribute('color')).toEqual('error');
+    el.color = '';
+    expect(el.color).toEqual(null);
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds the ability to use any icon for alerts. In order to not break things added a `color` property to set the alert color. The `size` property already worked as did the `icon` property to set to any icon.

**Related github/jira issue (required)**:
Fixes #1138 

**Steps necessary to review your pull request (required)**:
- review PR and docs
- go to http://localhost:4300/ids-alert/example.html
- notice last two icons are "non-alert" icons
- notice the size changes on the last icon
- notice the color is set to an alert color
- hover it

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
