### PR TITLE
IdsCalendar - Improvements to Event Customization

### DIFF
--- a/src/components/ids-calendar/demos/custom-calendar-event-manager.ts
+++ b/src/components/ids-calendar/demos/custom-calendar-event-manager.ts
@@ -1,0 +1,102 @@
+import { CalendarEventTypeData } from '../ids-calendar-event';
+import IdsCustomCalendarEvent from './custom-calendar-event';
+
+export default class CustomCalendarEventManager {
+  #CUSTOM_MAX_EVENT_COUNT = 3;
+
+  #eventPositionMap = new Map();
+
+  #eventPillAttributesMap = new Map();
+
+  /**
+   * Calculates the event Y_OFFSET value to set the event pill top position
+   * @param {IdsCustomCalendarEvent} calendarEvent IdsCustomCalendarEvent
+   * @returns {number} yOffset
+   */
+  generateYOffset(calendarEvent: IdsCustomCalendarEvent): number {
+    const eventTypeData = calendarEvent.eventTypeData;
+    const dateKey = calendarEvent.dateKey;
+    const order = calendarEvent.order;
+    let position = 0;
+    if (eventTypeData && order <= 3) {
+      // space between event pills
+      this.manageEventPillsPosition(dateKey, order, eventTypeData);
+      // position event element vertically
+      if (order === 0) {
+        position = 20;
+      } else if (this.#eventPositionMap.get(`${dateKey}_${order}`)) {
+        position = this.#eventPositionMap.get(`${dateKey}_${order}`);
+      } else {
+        // if event-types data doesn't contain noOfAttributes and attr values
+        position = (order * 18) + 25;
+      }
+    }
+    return position;
+  }
+
+  /**
+   * Checks if the event pills exceed the MAX_EVENT_COUNT in a day cell
+   * @param {IdsCustomCalendarEvent} calendarEvent IdsCustomCalendarEvent
+   * @returns {boolean} isEventOverflowing
+   */
+  isEventOverflowing(calendarEvent: IdsCustomCalendarEvent): boolean {
+    return calendarEvent.order > this.#CUSTOM_MAX_EVENT_COUNT - 1;
+  }
+
+  /**
+   * Manage event pill position vetically based on the number of attributes displayed in first event pill
+   * @param {string} dateKey generated date key
+   * @param {number} eventOrder Events order
+   * @param {CalendarEventTypeData} eventType Event
+   */
+  manageEventPillsPosition(dateKey: string, eventOrder: number, eventType: CalendarEventTypeData | any) {
+    const MAX_EVENT_PILL_ATTR_COUNT = 5;
+    const noOfAttributes = eventType.attrs?.length;
+    if (eventOrder === 0) {
+      if (noOfAttributes === 3) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 58);
+      } else if (noOfAttributes === 2) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 55);
+      } else if (noOfAttributes === 1) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 40);
+      }
+      this.#eventPillAttributesMap.set(`${dateKey}_${eventOrder}`, noOfAttributes);
+    } else if (eventOrder === 1) {
+      const attributesCount = this.#eventPillAttributesMap.get(`${dateKey}_${eventOrder - 1}`);
+      if ((attributesCount + noOfAttributes) > MAX_EVENT_PILL_ATTR_COUNT) {
+        this.#CUSTOM_MAX_EVENT_COUNT = 1;
+      } else {
+        this.#CUSTOM_MAX_EVENT_COUNT = 2;
+      }
+
+      if (attributesCount === 3 && noOfAttributes === 1) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 70);
+      } else if (attributesCount === 2) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 70);
+      } else if (attributesCount === 1 && noOfAttributes === 1) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 60);
+      } else if (attributesCount === 1 && noOfAttributes === 2) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 70);
+      }
+      this.#eventPillAttributesMap.set(`${dateKey}_${eventOrder}`, noOfAttributes);
+    } else if (eventOrder === 2) {
+      const firstPillAttributesCount = this.#eventPillAttributesMap.get(`${dateKey}_${eventOrder - 2}`);
+      const secondPillAttributesCount = this.#eventPillAttributesMap.get(`${dateKey}_${eventOrder - 1}`);
+      if ((firstPillAttributesCount + secondPillAttributesCount + noOfAttributes)
+        >= MAX_EVENT_PILL_ATTR_COUNT) {
+        this.#CUSTOM_MAX_EVENT_COUNT = 2;
+      } else {
+        this.#CUSTOM_MAX_EVENT_COUNT = 3;
+      }
+
+      if (secondPillAttributesCount === 3) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 70);
+      } else if (secondPillAttributesCount === 2) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 85);
+      } else if (secondPillAttributesCount === 1) {
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 75);
+      }
+      this.#eventPillAttributesMap.set(`${dateKey}_${eventOrder}`, noOfAttributes);
+    }
+  }
+}

--- a/src/components/ids-calendar/demos/custom-calendar-event-manager.ts
+++ b/src/components/ids-calendar/demos/custom-calendar-event-manager.ts
@@ -56,7 +56,7 @@ export default class CustomCalendarEventManager {
       if (noOfAttributes === 3) {
         this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 58);
       } else if (noOfAttributes === 2) {
-        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 55);
+        this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 54);
       } else if (noOfAttributes === 1) {
         this.#eventPositionMap.set(`${dateKey}_${eventOrder + 1}`, 40);
       }

--- a/src/components/ids-calendar/demos/custom-calendar-event.ts
+++ b/src/components/ids-calendar/demos/custom-calendar-event.ts
@@ -56,7 +56,7 @@ export default class IdsCustomCalendarEvent extends IdsCalendarEvent {
     const icon = this.eventData.icon ? `<ids-icon class='calendar-event-icon' icon='${this.eventData.icon}' height='12' width='12'></ids-icon>` : '';
     this.eventTypesJson.push(this.eventTypeData);
 
-    if (this.eventTypesJson) {
+    if (this.eventTypesJson && this.eventTypeData) {
       const eventPillsAttr = this.eventTypesJson.filter((item: any) => item.id === this.eventData?.type);
       if (eventPillsAttr.length > 0 && eventPillsAttr[0].attrs) {
         if (eventPillsAttr[0].id === 'dto' || eventPillsAttr[0].id === 'admin' || eventPillsAttr[0].id === 'sick') {

--- a/src/components/ids-calendar/demos/custom-calendar-event.ts
+++ b/src/components/ids-calendar/demos/custom-calendar-event.ts
@@ -3,7 +3,6 @@ import styles from './custom-calendar-event.scss';
 import { customElement, scss } from '../../../core/ids-decorators';
 
 interface CustomCalendarEventTypeData extends CalendarEventTypeData {
-  noOfAttributes?: number;
   attrs?: [];
 }
 
@@ -14,7 +13,7 @@ export default class IdsCustomCalendarEvent extends IdsCalendarEvent {
 
   eventTypesJson: CustomCalendarEventTypeData[] | any = [];
 
-  eventPillHeight = '20px'; // Default height for 1 line event pill
+  eventPillHeight = '18px'; // Default height for 1 line event pill
 
   constructor() {
     super();
@@ -29,6 +28,9 @@ export default class IdsCustomCalendarEvent extends IdsCalendarEvent {
     if (this.container) {
       this.container.style.height = this.eventPillHeight;
     }
+
+    // overrides the day cell date text position
+    document.documentElement.style.setProperty('--ids-month-view-day-text-top', '2px');
   }
 
   template(): string {

--- a/src/components/ids-calendar/demos/example-custom.html
+++ b/src/components/ids-calendar/demos/example-custom.html
@@ -38,7 +38,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell auto="true">
-        <ids-calendar id="custom-calendar" date="10/22/2019" show-details>
+        <ids-calendar id="custom-calendar" date="10/22/2019" show-details view-picker>
           <ids-custom-calendar-event slot="MonthViewCalendarEventTemplate"></ids-custom-calendar-event>
         </ids-calendar>
       </ids-layout-grid-cell>

--- a/src/components/ids-calendar/demos/example-custom.ts
+++ b/src/components/ids-calendar/demos/example-custom.ts
@@ -1,4 +1,7 @@
 import eventsJSON from '../../../assets/data/events.json';
+import IdsCalendar from '../ids-calendar';
+import IdsCustomCalendarEvent from './custom-calendar-event';
+import CustomCalendarEventManager from './custom-calendar-event-manager';
 
 const eventsURL: any = eventsJSON;
 
@@ -11,8 +14,16 @@ function getCalendarEvents(): Promise<any> {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const calendar: any = document.querySelector('ids-calendar');
+  const calendar: any = document.querySelector<IdsCalendar>('ids-calendar');
   const addEventMenu = document.querySelector('#add-event');
+
+  const eventManager = new CustomCalendarEventManager();
+
+  calendar?.addEventListener('beforeeventrendered', () => {
+    const view = calendar?.getView();
+    view.generateYOffset = (event: IdsCustomCalendarEvent): number => eventManager.generateYOffset(event);
+    view.isEventOverflowing = (event: IdsCustomCalendarEvent): boolean => eventManager.isEventOverflowing(event);
+  });
 
   // Set event types
   calendar.eventTypesData = [
@@ -22,7 +33,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       translationKey: 'DiscretionaryTimeOff',
       color: 'azure',
       checked: true,
-      noOfAttributes: 2,
       attrs: [
         'subject',
         'time'
@@ -34,7 +44,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       translationKey: 'AdministrativeLeave',
       color: 'amethyst',
       checked: true,
-      noOfAttributes: 2,
       attrs: [
         'subject',
         'time'
@@ -46,7 +55,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       translationKey: 'TeamEvent',
       color: 'emerald',
       checked: true,
-      noOfAttributes: 3,
       attrs: [
         'subject',
         'time',
@@ -59,7 +67,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       translationKey: 'SickTime',
       color: 'amber',
       checked: true,
-      noOfAttributes: 2,
       attrs: [
         'subject',
         'time'
@@ -72,7 +79,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       color: 'slate',
       checked: true,
       disabled: true,
-      noOfAttributes: 1,
       attrs: [
         'subject'
       ]

--- a/src/components/ids-month-view/ids-month-view.scss
+++ b/src/components/ids-month-view/ids-month-view.scss
@@ -459,7 +459,7 @@
       @include z-1();
 
       left: calc(100% - 25px);
-      top: 13px;
+      top: var(--ids-month-view-day-text-top, 13px);
       width: 10px;
       text-align: center;
     }


### PR DESCRIPTION
Implemented logic to override the default calendar event with custom calendar multiline event display and also added logic to display number of event pills in a day cell with dynamic count.

**Related github/jira issue (required):**
"Fixes https://github.com/infor-design/enterprise-wc/issues/911"

**Steps necessary to review your pull request (required):**

Checkout branch, npm run start
Go to http://localhost:4300/ids-calendar/example-custom.html
Added new example specific for IdsCalendarEvent overriding in ids-custom-calendar-event.ts and added new class ids-custom-calendar-event-manger.ts under IDS Calendar demos to handle multiline event pill display along with number of event pills to be displayed in a day cell.
The following is the screenshot for the above mentioned calendar event overriding.

<img width="780" alt="Custom Calendar Event" src="https://user-images.githubusercontent.com/113168229/216048925-43f0d892-eef4-4a0f-96fa-2baa01f4b495.png">

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->