### PR TITLE
1065 - Fix interaction bug in Dropdown IdsDataGridFilters

### DIFF
--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -509,8 +509,7 @@ export default class IdsDropdown extends Base {
           }
         }
       };
-      this.dropdownList.onTriggerClick = (e: Event) => {
-        e.stopPropagation();
+      this.dropdownList.onTriggerClick = () => {
         if (this.labelClicked) {
           this.labelClicked = false;
           return;
@@ -551,8 +550,6 @@ export default class IdsDropdown extends Base {
     if (!this.dropdownList || this.disabled || this.readonly) {
       return;
     }
-
-    this.dropdownList?.closeOtherPopups();
 
     // Trigger an async callback for contents
     if (typeof this.state.beforeShow === 'function') {

--- a/src/mixins/ids-popup-open-events-mixin/ids-popup-open-events-mixin.ts
+++ b/src/mixins/ids-popup-open-events-mixin/ids-popup-open-events-mixin.ts
@@ -78,14 +78,6 @@ const IdsPopupOpenEventsMixin = <T extends Constraints>(superclass: T) => class 
     this.hasOpenEvents = false;
     this.#currentPopupOpenEventsTarget = null;
   }
-
-  /**
-   * Closes unrelated Popup components via the established document-level event handler
-   * @returns {void}
-   */
-  closeOtherPopups() {
-    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 1 }));
-  }
 };
 
 export default IdsPopupOpenEventsMixin;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR is a followup to #1164 and #1133, and fixes a minor bug in IdsTimePickerPopups combined with IdsDataGridFilters.   A change I made to try and close other Dropdown components when a new one opens was causing all the dropdowns inside the TimePickerPopup to accidentally close the TimePickerPopup as well.  This PR fixes that interaction bug and removes some extraneous code related to it

**Related github/jira issue (required)**:
Closes #1065

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/filter-trigger-fields.html
- Use the "Pub. Time" field to filter on time.  Usage of the IdsDropDowns should not close the Time Picker Popup
- Open/Close all three Dropdown filter popups.  None of them should remain open when others are opened.
- Also try this on http://localhost:4300/ids-dropdown/example.html