### PR TITLE
1126 - Fix datagrid tooltip to show without text overflow

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Badge]` Fixed uneven shape on badge icons. ([#1014](https://github.com/infor-design/enterprise-wc/issues/1014))
 - `[Build]` Updated `esbuild` to fix issues with import order. ([#1140](https://github.com/infor-design/enterprise-wc/issues/1140))
 - `[Calendar]` Added a `beforeeventrendered` and `aftereventrendered` event. ([#1131](https://github.com/infor-design/enterprise-wc/issues/1131))
+- `[DataGrid]` Fixed tooltip to show without text overflow. ([#1126](https://github.com/infor-design/enterprise-wc/issues/1126)
 - `[Icons]` Changed the way custom icons work so they can be used only at one time and from a file. ([#1122](https://github.com/infor-design/enterprise-wc/issues/1122))
 - `[Icons]` Clean up examples for icons. ([#509](https://github.com/infor-design/enterprise-wc/issues/509))
 - `[Locale]` Locale information files and messages are now separate from the build. They must be served as assets from the `node_modules/ids-enterprise-wc/locale-data` folder. ([#1107](https://github.com/infor-design/enterprise-wc/issues/1107))

--- a/src/components/ids-data-grid/demos/tooltip.ts
+++ b/src/components/ids-data-grid/demos/tooltip.ts
@@ -52,7 +52,7 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-tooltip')!;
           tooltipContent = `Async Text: ${text}<br/>Row: ${rowIndex}, Cell: ${columnIndex}`;
         }
         resolve(tooltipContent);
-      }, 500);
+      }, 300);
     });
   };
 
@@ -87,7 +87,7 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-tooltip')!;
     filterType: dataGrid.filters.integer,
     formatter: dataGrid.formatters.hyperlink,
     formatOptions: { group: '' },
-    width: 88,
+    width: 140,
     tooltip: 'This is a product Id',
     headerTooltip: 'This is the product Id header',
     filterButtonTooltip: 'This is the product Id filterButton',
@@ -174,7 +174,9 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-tooltip')!;
     resizable: true,
     reorderable: true,
     formatter: dataGrid.formatters.integer,
-    filterType: dataGrid.filters.integer
+    filterType: dataGrid.filters.integer,
+    tooltip: 'This is Unit Price',
+    headerTooltip: 'This is Unit Price header',
   });
   columns.push({
     id: 'units',

--- a/test/ids-data-grid/ids-data-grid-func-tooltip-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-tooltip-test.ts
@@ -222,6 +222,10 @@ const checkTooltip = async (elem: any, grid: any, tooltipEl: any, shouldSetWidth
   const textEllipsis = (link ? elem : elem.querySelector('.text-ellipsis'));
   expect(tooltipEl.visible).toEqual(false);
   expect(elem).toBeTruthy();
+  const showtooltipMockCallback = jest.fn(() => { });
+  const hidetooltipMockCallback = jest.fn(() => { });
+  grid.addEventListener('showtooltip', showtooltipMockCallback);
+  grid.addEventListener('showtooltip', hidetooltipMockCallback);
   const mouseover = new MouseEvent('mouseover', { bubbles: true });
   const mouseout = new MouseEvent('mouseout', { bubbles: true });
   const scroll = new MouseEvent('scroll', { bubbles: true });
@@ -237,10 +241,12 @@ const checkTooltip = async (elem: any, grid: any, tooltipEl: any, shouldSetWidth
   elem.dispatchEvent(mouseover);
   await wait(tooltipWait);
   expect(tooltipEl.visible).toEqual(true);
+  expect(showtooltipMockCallback.mock.calls.length).toBe(1);
   grid.container.dispatchEvent(scroll);
   expect(tooltipEl.visible).toEqual(false);
   grid.container.dispatchEvent(mouseout);
   expect(tooltipEl.visible).toEqual(false);
+  expect(hidetooltipMockCallback.mock.calls.length).toBe(1);
   if (shouldSetWidth) {
     Object.defineProperty(elem, 'offsetWidth', { configurable: true, value: orig.offsetWidth });
     Object.defineProperty(elem, 'scrollWidth', { configurable: true, value: orig.scrollWidth });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed datagrid tooltip to show without text overflow.

**Related github/jira issue (required)**:
Closes #1126

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
Navigate to: http://localhost:4300/ids-data-grid/tooltip.html
- Hover on columns `Custom Tooltip` and `Unit Price`
- Tooltip should show, see in those columns text not overflowed

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
