### PR TITLE
1158 - IdsDataSource: Make default sort algorithm behave more like Excel

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Button/Input/Dropdown]` Added posibility to show loading indicator. ([#1048](https://github.com/infor-design/enterprise-wc/issues/1048))
 - `[Datagrid]` Added feature to export data grid to excel xlsx or csv file. ([#153](https://github.com/infor-design/enterprise-wc/issues/153))
 - `[Datagrid/Dropdown]` Separated IdsDropdownList into its own component, re-integrated the new component into IdsDropdown, and fixed containment/cutoff issues in IdsDataGrid using the new list component. ([#1065](https://github.com/infor-design/enterprise-wc/issues/1065))
+- `[Data Source]` Changed the default sort function to behave more like Excel, sorting separately numbers, strings, and empty space. ([#1158](https://github.com/infor-design/enterprise-wc/issues/1158))
 - `[Menu/Popup Menu]` Added Shortcut Key display feature to IdsMenuItem. ([#1108](https://github.com/infor-design/enterprise-wc/issues/1108))
 
 ## 1.0.0-beta.7

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -41,5 +41,5 @@ Adds a wrapper for components that need data arrays as a setting to render (list
 
 1. Clone the array so the original is not modified
 1. Flatten and unflatten data
-1. Sort
+1. Sort (by default uses an Excel-like sort - numbers -> strings -> empty)
 1. Filter

--- a/src/core/ids-data-source.ts
+++ b/src/core/ids-data-source.ts
@@ -301,6 +301,12 @@ class IdsDataSource {
       a = (a === undefined || a === null ? '' : a);
       if (typeof a === 'string') {
         a = a.toUpperCase();
+
+        // Convert number-only strings to real numbers before actual sort occurs
+        const numeric = Number(a);
+        if (a !== '' && !Number.isNaN(numeric) && Number.isFinite(numeric)) {
+          a = numeric;
+        }
       }
       return a;
     };
@@ -311,6 +317,18 @@ class IdsDataSource {
     return (a: any, b: any) => {
       a = key(a);
       b = key(b);
+
+      // Imitate how Excel sorts when comparing numbers with strings (numbers are always less than strings)
+      // The following string values will sort in this order (ascending):
+      // 1, 2, 07, 11, 1a, 22a, 2ab, a, B, c
+      if (typeof a === 'number' && typeof b === 'string' && b !== '') return ascending * -1;
+      if (typeof a === 'string' && typeof b === 'number' && a !== '') return ascending;
+
+      // an empty a always returns 1 (or 0 if equal with b)
+      if (a === '') return b === '' ? 0 : 1;
+
+      // an empty b always returns -1 (or 0 if equal with a)
+      if (b === '') return a === '' ? 0 : -1;
 
       if (typeof a !== typeof b) {
         a = a.toString().toLowerCase();

--- a/test/core/ids-data-source-func-test.ts
+++ b/test/core/ids-data-source-func-test.ts
@@ -3,7 +3,7 @@
  */
 import IdsDataSource from '../../src/core/ids-data-source';
 
-describe('IdsDataSourceMixin Tests', () => {
+describe('IdsDataSource Tests', () => {
   let datasource: any;
 
   beforeEach(async () => {
@@ -87,5 +87,86 @@ describe('IdsDataSourceMixin Tests', () => {
     expect(datasource.data[3].prop1).toEqual('a');
     expect(datasource.data[4].prop1).toEqual('a');
     expect(datasource.data[5].prop1).toEqual('a');
+  });
+
+  it('sorts numbers ahead of strings in ascending mode, opposite in descending mode', () => {
+    const dataset = [
+      { id: 0, prop1: '1' },
+      { id: 4, prop1: '1a' },
+      { id: 1, prop1: '2' },
+      { id: 2, prop1: '07' },
+      { id: 9, prop1: 'c' },
+      { id: 6, prop1: '2ab' },
+      { id: 3, prop1: '11' },
+      { id: 8, prop1: 'B' },
+      { id: 5, prop1: '22a' },
+      { id: 7, prop1: 'a' }
+    ];
+
+    datasource.data = dataset;
+    datasource.sort('prop1', true);
+
+    expect(datasource.data[0].prop1).toEqual('1');
+    expect(datasource.data[1].prop1).toEqual('2');
+    expect(datasource.data[2].prop1).toEqual('07');
+    expect(datasource.data[3].prop1).toEqual('11');
+    expect(datasource.data[4].prop1).toEqual('1a');
+    expect(datasource.data[5].prop1).toEqual('22a');
+    expect(datasource.data[6].prop1).toEqual('2ab');
+    expect(datasource.data[7].prop1).toEqual('a');
+    expect(datasource.data[8].prop1).toEqual('B');
+    expect(datasource.data[9].prop1).toEqual('c');
+
+    datasource.sort('prop1', false);
+
+    expect(datasource.data[0].prop1).toEqual('c');
+    expect(datasource.data[1].prop1).toEqual('B');
+    expect(datasource.data[2].prop1).toEqual('a');
+    expect(datasource.data[3].prop1).toEqual('2ab');
+    expect(datasource.data[4].prop1).toEqual('22a');
+    expect(datasource.data[5].prop1).toEqual('1a');
+    expect(datasource.data[6].prop1).toEqual('11');
+    expect(datasource.data[7].prop1).toEqual('07');
+    expect(datasource.data[8].prop1).toEqual('2');
+    expect(datasource.data[9].prop1).toEqual('1');
+  });
+
+  it('can sort numbers, strings, and empty space similar to Excel', () => {
+    const dataset = [
+      { productId: 2445204, productName: '01AM', quantity: 3 },
+      { productId: 2542205, productName: '01PT', quantity: 4 },
+      { productId: 2642205, productName: '02PT', quantity: 41 },
+      { productId: 2642206, productName: '03AM', quantity: 41 },
+      { productId: 2241202, productName: '1', quantity: 2 },
+      { productId: 2342203, productName: '10', quantity: 1 },
+      { productId: 2642207, productName: '05AM', quantity: 12 },
+      { productId: 2142201, productName: '05PT', quantity: 1 },
+      { productId: 2642206, productName: '06AM', quantity: 41 },
+      { productId: 2652206, productName: '07PT', quantity: 41 },
+      { productId: 2662206, productName: '10CD', quantity: 41 },
+      { productId: 2672456 },
+      { productId: 2672457 },
+    ];
+
+    datasource.data = dataset;
+    datasource.sort('productName', true);
+
+    expect(datasource.data[0].productName).toEqual('1');
+    expect(datasource.data[1].productName).toEqual('10');
+    expect(datasource.data[2].productName).toEqual('01AM');
+    expect(datasource.data[9].productName).toEqual('07PT');
+    expect(datasource.data[10].productName).toEqual('10CD');
+    expect(datasource.data[11].productName).toBe(undefined);
+    expect(datasource.data[12].productName).toBe(undefined);
+
+    datasource.sort('productName', false);
+
+    expect(datasource.data[0].productName).toEqual('10CD');
+    expect(datasource.data[1].productName).toEqual('07PT');
+    expect(datasource.data[2].productName).toEqual('06AM');
+    expect(datasource.data[9].productName).toEqual('10');
+    expect(datasource.data[10].productName).toEqual('1');
+    expect(datasource.data[11].productName).toBe(undefined);
+    expect(datasource.data[12].productName).toBe(undefined);
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR implements a similar logic change from infor-design/enterprise#6787 that identifies real numbers in a sort, and prioritizes them over string values, causing them to sort separately.  Additionally, the sort pushes items that are "empty" to the bottom of the set, regardless of whether the sort is ascending or descending. This behavior was requested to make our datagrid behave similarly to Microsoft Excel when sorting occurs.

In this repo, the change has been made to IdsDataSource instead of IdsDataGrid, which is where the sort now occurs.

**Related github/jira issue (required)**:
Closes #1158

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/combo-sort.html
- Use the "Product Name" column to change the sort.  The numbers `1` and `10` should always be separately sorted from the other values that contain text.  Compare the locations of text/number results with those seen on [the corresponding Enterprise example](https://main-enterprise.demo.design.infor.com/components/datagrid/test-combo-sort.html)
- In both cases (ascending and descending), any empty rows should remain at the bottom of the list.
- New functional tests added to the IdsDataSource test suite should pass  

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
