### PR TITLE
1108 - Add Shortcut Key display feature to IdsPopupMenu

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.8 Fixes
 
 - `[Datagrid/Dropdown]` Separated IdsDropdownList into its own component, re-integrated the new component into IdsDropdown, and fixed containment/cutoff issues in IdsDataGrid using the new list component. ([#1065](https://github.com/infor-design/enterprise-wc/issues/1065))
+- `[Menu/Popup Menu]` Added Shortcut Key display feature to IdsMenuItem. ([#1108](https://github.com/infor-design/enterprise-wc/issues/1108))
 
 ## 1.0.0-beta.7
 

--- a/src/assets/data/menu-array.json
+++ b/src/assets/data/menu-array.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "group",
+    "items": [
+      {
+        "id": "item-1",
+        "text": "Item One",
+        "value": 1
+      },
+      {
+        "id": "item-2",
+        "text": "Item Two",
+        "value": 2
+      },
+      {
+        "id": "item-3",
+        "text": "Item Three",
+        "value": 3
+      }
+    ]
+  }
+]

--- a/src/assets/data/menu-shortcuts.json
+++ b/src/assets/data/menu-shortcuts.json
@@ -1,0 +1,54 @@
+{
+  "id": "popup-menu-shortcuts",
+  "comment": "This dataset demonstrates how to create a Popup Menu with shortcut keys",
+  "contents": [
+    {
+      "id": "shortcuts-group",
+      "select": "none",
+      "items": [
+        {
+          "id": "action-create",
+          "icon": "folder",
+          "shortcutKeys": "⌘+R",
+          "text": "Create new folder"
+        },
+        {
+          "id": "action-previous",
+          "shortcutKeys": "⌘+⇧+←",
+          "text": "Previous"
+        },
+        {
+          "id": "action-next",
+          "shortcutKeys": "⌘+⇧+→",
+          "text": "Next"
+        },
+        {
+          "type": "separator"
+        },
+        {
+          "id": "action-copy-to",
+          "text": "Copy to..."
+        },
+        {
+          "id": "action-move-to",
+          "text": "Move to..."
+        },
+        {
+          "id": "action-long-form",
+          "icon": "edit",
+          "shortcutKeys": "Cmd+Shift+R",
+          "text": "Long form shortcut text"
+        },
+        {
+          "type": "separator"
+        },
+        {
+          "id": "action-delete",
+          "icon": "delete",
+          "shortcutKeys": "⌘+⌥+⇧",
+          "text": "Delete folder"
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/ids-menu/README.md
+++ b/src/components/ids-menu/README.md
@@ -132,6 +132,19 @@ This next example will cause a either a `selected` OR `deselected` event, as wel
 </ids-menu>
 ```
 
+### Shortcut keys
+
+IdsMenuItem elements can have a `shortcut-keys` attribute defined, which will pass text representing a keyboard shortcut to be displayed into the white space opposite the regular text:
+
+```html
+<ids-menu-item id="action-create" icon="folder" shortcut-keys="⌘+R">Create New Folder</ids-menu-item>
+```
+
+```js
+const menuItem = document.querySelector('ids-menu-item');
+menuItem.setAttribute('shortcut-keys', '⌘+R');
+```
+
 ## Class Hierarchy Menu Group
 
 - IdsMenuGroup

--- a/src/components/ids-menu/ids-menu-attributes.ts
+++ b/src/components/ids-menu/ids-menu-attributes.ts
@@ -55,6 +55,7 @@ const MENU_DEFAULTS: any = {
   disabled: false,
   icon: null,
   selected: false,
+  shortcutKeys: null,
   submenu: null,
   tabIndex: 0,
   value: null,

--- a/src/components/ids-menu/ids-menu-attributes.ts
+++ b/src/components/ids-menu/ids-menu-attributes.ts
@@ -47,8 +47,8 @@ const MENU_GROUP_SELECT_TYPES = [
   'multiple'
 ];
 
-// @TODO handle other menu-item sizes
-const MENU_ITEM_SIZE = 'medium';
+// Size for menu item icons
+const MENU_ITEM_ICON_SIZE = 'small';
 
 // Default Button state values
 const MENU_DEFAULTS: any = {
@@ -114,5 +114,5 @@ function isUsableItem(item: any, idsMenu: any) {
 }
 
 export {
-  MENU_GROUP_SELECT_TYPES, MENU_ITEM_SIZE, MENU_DEFAULTS, safeForAttribute, isValidGroup, isUsableItem
+  MENU_GROUP_SELECT_TYPES, MENU_ITEM_ICON_SIZE, MENU_DEFAULTS, safeForAttribute, isValidGroup, isUsableItem
 };

--- a/src/components/ids-menu/ids-menu-attributes.ts
+++ b/src/components/ids-menu/ids-menu-attributes.ts
@@ -27,7 +27,7 @@ export type IdsMenuContentsData = Array<IdsMenuGroupData | IdsMenuSeparatorData 
 
 export type IdsMenuGroupData = {
   id?: string;
-  items: IdsMenuContentsData;
+  items: Array<IdsMenuItemData | IdsMenuSeparatorData | IdsMenuHeaderData>;
   select?: 'none' | 'single' | 'multiple';
   type?: 'group';
 };

--- a/src/components/ids-menu/ids-menu-attributes.ts
+++ b/src/components/ids-menu/ids-menu-attributes.ts
@@ -1,5 +1,45 @@
 import { getClosestRootNode } from '../../utils/ids-dom-utils/ids-dom-utils';
 
+export type IdsMenuItemData = {
+  id?: string;
+  comment?: string;
+  disabled?: boolean;
+  icon?: string;
+  selected?: boolean;
+  shortcutKeys?: string;
+  submenu?: IdsMenuData;
+  text: string;
+  type: 'item';
+  value?: string | null;
+};
+
+export type IdsMenuHeaderData = {
+  for?: string;
+  text: string;
+  type: 'header';
+};
+
+export type IdsMenuSeparatorData = {
+  type: 'separator';
+};
+
+export type IdsMenuContentsData = Array<IdsMenuGroupData | IdsMenuSeparatorData | IdsMenuHeaderData>;
+
+export type IdsMenuGroupData = {
+  id?: string;
+  items: IdsMenuContentsData;
+  select?: 'none' | 'single' | 'multiple';
+  type?: 'group';
+};
+
+export type IdsMenuObjectData = {
+  id?: string;
+  contents?: IdsMenuContentsData;
+  length?: number;
+};
+
+export type IdsMenuData = IdsMenuObjectData | IdsMenuContentsData;
+
 // Menu Selection Types
 const MENU_GROUP_SELECT_TYPES = [
   'none',

--- a/src/components/ids-menu/ids-menu-item.scss
+++ b/src/components/ids-menu/ids-menu-item.scss
@@ -3,6 +3,14 @@
 @import '../../mixins/sass/ids-check-mixin';
 @import '../../mixins/sass/ids-checkbox-mixin';
 
+/**
+ * NOTE ABOUT MENU ITEM ELEMENT ORDER:
+ * Definitions for grid template size in IdsMenuItem are defined based on the below order.
+ * If changes are made to IdsMenuItem's rendering, this order must remain in place.
+ *
+ * [checkmark?] - [icon?] - text - [shortcut text?] - [submenu icon?]
+ **/
+
 :host {
   @include block();
 
@@ -192,6 +200,21 @@
   }
 
   // ================================================
+  // Rules for a menu item with shortcut keys
+
+  &.has-shortcuts {
+    a {
+      grid-template-columns: 0 50% 50%;
+    }
+
+    &:not(.has-submenu) {
+      .ids-menu-item-shortcuts {
+        margin-inline-start: 16px;
+      }
+    }
+  }
+
+  // ================================================
   // Rules for a menu item with an icon
 
   &.has-icon {
@@ -216,7 +239,7 @@
     a {
       @include pl-4();
 
-      grid-template-columns: 30px 0 max-content;
+      grid-template-columns: 30px 0 max-content 0;
 
       // When checkmarks are present, all column placements change
       .check {
@@ -239,12 +262,10 @@
     }
   }
 
-  // ================================================
-  // Rules for a menu item with shortcut keys
-
-  &.has-shortcuts {
+  &.has-shortcuts.has-checkmark,
+  &.has-shortcuts.has-multi-checkmark {
     a {
-      grid-template-columns: 50% 50%;
+      grid-template-columns: 30px 0 50% calc(50% - 30px);
     }
   }
 
@@ -255,11 +276,11 @@
     a {
       grid-template-columns: 0 calc(100% - 25px) 25px;
     }
-  }
 
-  &.has-shortcuts.has-submenu {
-    a {
-      grid-template-columns: 50% calc(50% - 25px) 25px;
+    // NOTE: Submenu items contain this element,
+    // but hide it from the grid template calculation
+    .ids-menu-item-shortcuts {
+      display: none;
     }
   }
 
@@ -287,19 +308,17 @@
   // Rules for a menu item with an action-defined icon, and a submenu + submenu icon
   // Also for a menu item with a checkmark, and a submenu + submenu icon
 
-  &.has-icon.has-submenu,
-  &.has-checkmark.has-submenu,
-  &.has-multi-checkmark.has-submenu {
+  &.has-icon.has-submenu {
     a {
       grid-template-columns: 30px calc(100% - 55px) 25px;
     }
   }
 
-  &.has-icon.has-shortcuts.has-submenu,
-  &.has-checkmark.has-shortcuts.has-submenu,
-  &.has-multi-checkmark.has-shortcuts.has-submenu {
+  // Icon slot is still present (but hidden) in this configuration
+  &.has-checkmark.has-submenu,
+  &.has-multi-checkmark.has-submenu {
     a {
-      grid-template-columns: 30px calc(50% - 30px) calc(50% - 25px) 25px;
+      grid-template-columns: 30px 0 calc(100% - 55px) 25px;
     }
   }
 
@@ -310,13 +329,6 @@
   &.has-icon.has-multi-checkmark.has-submenu {
     a {
       grid-template-columns: 30px 30px calc(100% - 85px) 25px;
-    }
-  }
-
-  &.has-icon.has-checkmark.has-shortcuts.has-submenu,
-  &.has-icon.has-multi-checkmark.has-shortcuts.has-submenu {
-    a {
-      grid-template-columns: 30px 30px calc(50% - 45px) calc(50% - 40px) 25px;
     }
   }
 }

--- a/src/components/ids-menu/ids-menu-item.scss
+++ b/src/components/ids-menu/ids-menu-item.scss
@@ -179,6 +179,7 @@
 
   // ================================================
   // Hidden state
+
   &.hidden {
     display: none;
   }
@@ -198,6 +199,12 @@
       @include px-8();
 
       grid-template-columns: 30px max-content;
+    }
+  }
+
+  &.has-shortcuts.has-icon {
+    a {
+      grid-template-columns: 30px calc(50% - 15px) calc(50% - 15px);
     }
   }
 
@@ -233,11 +240,26 @@
   }
 
   // ================================================
+  // Rules for a menu item with shortcut keys
+
+  &.has-shortcuts {
+    a {
+      grid-template-columns: 50% 50%;
+    }
+  }
+
+  // ================================================
   // Rules for a menu item with a submenu + submenu icon
 
   &.has-submenu {
     a {
       grid-template-columns: 0 calc(100% - 25px) 25px;
+    }
+  }
+
+  &.has-shortcuts.has-submenu {
+    a {
+      grid-template-columns: 50% calc(50% - 25px) 25px;
     }
   }
 
@@ -254,6 +276,13 @@
     }
   }
 
+  &.has-shortcuts.has-icon.has-checkmark,
+  &.has-shortcuts.has-icon.has-mutlt-checkmark {
+    a {
+      grid-template-columns: 30px 30px calc(50% - 30px) calc(50% - 30px);
+    }
+  }
+
   // ================================================
   // Rules for a menu item with an action-defined icon, and a submenu + submenu icon
   // Also for a menu item with a checkmark, and a submenu + submenu icon
@@ -266,6 +295,14 @@
     }
   }
 
+  &.has-icon.has-shortcuts.has-submenu,
+  &.has-checkmark.has-shortcuts.has-submenu,
+  &.has-multi-checkmark.has-shortcuts.has-submenu {
+    a {
+      grid-template-columns: 30px calc(50% - 30px) calc(50% - 25px) 25px;
+    }
+  }
+
   // ================================================
   // Rules for a menu item with a checkmark, action-defined icon, and a submenu + submenu icon
 
@@ -275,6 +312,18 @@
       grid-template-columns: 30px 30px calc(100% - 85px) 25px;
     }
   }
+
+  &.has-icon.has-checkmark.has-shortcuts.has-submenu,
+  &.has-icon.has-multi-checkmark.has-shortcuts.has-submenu {
+    a {
+      grid-template-columns: 30px 30px calc(50% - 45px) calc(50% - 40px) 25px;
+    }
+  }
+}
+
+.ids-menu-item-shortcuts {
+  pointer-events: none;
+  text-align: end;
 }
 
 // ===============================================

--- a/src/components/ids-menu/ids-menu-item.scss
+++ b/src/components/ids-menu/ids-menu-item.scss
@@ -65,7 +65,8 @@
   // ================================================
   // Standard Rules for a menu item with no icons
   a {
-    @include px-8();
+    @include pl-12();
+    @include pr-8();
     @include py-8();
     @include text-16();
 
@@ -76,7 +77,7 @@
     text-overflow: ellispis;
     user-select: inherit;
     white-space: nowrap;
-    width: calc(100% - 16px);
+    width: calc(100% - 20px);
 
     // Disable default browser focus state.
     // (comment this out to debug the true menu focus state)
@@ -210,6 +211,7 @@
     &:not(.has-submenu) {
       .ids-menu-item-shortcuts {
         margin-inline-start: 16px;
+        margin-inline-end: 4px; // line up with submenu icons
       }
     }
   }

--- a/src/components/ids-menu/ids-menu-item.ts
+++ b/src/components/ids-menu/ids-menu-item.ts
@@ -82,9 +82,7 @@ export default class IdsMenuItem extends Base {
     const check = this.templateCheck();
 
     // Icon
-    let icon = '';
-    if (this.state?.icon) icon = this.templateDisplayIcon(this.state.icon);
-    const iconSlot = `<span class="ids-menu-item-icon" role="presentation"><slot name="icon">${icon}</slot></span>`;
+    const iconSlot = `<span class="ids-menu-item-icon" role="presentation"><slot name="icon"></slot></span>`;
 
     // Selected
     let selectedClass = '';
@@ -479,7 +477,7 @@ export default class IdsMenuItem extends Base {
    * @returns {boolean} true if this item is able to be selected
    */
   get isSelectable(): boolean {
-    return this.group?.select !== null && !this.submenu;
+    return this.group?.select !== null;
   }
 
   /**
@@ -593,12 +591,6 @@ export default class IdsMenuItem extends Base {
       this.setAttribute(attributes.SHORTCUT_KEYS, val);
       this.appendShortcuts(val);
     }
-
-    /*
-    if (this.group && typeof this.group.updateIconAlignment === 'function') {
-      this.group.updateIconAlignment();
-    }
-    */
   }
 
   /**

--- a/src/components/ids-menu/ids-menu-item.ts
+++ b/src/components/ids-menu/ids-menu-item.ts
@@ -1,7 +1,7 @@
 import { customElement, scss } from '../../core/ids-decorators';
 import { attributes, htmlAttributes } from '../../core/ids-attributes';
 import {
-  MENU_ITEM_SIZE, MENU_DEFAULTS, safeForAttribute
+  MENU_ITEM_ICON_SIZE, MENU_DEFAULTS, safeForAttribute
 } from './ids-menu-attributes';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 
@@ -123,7 +123,7 @@ export default class IdsMenuItem extends Base {
 
   templateDisplayIcon(icon: string) {
     const viewbox = this.viewbox ? ` viewbox="${this.viewbox}"` : '';
-    return `<ids-icon slot="icon" icon="${icon}"${viewbox} size="${MENU_ITEM_SIZE}" part="icon" class="ids-icon ids-menu-item-display-icon"></ids-icon>`;
+    return `<ids-icon slot="icon" icon="${icon}"${viewbox} size="${MENU_ITEM_ICON_SIZE}" part="icon" class="ids-icon ids-menu-item-display-icon"></ids-icon>`;
   }
 
   templateShortcutKeys(shortcutText: string) {
@@ -131,7 +131,7 @@ export default class IdsMenuItem extends Base {
   }
 
   templateSubmenuIcon() {
-    return `<ids-icon slot="icon" icon="dropdown" size="${MENU_ITEM_SIZE}" class="ids-icon ids-menu-item-submenu-icon"></ids-icon>`;
+    return `<ids-icon slot="icon" icon="dropdown" size="${MENU_ITEM_ICON_SIZE}" class="ids-icon ids-menu-item-submenu-icon"></ids-icon>`;
   }
 
   /**

--- a/src/components/ids-menu/ids-menu.ts
+++ b/src/components/ids-menu/ids-menu.ts
@@ -424,6 +424,7 @@ export default class IdsMenu extends Base {
    */
   get focusTarget() {
     if (this.lastHovered) return this.lastHovered;
+    if (this.lastNavigated) return this.lastNavigated;
 
     const highlighted = this.items.filter((item: IdsMenuItem) => item.highlighted);
     if (highlighted.length) return highlighted[highlighted.length - 1];
@@ -565,6 +566,9 @@ export default class IdsMenu extends Base {
     }
 
     this.lastNavigated = currentItem;
+    if (this.lastHovered) this.lastHovered = null;
+
+    // Focus/Highlight
     if (!currentItem.disabled && !currentItem.hidden && doFocus) {
       currentItem.focus();
       this.highlightItem(currentItem);

--- a/src/components/ids-menu/ids-menu.ts
+++ b/src/components/ids-menu/ids-menu.ts
@@ -348,24 +348,21 @@ export default class IdsMenu extends Base {
    * @returns {void}
    */
   set data(value: IdsMenuData) {
-    // If provided an object, search for a `contents` property and store its contents
-    if (typeof value === 'object') {
-      const objData = (value as IdsMenuObjectData);
-      if (Array.isArray(objData.contents)) {
-        this.datasource.data = objData.contents;
-        // Set the ID of this component if it's present in the object
-        if (objData.id) {
-          this.id = objData.id;
-        }
-        this.renderFromData();
-      }
-      return;
-    }
-
     // Accept the `contents` array directly if provided
     if (Array.isArray(value)) {
       this.datasource.data = (value as IdsMenuContentsData);
       this.renderFromData();
+      return;
+    }
+
+    // If provided an object, search for a `contents` property and store its contents
+    if (value && typeof value === 'object') {
+      const objData = (value as IdsMenuObjectData);
+      if (Array.isArray(objData.contents)) {
+        this.datasource.data = objData.contents;
+        if (objData.id) this.id = objData.id;
+        this.renderFromData();
+      }
       return;
     }
 

--- a/src/components/ids-menu/ids-menu.ts
+++ b/src/components/ids-menu/ids-menu.ts
@@ -1,7 +1,12 @@
 import { attributes, htmlAttributes } from '../../core/ids-attributes';
 import { customElement, scss } from '../../core/ids-decorators';
 import { getClosestContainerNode } from '../../utils/ids-dom-utils/ids-dom-utils';
-import { isValidGroup, isUsableItem } from './ids-menu-attributes';
+import {
+  isValidGroup,
+  isUsableItem,
+  IdsMenuContentsData,
+  IdsMenuObjectData
+} from './ids-menu-attributes';
 
 import IdsDataSource from '../../core/ids-data-source';
 import IdsKeyboardMixin from '../../mixins/ids-keyboard-mixin/ids-keyboard-mixin';
@@ -16,6 +21,8 @@ import '../ids-separator/ids-separator';
 
 import styles from './ids-menu.scss';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
+
+import type { IdsMenuData } from './ids-menu-attributes';
 import type IdsMenuItem from './ids-menu-item';
 import type IdsMenuHeader from './ids-menu-header';
 
@@ -332,26 +339,28 @@ export default class IdsMenu extends Base {
   }
 
   /**
-   * Set the data array of the data grid
-   * @param {Array<any>|object} value The array to use
+   * Set the data array of the menu
+   * @param {IdsMenuData} value The array to use
    * @returns {void}
    */
-  set data(value: any) {
-    if (value) {
-      // If provided an object, search for a `contents` property and store that
-      if (typeof value === 'object' && Array.isArray(value.contents)) {
-        this.datasource.data = value.contents;
+  set data(value: IdsMenuData) {
+    // If provided an object, search for a `contents` property and store its contents
+    if (typeof value === 'object') {
+      const objData = (value as IdsMenuObjectData);
+      if (Array.isArray(objData.contents)) {
+        this.datasource.data = objData.contents;
         // Set the ID of this component if it's present in the object
-        if (value?.id) {
-          this.id = value.id;
+        if (objData.id) {
+          this.id = objData.id;
         }
-      } else if (Array.isArray(value)) {
-        this.datasource.data = value;
-      } else {
-        // accept no other non-empty types
-        return;
+        this.renderFromData();
       }
+      return;
+    }
 
+    // Accept the `contents` array directly if provided
+    if (Array.isArray(value)) {
+      this.datasource.data = (value as IdsMenuContentsData);
       this.renderFromData();
       return;
     }
@@ -360,7 +369,7 @@ export default class IdsMenu extends Base {
   }
 
   /**
-   * @returns {Array<any>|object} containing the dataset
+   * @returns {IdsMenuData} containing the dataset
    */
   get data() {
     return this?.datasource?.data || [];

--- a/src/components/ids-menu/ids-menu.ts
+++ b/src/components/ids-menu/ids-menu.ts
@@ -276,6 +276,10 @@ export default class IdsMenu extends Base {
       if (item.selected) {
         selected = ' selected="true"';
       }
+      let shortcutKeys = '';
+      if (typeof item.shortcutKeys === 'string') {
+        shortcutKeys = ` shortcut-keys="${item.shortcutKeys}"`;
+      }
       let value = '';
       if (typeof item.value !== 'undefined' && item.value !== null && item.value !== '') {
         value = ` value="${item.value}"`;
@@ -285,7 +289,7 @@ export default class IdsMenu extends Base {
         submenu = renderSubmenu(item.submenu);
       }
 
-      return `<ids-menu-item${id}${disabled}${icon}${selected}${value}>
+      return `<ids-menu-item${id}${disabled}${icon}${selected}${shortcutKeys}${value}>
         ${text}
         ${submenu}
       </ids-menu-item>`;

--- a/src/components/ids-popup-menu/demos/data-driven.html
+++ b/src/components/ids-popup-menu/demos/data-driven.html
@@ -7,7 +7,7 @@
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-popup-menu id="popupmenu"></ids-popup-menu>
+    <ids-popup-menu id="popupmenu" align="left, top"></ids-popup-menu>
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
@@ -17,7 +17,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-text>This Popupmenu is controlled by a Datasource Mixin instead of by its markup</ids-text>
+        <ids-text>This Popupmenu's contents are controlled by an IdsDataSource instead of defined in HTML markup</ids-text>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-popup-menu/demos/data-driven.ts
+++ b/src/components/ids-popup-menu/demos/data-driven.ts
@@ -1,7 +1,7 @@
 // Supporting components
 import '../ids-popup-menu';
 import '../../ids-popup/ids-popup';
-import json from '../../../assets/data/menu-array.json';
+import json from '../../../assets/data/menu-contents.json';
 
 document.addEventListener('DOMContentLoaded', () => {
   const popupmenuEl: any = document.querySelector('#popupmenu');

--- a/src/components/ids-popup-menu/demos/data-driven.ts
+++ b/src/components/ids-popup-menu/demos/data-driven.ts
@@ -1,7 +1,7 @@
 // Supporting components
 import '../ids-popup-menu';
 import '../../ids-popup/ids-popup';
-import json from '../../../assets/data/menu-contents.json';
+import json from '../../../assets/data/menu-array.json';
 
 document.addEventListener('DOMContentLoaded', () => {
   const popupmenuEl: any = document.querySelector('#popupmenu');

--- a/src/components/ids-popup-menu/demos/index.yaml
+++ b/src/components/ids-popup-menu/demos/index.yaml
@@ -14,6 +14,9 @@
   - link: selected-state.html
     type: Example
     description: Showing a Popup Menu with selections
+  - link: shortcut-keys.html
+    type: Example
+    description: Showing a Popup Menu displaying shortcut key icons
   - link: trigger-immediate.html
     type: Test
     description: Showing a Popup Menu invoked on demand

--- a/src/components/ids-popup-menu/demos/shortcut-keys.html
+++ b/src/components/ids-popup-menu/demos/shortcut-keys.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-popup-menu id="popupmenu">
+      <ids-menu-group>
+        <ids-menu-item icon="folder">Create new folder</ids-menu-item>
+        <ids-menu-item>Previous</ids-menu-item>
+        <ids-menu-item>Next</ids-menu-item>
+        <ids-separator></ids-separator>
+        <ids-menu-item>Copy to...</ids-menu-item>
+        <ids-menu-item>Move to...</ids-menu-item>
+        <ids-menu-item icon="edit">Long-form shortcut text</ids-menu-item>
+        <ids-separator></ids-separator>
+        <ids-menu-item icon="trash">Delete folder</ids-menu-item>
+      </ids-menu-group>
+    </ids-popup-menu>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h1">Popup Menu (with Shortcut keys)</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-text>Right-click anywhere in the page to activate a Popupmenu</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+
+</html>

--- a/src/components/ids-popup-menu/demos/shortcut-keys.html
+++ b/src/components/ids-popup-menu/demos/shortcut-keys.html
@@ -36,7 +36,12 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-text>Right-click anywhere in the page to activate a Popupmenu</ids-text>
+        <ids-text type="p">Right-click anywhere in the page to activate a Popupmenu.<br />
+          Use the controls below to change menu configuration and test icon/text alignments.
+        </ids-text>
+        <p><ids-checkbox id="controls-icons" label="Enable icons" checked></ids-checkbox></p>
+        <p><ids-checkbox id="controls-selection" label="Enable single selection"></ids-checkbox></p>
+        <p><ids-checkbox id="controls-submenu" label="Enable a submenu"></ids-checkbox></p>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-popup-menu/demos/shortcut-keys.html
+++ b/src/components/ids-popup-menu/demos/shortcut-keys.html
@@ -8,21 +8,6 @@
   <%= htmlWebpackPlugin.options.font %>
 </head>
 
-<!-- Defining the same menu in HTML markup only -->
-<!--
-<ids-menu-group>
-  <ids-menu-item icon="folder">Create new folder</ids-menu-item>
-  <ids-menu-item>Previous</ids-menu-item>
-  <ids-menu-item>Next</ids-menu-item>
-  <ids-separator></ids-separator>
-  <ids-menu-item>Copy to...</ids-menu-item>
-  <ids-menu-item>Move to...</ids-menu-item>
-  <ids-menu-item icon="edit">Long-form shortcut text</ids-menu-item>
-  <ids-separator></ids-separator>
-  <ids-menu-item icon="trash">Delete folder</ids-menu-item>
-</ids-menu-group>
---->
-
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>

--- a/src/components/ids-popup-menu/demos/shortcut-keys.html
+++ b/src/components/ids-popup-menu/demos/shortcut-keys.html
@@ -8,22 +8,25 @@
   <%= htmlWebpackPlugin.options.font %>
 </head>
 
+<!-- Defining the same menu in HTML markup only -->
+<!--
+<ids-menu-group>
+  <ids-menu-item icon="folder">Create new folder</ids-menu-item>
+  <ids-menu-item>Previous</ids-menu-item>
+  <ids-menu-item>Next</ids-menu-item>
+  <ids-separator></ids-separator>
+  <ids-menu-item>Copy to...</ids-menu-item>
+  <ids-menu-item>Move to...</ids-menu-item>
+  <ids-menu-item icon="edit">Long-form shortcut text</ids-menu-item>
+  <ids-separator></ids-separator>
+  <ids-menu-item icon="trash">Delete folder</ids-menu-item>
+</ids-menu-group>
+--->
+
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-popup-menu id="popupmenu">
-      <ids-menu-group>
-        <ids-menu-item icon="folder">Create new folder</ids-menu-item>
-        <ids-menu-item>Previous</ids-menu-item>
-        <ids-menu-item>Next</ids-menu-item>
-        <ids-separator></ids-separator>
-        <ids-menu-item>Copy to...</ids-menu-item>
-        <ids-menu-item>Move to...</ids-menu-item>
-        <ids-menu-item icon="edit">Long-form shortcut text</ids-menu-item>
-        <ids-separator></ids-separator>
-        <ids-menu-item icon="trash">Delete folder</ids-menu-item>
-      </ids-menu-group>
-    </ids-popup-menu>
+    <ids-popup-menu id="popupmenu" align="left, top"></ids-popup-menu>
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>

--- a/src/components/ids-popup-menu/demos/shortcut-keys.ts
+++ b/src/components/ids-popup-menu/demos/shortcut-keys.ts
@@ -40,7 +40,6 @@ document.addEventListener('DOMContentLoaded', () => {
       items.forEach((item: IdsMenuItem) => {
         if (item.iconEl) {
           item.removeAttribute('icon');
-          debugger;
         }
       });
     } else {

--- a/src/components/ids-popup-menu/demos/shortcut-keys.ts
+++ b/src/components/ids-popup-menu/demos/shortcut-keys.ts
@@ -1,13 +1,17 @@
 // Supporting components
-import '../ids-popup-menu';
-import '../../ids-popup/ids-popup';
+import type IdsPopupMenu from '../ids-popup-menu';
+import type IdsMenuGroup from '../../ids-menu/ids-menu-group';
+import type IdsMenuItem from '../../ids-menu/ids-menu-item';
+import type IdsPopup from '../../ids-popup/ids-popup';
+import type IdsCheckbox from '../../ids-checkbox/ids-checkbox';
+
 import json from '../../../assets/data/menu-shortcuts.json';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const popupmenuEl: any = document.querySelector('#popupmenu');
+  const popupmenuEl: IdsPopupMenu = document.querySelector<IdsPopupMenu>('#popupmenu')!;
 
   // Configure the menu
-  const popupEl = popupmenuEl.popup;
+  const popupEl: IdsPopup = popupmenuEl.popup!;
   popupEl.setAttribute('align', 'left, top');
 
   // Load/set data
@@ -17,6 +21,61 @@ document.addEventListener('DOMContentLoaded', () => {
     const data = await res.json();
     popupmenuEl.data = data;
   };
-
   setData();
+
+  // Disable/Enable selection on the menu
+  const singleSelectCheckEl = document.querySelector<IdsCheckbox>('#controls-selection')!;
+  singleSelectCheckEl.addEventListener('change', (e: Event) => {
+    const menuGroupEl = popupmenuEl.children[0] as IdsMenuGroup;
+    menuGroupEl.select = (e.target as IdsCheckbox)?.checked ? 'single' : 'none';
+  });
+
+  // Add/remove icons to some menu items
+  const iconsCheckEl = document.querySelector<IdsCheckbox>('#controls-icons')!;
+  iconsCheckEl.addEventListener('change', (e: Event) => {
+    const items = popupmenuEl.items;
+    const checked = (e.target as IdsCheckbox)?.checked;
+
+    if (!checked) {
+      items.forEach((item: IdsMenuItem) => {
+        if (item.iconEl) {
+          item.removeAttribute('icon');
+          debugger;
+        }
+      });
+    } else {
+      items[0].icon = 'folder';
+      items[5].icon = 'edit';
+      items[6].icon = 'delete';
+      if (items[7]) items[7].icon = 'settings';
+    }
+  });
+
+  // Add/remove a menu item that contains a submenu (further altering menu item alignment)
+  const submenuCheckEl = document.querySelector<IdsCheckbox>('#controls-submenu')!;
+  submenuCheckEl.addEventListener('change', (e: Event) => {
+    const submenuItem = popupmenuEl.items[7] as IdsMenuItem;
+    const menuGroupEl = popupmenuEl.children[0] as IdsMenuGroup;
+    const checked = (e.target as IdsCheckbox)?.checked;
+
+    if (!checked) submenuItem?.remove();
+    else {
+      const iconAttr = iconsCheckEl.checked ? ' icon="settings"' : '';
+      menuGroupEl.insertAdjacentHTML(
+        'beforeend',
+        `<ids-menu-item id="contains-submenu"${iconAttr}>
+          More Options...
+          <ids-popup-menu>
+            <ids-menu-header id="keep-open-header">Single-selectable Items that keep the menu open</ids-menu-header>
+            <ids-menu-group id="single-sub-items" select="single" keep-open aria-labelledby="keep-open-header">
+              <ids-menu-item value="sub-sub-single-1">Sub-Sub-Item One</ids-menu-item>
+              <ids-menu-item value="sub-sub-single-2">Sub-Sub-Item Two</ids-menu-item>
+              <ids-menu-item value="sub-sub-single-3">Sub-Sub-Item Three</ids-menu-item>
+              <ids-menu-item value="sub-sub-single-4">Sub-Sub-Item Four</ids-menu-item>
+            </ids-menu-group>
+          </ids-popup-menu>
+        </ids-menu-item>`
+      );
+    }
+  });
 });

--- a/src/components/ids-popup-menu/demos/shortcut-keys.ts
+++ b/src/components/ids-popup-menu/demos/shortcut-keys.ts
@@ -1,7 +1,7 @@
 // Supporting components
 import '../ids-popup-menu';
 import '../../ids-popup/ids-popup';
-import json from '../../../assets/data/menu-contents.json';
+import json from '../../../assets/data/menu-shortcuts.json';
 
 document.addEventListener('DOMContentLoaded', () => {
   const popupmenuEl: any = document.querySelector('#popupmenu');

--- a/src/components/ids-popup-menu/demos/standalone-css.html
+++ b/src/components/ids-popup-menu/demos/standalone-css.html
@@ -39,14 +39,36 @@
                 </li>
               </ul>
               <div class="ids-separator"></div>
+              <div class="ids-menu-header" id="icon-shortcuts-header">Shortcut Keys</div>
+              <ul class="ids-menu-group">
+                <li class="ids-menu-item has-shortcuts">
+                  <a>
+                    <span class="ids-menu-item-text">Copy</span>
+                    <span class="ids-menu-item-shortcuts">⌘+R</span>
+                  </a>
+                </li>
+              </ul>
+              <div class="ids-separator"></div>
               <div class="ids-menu-header" id="icon-items-header">Icon Items</div>
               <ul class="ids-menu-group">
                 <li class="ids-menu-item has-icon">
                   <a>
-                    <svg class="ids-menu-item-display-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                    <svg class="ids-menu-item-display-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="14" width="14" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                       <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
                     </svg>
                     <span class="ids-menu-item-text">Settings</span>
+                  </a>
+                </li>
+                <li class="ids-menu-item has-icon has-shortcuts">
+                  <a>
+                    <svg class="ids-menu-item-display-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none"
+                      height="14" width="14" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                      <path
+                        d="M13 11.5h2.5v-9h-10V4m-3 3V5.5H4m1 0h2m.941 0h2.118M12.5 7V5.5H11m-3 10h2m2.5-2.5v-2m0-1V8m0 5.94v1.56H11m-4.5-.032a4.298 4.298 0 01-2.118-.866M3.5 13.94c-.5-.52-1-1.04-1-2.53m0-1.41V8"
+                        stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
+                    </svg>
+                    <span class="ids-menu-item-text">Copy</span>
+                    <span class="ids-menu-item-shortcuts">⌘+R</span>
                   </a>
                 </li>
               </ul>
@@ -88,7 +110,7 @@
                 <li class="ids-menu-item has-submenu">
                   <a>
                     <span class="ids-menu-item-text">Settings</span>
-                    <svg class="ids-menu-item-submenu-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                    <svg class="ids-menu-item-submenu-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="14" width="14" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                       <path d="M4 6l5 6 5-6H4" fill="currentColor" fill-rule="evenodd" stroke="none"></path>
                     </svg>
                   </a>
@@ -99,11 +121,11 @@
               <ul class="ids-menu-group">
                 <li class="ids-menu-item has-submenu has-icon">
                   <a>
-                    <svg class="ids-menu-item-display-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                    <svg class="ids-menu-item-display-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="14" width="14" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                       <path d="M13.25 1.5h-8.5L.5 8.75 4.75 16h8.5l4.25-7.25-4.25-7.25zm-1 7.25a3.25 3.25 0 11-6.499.001 3.25 3.25 0 016.499-.001z" stroke="currentColor" fill="none" fill-rule="evenodd" vector-effect="non-scaling-stroke"></path>
                     </svg>
                     <span class="ids-menu-item-text">Settings</span>
-                    <svg class="ids-menu-item-submenu-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="18" width="18" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
+                    <svg class="ids-menu-item-submenu-icon" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" fill="none" height="14" width="14" viewBox="0 0 18 18" focusable="false" aria-hidden="true">
                       <path d="M4 6l5 6 5-6H4" fill="currentColor" fill-rule="evenodd" stroke="none"></path>
                     </svg>
                   </a>

--- a/src/components/ids-popup-menu/ids-popup-menu.ts
+++ b/src/components/ids-popup-menu/ids-popup-menu.ts
@@ -2,11 +2,13 @@ import { customElement, scss } from '../../core/ids-decorators';
 import { attributes, htmlAttributes } from '../../core/ids-attributes';
 import { stripHTML } from '../../utils/ids-xss-utils/ids-xss-utils';
 import { getElementAtMouseLocation } from '../../utils/ids-dom-utils/ids-dom-utils';
-import '../ids-popup/ids-popup';
+
 import IdsAttachmentMixin from '../../mixins/ids-attachment-mixin/ids-attachment-mixin';
 import IdsPopupOpenEventsMixin from '../../mixins/ids-popup-open-events-mixin/ids-popup-open-events-mixin';
 import IdsPopupInteractionsMixin from '../../mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin';
 import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
+
+import '../ids-popup/ids-popup';
 import IdsMenu from '../ids-menu/ids-menu';
 
 import styles from './ids-popup-menu.scss';
@@ -40,6 +42,7 @@ export default class IdsPopupMenu extends Base {
   static get attributes() {
     return [
       ...super.attributes,
+      attributes.ALIGN,
       attributes.WIDTH
     ];
   }
@@ -50,7 +53,9 @@ export default class IdsPopupMenu extends Base {
    */
   template(): string {
     const menuTemplate = super.template();
-    return `<ids-popup class="ids-popup-menu" type="menu">${menuTemplate}</ids-popup>`;
+    const alignAttr = this.align ? ` align="${this.align}"` : '';
+
+    return `<ids-popup class="ids-popup-menu" type="menu"${alignAttr}>${menuTemplate}</ids-popup>`;
   }
 
   /**
@@ -72,8 +77,7 @@ export default class IdsPopupMenu extends Base {
       this.popupDelay = 200;
       this.target = this.parentMenuItem;
       this.triggerType = 'hover';
-      this.popup?.setAttribute('align', 'right, top');
-      this.popup?.setAttribute('align-edge', 'right');
+      this.align = 'right, top';
     }
   }
 
@@ -176,6 +180,23 @@ export default class IdsPopupMenu extends Base {
         this.hideAndFocus();
       });
     }
+  }
+
+  /**
+   * Passes an `align` setting down to the internal IdsPopup
+   * @param {string} val a comma-delimited set of alignment types `direction1, direction2`
+   */
+  set align(val: string) {
+    if (typeof val !== 'string') return;
+    if (this.popup) this.popup.align = val;
+  }
+
+  /**
+   * Retrieves the `align` setting from the internal IdsPopup
+   * @returns {string} a comma-delimited set of alignment types `direction1, direction2`
+   */
+  get align() {
+    return this.popup?.align || 'top, left';
   }
 
   /**

--- a/src/components/ids-popup/ids-popup-attributes.ts
+++ b/src/components/ids-popup/ids-popup-attributes.ts
@@ -5,6 +5,8 @@ export type IdsPopupElementRef = IdsElement | HTMLElement | SVGElement | null;
 
 const CENTER = 'center';
 
+const DEFAULT_ALIGN_EDGE = CENTER;
+
 // Locations in which a parent-positioned Popup can be located
 const ALIGNMENT_EDGES = [CENTER, 'bottom', 'top', 'left', 'right'];
 
@@ -88,6 +90,7 @@ export {
   ALIGNMENTS_EDGES_Y,
   ANIMATION_STYLES,
   ARROW_TYPES,
+  DEFAULT_ALIGN_EDGE,
   POSITION_STYLES,
   TYPES,
   POPUP_PROPERTIES,

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -333,6 +333,7 @@ export const attributes = {
   SELECTED: 'selected',
   SELECTION: 'selection',
   SHAPE: 'shape',
+  SHORTCUT_KEYS: 'shortcut-keys',
   SHOW_BROWSE_LINK: 'show-browse-link',
   SHOW_CANCEL: 'show-cancel',
   SHOW_CLEAR: 'show-clear',

--- a/test/ids-menu/ids-menu-func-test.ts.snap
+++ b/test/ids-menu/ids-menu-func-test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IdsMenu Component IdsMenuItem can render a new item correctly 1`] = `"<ids-menu-item id="newitem" icon="settings" viewbox="0 0 20 20" selected=""><ids-icon slot="icon" icon="settings" size="medium" part="icon" class="ids-icon ids-menu-item-display-icon"></ids-icon></ids-menu-item>"`;
+exports[`IdsMenu Component IdsMenuItem can render a new item correctly 1`] = `"<ids-menu-item id="newitem" icon="settings" viewbox="0 0 20 20" selected=""><ids-icon slot="icon" icon="settings" size="small" part="icon" class="ids-icon ids-menu-item-display-icon"></ids-icon></ids-menu-item>"`;

--- a/test/ids-popup-menu/ids-popup-menu-data-driven-func-test.ts
+++ b/test/ids-popup-menu/ids-popup-menu-data-driven-func-test.ts
@@ -7,7 +7,9 @@ import IdsPopupMenu from '../../src/components/ids-popup-menu/ids-popup-menu';
 import '../../src/components/ids-popup/ids-popup';
 
 // Pull in menu contents
-import dataset from '../../src/assets/data/menu-contents.json';
+import defaultDataset from '../../src/assets/data/menu-contents.json';
+import arrayDataset from '../../src/assets/data/menu-array.json';
+import shortcutDataset from '../../src/assets/data/menu-shortcuts.json';
 
 describe('IdsPopupMenu Component', () => {
   let menu: any;
@@ -16,7 +18,7 @@ describe('IdsPopupMenu Component', () => {
     // Invoke/Append the main menu
     menu = new IdsPopupMenu();
     menu.id = 'test-menu';
-    menu.data = dataset;
+    menu.data = defaultDataset;
     document.body.appendChild(menu);
   });
 
@@ -57,28 +59,12 @@ describe('IdsPopupMenu Component', () => {
     document.body.innerHTML = '';
     menu = new IdsPopupMenu();
     menu.id = 'test-menu';
-    menu.data = [
-      {
-        type: 'group',
-        items: [
-          {
-            id: 'item-1',
-            text: 'Item One',
-            value: 1
-          },
-          {
-            id: 'item-2',
-            text: 'Item Two',
-            value: 2
-          }
-        ]
-      }
-    ];
+    menu.data = arrayDataset;
     document.body.appendChild(menu);
 
     expect(errors).not.toHaveBeenCalled();
     expect(menu.groups.length).toEqual(1);
-    expect(menu.items.length).toEqual(2);
+    expect(menu.items.length).toEqual(3);
   });
 
   it('renders with no errors when given an empty dataset', () => {
@@ -240,5 +226,18 @@ describe('IdsPopupMenu Component', () => {
     expect(errors).not.toHaveBeenCalled();
     expect(item).toBeDefined();
     expect(item.hasSubmenu).toBeFalsy();
+  });
+
+  it('propagates `shortcutKeys` property onto menu items if provided', () => {
+    const errors = jest.spyOn(global.console, 'error');
+
+    document.body.innerHTML = '';
+    menu = new IdsPopupMenu();
+    menu.data = shortcutDataset;
+    document.body.appendChild(menu);
+
+    expect(errors).not.toHaveBeenCalled();
+    expect(menu.items[0].shortcutKeys).toBe('⌘+R');
+    expect(document.querySelector('ids-menu-item')?.getAttribute('shortcut-keys')).toBe('⌘+R');
   });
 });

--- a/test/ids-popup-menu/ids-popup-menu-func-test.ts.snap
+++ b/test/ids-popup-menu/ids-popup-menu-func-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IdsPopupMenu Component IdsMenuItem can render a new item correctly 1`] = `
-"<ids-menu-item id="newitem" icon="settings" selected=""><ids-icon slot="icon" icon="settings" size="medium" part="icon" class="ids-icon ids-menu-item-display-icon"></ids-icon><ids-popup-menu id="new-submenu" role="none" hidden=""><ids-menu-group id="new-group" role="group" aria-label="Menu group containing 3 item(s)">
+"<ids-menu-item id="newitem" icon="settings" selected=""><ids-icon slot="icon" icon="settings" size="small" part="icon" class="ids-icon ids-menu-item-display-icon"></ids-icon><ids-popup-menu id="new-submenu" role="none" hidden=""><ids-menu-group id="new-group" role="group" aria-label="Menu group containing 3 item(s)">
   <ids-menu-item id="newitem1" value="new1">First New Item</ids-menu-item>
   <ids-menu-item id="newitem2" value="new2">Second New Item</ids-menu-item>
   <ids-menu-item id="newitem3" value="new3">Third New Item</ids-menu-item>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds a 4.x popupmenu feature to the IdsPopupMenu web component:
- Uses a `shortcut-keys` attribute to define a text string containing shortcut keys.
- Adds `shortcut-keys` to the Popup Menu's routines for building menus from JSON data.
- Adds Typescript Types for the JSON data structure used for defining IdsPopupMenus in IdsDataSource and externally.
- Adds tests/docs for the new feature

**Related github/jira issue (required)**:
Closes #1108

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-popup-menu/shortcut-keys.html.  
- Use the settings on this page to test different variations of the Popup Menu with items that contain shortcut key text
- Review new TS types for IdsMenu JSON data: https://github.com/infor-design/enterprise-wc/blob/1108-popupmenu-shortcut-keys/src/components/ids-menu/ids-menu-attributes.ts#L3-L41
- Review other examples/tests/docs

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
