### PR TITLE
1064 - Use IdsTimePickerPopup in IdsDataGridFilter, fix containment/cutoff issues

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Build]` Updated `esbuild` to fix issues with import order. ([#1140](https://github.com/infor-design/enterprise-wc/issues/1140))
 - `[Calendar]` Added a `beforeeventrendered` and `aftereventrendered` event. ([#1131](https://github.com/infor-design/enterprise-wc/issues/1131))
 - `[DataGrid]` Fixed tooltip to show without text overflow. ([#1126](https://github.com/infor-design/enterprise-wc/issues/1126)
+- `[DataGrid/TimePicker]` IdsDataGrid now uses the IdsTimePickerPopup component inside Time-based filters. ([#1064](https://github.com/infor-design/enterprise-wc/issues/1064))
 - `[Icons]` Changed the way custom icons work so they can be used only at one time and from a file. ([#1122](https://github.com/infor-design/enterprise-wc/issues/1122))
 - `[Icons]` Clean up examples for icons. ([#509](https://github.com/infor-design/enterprise-wc/issues/509))
 - `[Locale]` Locale information files and messages are now separate from the build. They must be served as assets from the `node_modules/ids-enterprise-wc/locale-data` folder. ([#1107](https://github.com/infor-design/enterprise-wc/issues/1107))

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -526,7 +526,7 @@ export default class IdsDataGridFilters {
         if (filterType === 'date' || filterType === 'time') {
           if (/string|undefined/g.test(typeof value)) value = formatterVal();
           const getValues = (rValue: any, cValue: any) => {
-            const format = c.format || column.formatOptions;
+            const format = c.format || column.formatOptions || this.root.localeAPI?.calendar().timeFormat;
             cValue = this.root.localeAPI?.parseDate(cValue, format);
             if (cValue) {
               if (filterType === 'time') {

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -14,7 +14,7 @@ import '../ids-icon/ids-icon';
 import '../ids-trigger-field/ids-trigger-button';
 import '../ids-trigger-field/ids-trigger-field';
 import '../ids-date-picker/ids-date-picker-popup';
-import '../ids-time-picker/ids-time-picker';
+import '../ids-time-picker/ids-time-picker-popup';
 
 import type IdsMenuItem from '../ids-menu/ids-menu-item';
 import type IdsTriggerField from '../ids-trigger-field/ids-trigger-field';
@@ -208,7 +208,10 @@ export default class IdsDataGridFilters {
 
     return `
       ${this.#filterButtonTemplate(TYPE, column)}
-      <ids-time-picker
+      ${this.#triggerFieldTemplate(TYPE, column, 'clock', 'TimePickerTriggerButton')}
+      <ids-time-picker-popup
+        attachment=".ids-data-grid-wrapper"
+        trigger-type="click"
         color-variant="${!this.root.listStyle ? 'alternate-formatter' : 'alternate-list-formatter'}"
         data-filter-type="${TYPE}"
         size="${opt.size || 'full'}"
@@ -219,7 +222,7 @@ export default class IdsDataGridFilters {
         compact
         ${format}${placeholder}${minuteInterval}${secondInterval}
         ${autoselect}${autoupdate}${disabled}${readonly}${value}
-      ></ids-time-picker>
+      ></ids-time-picker-popup>
     `;
   }
 
@@ -742,6 +745,7 @@ export default class IdsDataGridFilters {
       const triggerBtn = node?.querySelector('ids-trigger-button');
       const triggerField = node?.querySelector('ids-trigger-field');
       const datePickerPopup = node?.querySelector('ids-date-picker-popup');
+      const timePickerPopup = node?.querySelector('ids-time-picker-popup');
       let menuAttachment = '.ids-data-grid-wrapper';
 
       // Slotted filter only
@@ -789,26 +793,33 @@ export default class IdsDataGridFilters {
 
       btn?.setAttribute('data-filter-conditions-button', '');
 
-      // Timepicker needs a different element to use for targeting outside clicks
-      // (normally it targets the body tag, but this causes usability issues when combined with data grid)
-      if (timePicker) {
-        timePicker.popupOpenEventsTarget = timePicker.closest('.ids-data-grid');
+      const dateOrTimePopup = datePickerPopup || timePickerPopup;
+      if (dateOrTimePopup) {
+        dateOrTimePopup.appendToTargetParent();
+        dateOrTimePopup.popupOpenEventsTarget = document.body;
+        dateOrTimePopup.onOutsideClick = (e: MouseEvent) => {
+          if (!e.composedPath().includes(dateOrTimePopup)) { dateOrTimePopup.hide(); }
+        };
+        dateOrTimePopup.setAttribute(attributes.TRIGGER_TYPE, 'click');
+        dateOrTimePopup.setAttribute(attributes.TARGET, `#${triggerField.getAttribute('id')}`);
+        dateOrTimePopup.setAttribute(attributes.TRIGGER_ELEM, `#${triggerBtn.getAttribute('id')}`);
+        dateOrTimePopup.popup.setAttribute(attributes.ARROW_TARGET, `#${triggerBtn.getAttribute('id')}`);
+        dateOrTimePopup.setAttribute(attributes.ATTACHMENT, menuAttachment);
+        dateOrTimePopup.refreshTriggerEvents();
       }
 
-      // Date picker adjust range settings
+      // Date Picker - Adjust range settings
       if (datePickerPopup) {
-        datePickerPopup.appendToTargetParent();
-        datePickerPopup.popupOpenEventsTarget = datePickerPopup.closest('.ids-data-grid-wrapper');
-        datePickerPopup.setAttribute(attributes.TRIGGER_TYPE, 'click');
-        datePickerPopup.setAttribute(attributes.TARGET, `#${triggerField.getAttribute('id')}`);
-        datePickerPopup.setAttribute(attributes.TRIGGER_ELEM, `#${triggerBtn.getAttribute('id')}`);
-        datePickerPopup.popup.setAttribute(attributes.ARROW_TARGET, `#${triggerBtn.getAttribute('id')}`);
-        datePickerPopup.setAttribute(attributes.ATTACHMENT, menuAttachment);
-        datePickerPopup.refreshTriggerEvents();
-
         const rangeSettings = column.filterOptions?.rangeSettings;
         if (rangeSettings) datePickerPopup.rangeSettings = rangeSettings;
         datePickerPopup.useRange = (btn?.menuEl?.getSelectedValues()[0] === 'in-range');
+      }
+
+      // Time Picker - Adjust format
+      if (timePickerPopup) {
+        const format = this.root.localeAPI?.calendar().timeFormat;
+        triggerField.format = format;
+        timePickerPopup.format = format;
       }
 
       // Integer type mask
@@ -855,6 +866,12 @@ export default class IdsDataGridFilters {
 
     // Capture 'dayselected' events from IdsDatePickerPopup
     this.root.onEvent(`dayselected.${this.#id()}`, this.root.wrapper, (e: any) => {
+      e.target.value = e.detail.value;
+      this.applyFilter();
+    });
+
+    // Capture 'timeselected' events from IdsTimePickerPopup
+    this.root.onEvent(`timeselected.${this.#id()}`, this.root.wrapper, (e: any) => {
       e.target.value = e.detail.value;
       this.applyFilter();
     });

--- a/src/components/ids-menu-button/ids-menu-button.ts
+++ b/src/components/ids-menu-button/ids-menu-button.ts
@@ -211,11 +211,16 @@ export default class IdsMenuButton extends IdsButton {
       return;
     }
     this.resizeMenu();
-    this.setPopupArrow();
     this.menuEl.triggerType = 'click';
     this.menuEl.target = this;
 
     this.setAttribute(htmlAttributes.ARIA_HASPOPUP, 'menu');
+
+    if (this.menuEl.popup) {
+      this.menuEl.popup.align = 'bottom, left';
+      this.menuEl.popup.y = 8;
+      this.setPopupArrow();
+    }
 
     // ====================================================================
     // Setup menu-specific event listeners, if they aren't already applied

--- a/src/components/ids-time-picker/demos/picker-only.ts
+++ b/src/components/ids-time-picker/demos/picker-only.ts
@@ -58,8 +58,12 @@ document.addEventListener('DOMContentLoaded', () => {
     demoIdsContainer.insertAdjacentHTML('beforeend', pickerHTML);
 
     const picker = document.querySelector<any>('ids-time-picker-popup')!;
-    picker.align = 'left, top';
-    picker.arrow = 'bottom';
+    if (picker.popup) {
+      picker.popup.align = 'bottom, left';
+      picker.popup.arrow = 'bottom';
+      picker.popup.x = 0;
+      picker.popup.y = 12;
+    }
 
     // Fix onOutsideClick to consider clicking on trigger buttons
     picker.onOutsideClick = (e: Event) => {
@@ -86,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (data) {
       if (picker) {
         if (picker.popup) {
-          picker.popup.align = 'left, top';
+          picker.popup.align = 'bottom, left';
           picker.popup.arrow = 'bottom';
           picker.popup.arrowTarget = `#${btnId}`;
         }
@@ -118,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (picker.popup) {
         picker.popup.arrow = 'bottom';
         picker.popup.arrowTarget = `#${btnId}`;
-        picker.popup.align = 'left, top';
+        picker.popup.align = 'bottom, left';
         if (!picker.popup.visible) {
           picker.show();
         } else if (picker.target !== currentTarget) {

--- a/src/components/ids-time-picker/ids-time-picker-popup.ts
+++ b/src/components/ids-time-picker/ids-time-picker-popup.ts
@@ -66,7 +66,7 @@ class IdsTimePickerPopup extends Base implements IdsPickerPopupCallbacks {
       return `<div class="ids-time-picker-popup embedded" part="container">${dropdownHTML}</div>`;
     }
 
-    return `<ids-popup class="ids-time-picker-popup" type="menu" tabindex="-1" part="popup" y="12" animated>
+    return `<ids-popup class="ids-time-picker-popup" type="menu" tabIndex="-1" align="bottom, left" arrow="bottom" part="popup" y="12" animated>
       <section slot="content">
         ${dropdownHTML}
         <ids-modal-button class="popup-btn" hidden="${this.autoupdate}" part="btn-set" type="primary">

--- a/src/components/ids-time-picker/ids-time-picker-popup.ts
+++ b/src/components/ids-time-picker/ids-time-picker-popup.ts
@@ -66,7 +66,7 @@ class IdsTimePickerPopup extends Base implements IdsPickerPopupCallbacks {
       return `<div class="ids-time-picker-popup embedded" part="container">${dropdownHTML}</div>`;
     }
 
-    return `<ids-popup class="ids-time-picker-popup" type="menu" tabindex="-1" part="popup" x="12" animated>
+    return `<ids-popup class="ids-time-picker-popup" type="menu" tabindex="-1" part="popup" y="12" animated>
       <section slot="content">
         ${dropdownHTML}
         <ids-modal-button class="popup-btn" hidden="${this.autoupdate}" part="btn-set" type="primary">

--- a/src/mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin.ts
+++ b/src/mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin.ts
@@ -200,11 +200,6 @@ const IdsPopupInteractionsMixin = <T extends Constraints>(superclass: T) => clas
     // Based on the trigger type, bind new events
     switch (this.state.triggerType) {
       case 'click':
-      // Configure some settings for opening
-        this.popup.align = 'bottom, left';
-        this.popup.arrow = 'bottom';
-        this.popup.y = 8;
-
         // Announce Popup control with `aria-controls` on the target
         if (targetElem.id && !(targetElem instanceof Window)) {
           targetElem.setAttribute('aria-controls', `${this.id}`);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR follows up #667's work on separation of IdsPopup-based filter popups from their host components and into standalone components that can be moved around freely in the DOM.  This PR enables IdsTimePickerPopup to work in place of the "built-in" picker component, fixing the stacking context issue in IdsDataGrid.

**Related github/jira issue (required)**:
Closes #1064
Related to #667

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/filter-trigger-fields.html
- Use the "Pub. Time" column filter to slim down the results set (I used 2:25 PM)
- Re-open the timepicker popup.  When it opens, the entire popup should be accessible.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
