### PR TITLE
1154 - Add support for double event click with data grid

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Button/Input/Dropdown]` Added posibility to show loading indicator. ([#1048](https://github.com/infor-design/enterprise-wc/issues/1048))
 - `[Datagrid]` Added feature to export data grid to excel xlsx or csv file. ([#153](https://github.com/infor-design/enterprise-wc/issues/153))
+- `[DataGrid]` Added support for double click event. ([#1154](https://github.com/infor-design/enterprise-wc/issues/1154))
 - `[Datagrid/Dropdown]` Separated IdsDropdownList into its own component, re-integrated the new component into IdsDropdown, and fixed containment/cutoff issues in IdsDataGrid using the new list component. ([#1065](https://github.com/infor-design/enterprise-wc/issues/1065))
 - `[Data Source]` Changed the default sort function to behave more like Excel, sorting separately numbers, strings, and empty space. ([#1158](https://github.com/infor-design/enterprise-wc/issues/1158))
 - `[Datagrid]` Fixed broken validation styling in editable cells. ([#1171](https://github.com/infor-design/enterprise-wc/issues/1171))

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -471,7 +471,7 @@ The formatter is then linked via the column on the formatter setting. When the g
 - `rowactivated` Fires for each row that is activated.
 - `rowdeactivated` Fires for each row that is deactivated.
 - `rowclick` Fires for each row that is clicked.
-- `doubleclick` Fires each time double clicked on body cells or header cells. Based on where it clicked details can be capture like `type: 'body-cell'|'header-title'|'header-filter'` etc.
+- `dblclick` Fires each time double clicked on body cells or header cells. Based on where it clicked details can be capture like `type: 'body-cell'|'header-title'|'header-filter'` etc.
 - `filtered` Fires after a filter action occurs, clear or apply filter condition.
 - `filteroperatorchanged` Fires once a filter operator changed.
 - `filterrowopened` Fires after the filter row is opened by the user.

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -471,7 +471,8 @@ The formatter is then linked via the column on the formatter setting. When the g
 - `rowactivated` Fires for each row that is activated.
 - `rowdeactivated` Fires for each row that is deactivated.
 - `rowclick` Fires for each row that is clicked.
-- `rowdoubleclick` Fires for each row that is double clicked.
+- `doubleclick` Fires each time double clicked on body cells or header cells. Based on where it clicked details can be capture like `type: 'body-cell'|'header-title'|'header-filter'` etc.
+- `doubleclick` Fires each time double clicked on body cells or header cells. Based on where it clicked can capture the details like type: 'body-cell'|'header-title'|'header-filter' etc.
 - `filtered` Fires after a filter action occurs, clear or apply filter condition.
 - `filteroperatorchanged` Fires once a filter operator changed.
 - `filterrowopened` Fires after the filter row is opened by the user.

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -472,7 +472,6 @@ The formatter is then linked via the column on the formatter setting. When the g
 - `rowdeactivated` Fires for each row that is deactivated.
 - `rowclick` Fires for each row that is clicked.
 - `doubleclick` Fires each time double clicked on body cells or header cells. Based on where it clicked details can be capture like `type: 'body-cell'|'header-title'|'header-filter'` etc.
-- `doubleclick` Fires each time double clicked on body cells or header cells. Based on where it clicked can capture the details like type: 'body-cell'|'header-title'|'header-filter' etc.
 - `filtered` Fires after a filter action occurs, clear or apply filter condition.
 - `filteroperatorchanged` Fires once a filter operator changed.
 - `filterrowopened` Fires after the filter row is opened by the user.

--- a/src/components/ids-data-grid/demos/double-click.html
+++ b/src/components/ids-data-grid/demos/double-click.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">Data Grid (Double Click)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="16" type="p">Double click on grid body cells or header cells, and check the console for "doubleclick" event details.</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto="true">
+      <ids-layout-grid-cell>
+        <ids-data-grid id="data-grid-double-click" label="Books" editable="true"></ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/double-click.ts
+++ b/src/components/ids-data-grid/demos/double-click.ts
@@ -95,7 +95,7 @@ if (dataGrid) {
     });
 
     // Bind double click event
-    dataGrid.addEventListener('doubleclick', (e: Event) => {
+    dataGrid.addEventListener('dblclick', (e: Event) => {
       console.info(`Double Clicked`, (<CustomEvent>e).detail);
     });
 

--- a/src/components/ids-data-grid/demos/double-click.ts
+++ b/src/components/ids-data-grid/demos/double-click.ts
@@ -1,0 +1,138 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+import booksJSON from '../../../assets/data/books.json';
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-double-click');
+const container: any = document.querySelector('ids-container');
+
+if (dataGrid) {
+  (async function init() {
+    // Set Locale and wait for it to load
+    await container?.setLocale('en-US');
+
+    // Do an ajax request
+    const url: any = booksJSON;
+    const columns: IdsDataGridColumn[] = [];
+
+    // Set up columns
+    columns.push({
+      id: 'rowNumber',
+      name: '#',
+      formatter: dataGrid.formatters.rowNumber,
+      readonly: true,
+      width: 65
+    });
+    columns.push({
+      id: 'description',
+      name: 'Description',
+      field: 'description',
+      width: 180,
+      editor: {
+        type: 'input',
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true,
+          validate: 'required'
+        }
+      },
+      formatter: dataGrid.formatters.text,
+      filterType: dataGrid.filters.text,
+      resizable: true,
+    });
+    columns.push({
+      id: 'ledger',
+      name: 'Ledger',
+      field: 'ledger',
+      formatter: dataGrid.formatters.text,
+      resizable: true,
+      hidden: true
+    });
+    columns.push({
+      id: 'publishDate',
+      name: 'Pub. Date',
+      field: 'publishDate',
+      formatter: dataGrid.formatters.date,
+      resizable: true,
+    });
+    columns.push({
+      id: 'publishTime',
+      name: 'Pub. Time',
+      field: 'publishDate',
+      formatter: dataGrid.formatters.time,
+      resizable: true,
+    });
+    columns.push({
+      id: 'price',
+      name: 'Price',
+      field: 'price',
+      formatter: dataGrid.formatters.decimal,
+      resizable: true,
+      formatOptions: { locale: 'en-US' }
+    });
+    columns.push({
+      id: 'bookCurrency',
+      name: 'Currency',
+      field: 'bookCurrency',
+      formatter: dataGrid.formatters.text,
+      resizable: true,
+    });
+    columns.push({
+      id: 'transactionCurrency',
+      name: 'Transaction Currency',
+      field: 'transactionCurrency',
+      formatter: dataGrid.formatters.text,
+      resizable: true,
+    });
+    columns.push({
+      id: 'integer',
+      name: 'Price (Int)',
+      field: 'price',
+      formatter: dataGrid.formatters.integer,
+      resizable: true,
+      formatOptions: { locale: 'en-US' }
+    });
+
+    // Bind double click event
+    dataGrid.addEventListener('doubleclick', (e: Event) => {
+      console.info(`Double Clicked`, (<CustomEvent>e).detail);
+    });
+
+    dataGrid.columns = columns;
+    const setData = async () => {
+      const res = await fetch(url);
+      const data = await res.json();
+      dataGrid.columnGroups = [
+        {
+          colspan: 2,
+          id: 'group1',
+          name: 'Column Group One',
+          align: 'center'
+        },
+        {
+          colspan: 2,
+          id: 'group2',
+          name: 'Column Group Two',
+          headerIcon: 'error',
+          headerIconTooltip: 'The group2 icon.',
+        },
+        {
+          colspan: 2,
+          id: 'group3',
+          name: 'Column Group Three',
+          align: 'right'
+        },
+        {
+          colspan: 3,
+          id: 'group4',
+          name: 'Column Group Four',
+          align: 'left'
+        }
+      ];
+      dataGrid.data = data;
+    };
+
+    setData();
+  }());
+}

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -77,6 +77,9 @@
   - link: disable-client-filter.html
     type: Example
     description: Shows a data grid with disable client filter
+  - link: double-click.html
+    type: Example
+    description: Showing a data grid with double click event
   - link: editable.html
     type: Example
     description: Shows a data grid with editable cells

--- a/src/components/ids-data-grid/demos/suppress-row-click-selection.ts
+++ b/src/components/ids-data-grid/demos/suppress-row-click-selection.ts
@@ -95,7 +95,7 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-multi')!;
     console.info(`Row Clicked`, (<CustomEvent>e).detail);
   });
 
-  dataGrid.addEventListener('doubleclick', (e: Event) => {
+  dataGrid.addEventListener('dblclick', (e: Event) => {
     console.info(`Double Clicked`, (<CustomEvent>e).detail);
   });
 }());

--- a/src/components/ids-data-grid/demos/suppress-row-click-selection.ts
+++ b/src/components/ids-data-grid/demos/suppress-row-click-selection.ts
@@ -95,7 +95,7 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-multi')!;
     console.info(`Row Clicked`, (<CustomEvent>e).detail);
   });
 
-  dataGrid.addEventListener('rowdoubleclick', (e: Event) => {
-    console.info(`Row Double Clicked`, (<CustomEvent>e).detail);
+  dataGrid.addEventListener('doubleclick', (e: Event) => {
+    console.info(`Double Clicked`, (<CustomEvent>e).detail);
   });
 }());

--- a/src/components/ids-data-grid/ids-data-grid-container-arguments.ts
+++ b/src/components/ids-data-grid/ids-data-grid-container-arguments.ts
@@ -1,0 +1,159 @@
+import { eventPath, findInPath } from '../../utils/ids-event-path-utils/ids-event-path-utils';
+import { stringToNumber } from '../../utils/ids-string-utils/ids-string-utils';
+
+import type IdsDataGrid from './ids-data-grid';
+
+/**
+ * Container arguments interface.
+ */
+export interface IdsDataGridContainerArgs {
+  /* Column id */
+  columnId?: string;
+  /* Column data */
+  columnData?: any;
+  /* Column index */
+  columnIndex?: number;
+  /* Column group id */
+  columnGroupId?: string;
+  /* Column group data */
+  columnGroupData?: any;
+  /* Column group index */
+  columnGroupIndex?: number;
+  /* Field data */
+  fieldData?: any;
+  /* The grid api object */
+  grid?: IdsDataGrid;
+  /* Is header group */
+  isHeaderGroup?: boolean;
+  /* Row data */
+  rowData?: any;
+  /* Row index */
+  rowIndex?: number,
+  /* Type of target element */
+  type?: string;
+}
+
+/**
+ * Types for container target element.
+ */
+export const containerTypes = {
+  BODY_CELL: 'body-cell',
+  BODY_CELL_EDITOR: 'body-cell-editor',
+  HEADER_TITLE: 'header-title',
+  HEADER_ICON: 'header-icon',
+  HEADER_FILTER: 'header-filter',
+  HEADER_FILTER_BUTTON: 'header-filter-button',
+};
+
+/**
+ * Get header arguments.
+ * @private
+ * @param {IdsDataGrid} this The data grid object.
+ * @param  {HTMLElement[]} path List of path element.
+ * @param  {HTMLElement} columnheader The column header element.
+ * @returns {IdsDataGridContainerArgs} The header arguments.
+ */
+export function containerHeaderArgs(
+  this: IdsDataGrid,
+  path: HTMLElement[],
+  columnheader: HTMLElement
+): IdsDataGridContainerArgs {
+  const filterWrapper = findInPath(path, '.ids-data-grid-header-cell-filter-wrapper') as HTMLElement;
+  const isHeaderIcon = !!(findInPath(path, '.ids-data-grid-header-icon') as HTMLElement);
+  const isHeaderGroup = columnheader.hasAttribute('column-group-id');
+
+  // Set type
+  const types = containerTypes;
+  let type = types.HEADER_TITLE;
+  if (isHeaderIcon) type = types.HEADER_ICON;
+  else if (filterWrapper) {
+    const filterButton = findInPath(path, '[data-filter-conditions-button]') as HTMLElement;
+    type = filterButton ? types.HEADER_FILTER_BUTTON : types.HEADER_FILTER;
+  }
+
+  // The arguments to pass along callback
+  let callbackArgs: IdsDataGridContainerArgs = { type, isHeaderGroup, grid: this };
+  if (isHeaderGroup) {
+    // Header (Group)
+    const columnGroupId = columnheader.getAttribute('column-group-id') as string;
+    const columnGroupData = this.columnGroupDataById(columnGroupId);
+    callbackArgs = {
+      ...callbackArgs,
+      columnGroupId,
+      columnGroupData,
+      rowIndex: 0,
+      columnGroupIndex: this.columnGroupIdxById(columnGroupId),
+    };
+  } else {
+    // Header (Non-Group)
+    const columnId = columnheader.getAttribute('column-id') as string;
+    const columnIndex = this.columnIdxById(columnId);
+    const columnData = this.columns[columnIndex as number];
+    callbackArgs = {
+      ...callbackArgs,
+      columnId,
+      columnIndex,
+      columnData,
+      rowIndex: this.columnGroups ? 1 : 0,
+    };
+  }
+  return callbackArgs;
+}
+
+/**
+ * Get body cell callback arguments.
+ * @private
+ * @param {IdsDataGrid} this The data grid object.
+ * @param  {HTMLElement[]} path List of path element.
+ * @param  {HTMLElement} cellEl The cell element.
+ * @returns {void}
+ */
+export function containerBodyCellArgs(
+  this: IdsDataGrid,
+  path: HTMLElement[],
+  cellEl: HTMLElement
+): IdsDataGridContainerArgs {
+  const isEditing = !!(findInPath(path, '.is-editing') as HTMLElement);
+  const rowIndex = stringToNumber(findInPath(path, '[role="row"]')?.getAttribute('data-index'));
+  const columnIndex = stringToNumber(cellEl.getAttribute('aria-colindex')) - 1;
+  const rowData = this.data[rowIndex];
+  const columnData = this.columns[columnIndex];
+  const columnId = columnData.id;
+  const fieldData = rowData[columnId];
+
+  // The arguments to pass along callback
+  return {
+    type: isEditing ? containerTypes.BODY_CELL_EDITOR : containerTypes.BODY_CELL,
+    rowData,
+    rowIndex,
+    columnData,
+    columnId,
+    columnIndex,
+    fieldData,
+    grid: this
+  };
+}
+
+/**
+ * Get container arguments.
+ * @param {IdsDataGrid} this The data grid object.
+ * @param {MouseEvent} e The event.
+ * @returns {IdsDataGridContainerArgs} The callback arguments.
+ */
+export function containerArguments(
+  this: IdsDataGrid,
+  e: MouseEvent
+): IdsDataGridContainerArgs {
+  const path = eventPath(e);
+  const cellEl = findInPath(path, '[role="gridcell"]');
+  const columnheader = findInPath(path, '[role="columnheader"]');
+  let args: IdsDataGridContainerArgs = {};
+
+  if (cellEl) {
+    args = containerBodyCellArgs.apply(this, [path, cellEl]);
+  } else if (columnheader) {
+    args = containerHeaderArgs.apply(this, [path, columnheader]);
+  }
+
+  return args;
+}

--- a/src/components/ids-data-grid/ids-data-grid-contextmenu.ts
+++ b/src/components/ids-data-grid/ids-data-grid-contextmenu.ts
@@ -1,40 +1,21 @@
 import { eventPath, findInPath, HTMLElementEvent } from '../../utils/ids-event-path-utils/ids-event-path-utils';
-import { stringToNumber } from '../../utils/ids-string-utils/ids-string-utils';
+import {
+  containerHeaderArgs,
+  containerBodyCellArgs,
+  IdsDataGridContainerArgs
+} from './ids-data-grid-container-arguments';
+
 import type IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
 import type IdsDataGrid from './ids-data-grid';
 
 /**
  * Contextmenu arguments interface.
  */
-export interface IdsDataGridContextmenuArgs {
-  /* Column id */
-  columnId?: string;
-  /* Column data */
-  columnData?: any;
-  /* Column index */
-  columnIndex?: number;
-  /* Column group id */
-  columnGroupId?: string;
-  /* Column group data */
-  columnGroupData?: any;
-  /* Column group index */
-  columnGroupIndex?: number;
-  /* Field data */
-  fieldData?: any;
-  /* The grid api object */
-  grid?: IdsDataGrid;
-  /* Is header group */
-  isHeaderGroup?: boolean;
+export interface IdsDataGridContextmenuArgs extends IdsDataGridContainerArgs {
   /* The popup menu element attached with contextmenu */
   menuEl?: IdsPopupMenu;
   /* The origin event dispatched */
   menuSelectedEvent?: any;
-  /* Row data */
-  rowData?: any;
-  /* Row index */
-  rowIndex?: number,
-  /* Type of contextmenu as unique identifier */
-  type?: string;
   /* The selected value for menu item */
   menuSelectedValue?: string;
 }
@@ -84,10 +65,10 @@ function setContextmenuCompulsoryAttributes(menu?: IdsPopupMenu): void {
  * Show contextmenu.
  * @private
  * @param {IdsDataGrid} this The data grid object.
- * @param {HTMLElementEvent<HTMLElement[]>} e The contextmenu event.
+ * @param {MouseEvent} e The contextmenu event.
  * @returns {void}
  */
-function showContextmenu(this: IdsDataGrid, e: any): boolean {
+function showContextmenu(this: IdsDataGrid, e: MouseEvent): boolean {
   const { menu: menuEl, target, callbackArgs } = this.contextmenuInfo;
   let isShow = false;
   if (menuEl && target && callbackArgs) {
@@ -130,102 +111,17 @@ function showContextmenu(this: IdsDataGrid, e: any): boolean {
 }
 
 /**
- * Get body cell callback arguments.
- * @private
- * @param {IdsDataGrid} this The data grid object.
- * @param  {HTMLElement[]} path List of path element.
- * @param  {HTMLElement} cellEl The cell element.
- * @returns {void}
- */
-function contextmenuBodyCellArgs(this: IdsDataGrid, path: HTMLElement[], cellEl: HTMLElement): IdsDataGridContextmenuArgs {
-  const isEditing = !!(findInPath(path, '.is-editing') as HTMLElement);
-  const rowIndex = stringToNumber(findInPath(path, '[role="row"]')?.getAttribute('data-index'));
-  const columnIndex = stringToNumber(cellEl.getAttribute('aria-colindex')) - 1;
-  const rowData = this.data[rowIndex];
-  const columnData = this.columns[columnIndex];
-  const columnId = columnData.id;
-  const fieldData = rowData[columnId];
-
-  // The arguments to pass along callback
-  return {
-    type: isEditing ? this.contextmenuTypes.BODY_CELL_EDITOR : this.contextmenuTypes.BODY_CELL,
-    rowData,
-    rowIndex,
-    columnData,
-    columnId,
-    columnIndex,
-    fieldData,
-    grid: this
-  };
-}
-
-/**
- * Get header callback arguments.
- * @private
- * @param {IdsDataGrid} this The data grid object.
- * @param  {HTMLElement[]} path List of path element.
- * @param  {HTMLElement} columnheader The column header element.
- * @returns {void}
- */
-function contextmenuHeaderArgs(
-  this: IdsDataGrid,
-  path: HTMLElement[],
-  columnheader: HTMLElement
-): IdsDataGridContextmenuArgs {
-  const filterWrapper = findInPath(path, '.ids-data-grid-header-cell-filter-wrapper') as HTMLElement;
-  const isHeaderIcon = !!(findInPath(path, '.ids-data-grid-header-icon') as HTMLElement);
-  const isHeaderGroup = columnheader.hasAttribute('column-group-id');
-
-  // Set type
-  const types = this.contextmenuTypes;
-  let type = types.HEADER_TITLE;
-  if (isHeaderIcon) type = types.HEADER_ICON;
-  else if (filterWrapper) {
-    const filterButton = findInPath(path, '[data-filter-conditions-button]') as HTMLElement;
-    type = filterButton ? types.HEADER_FILTER_BUTTON : types.HEADER_FILTER;
-  }
-
-  // The arguments to pass along callback
-  let callbackArgs: IdsDataGridContextmenuArgs = { type, isHeaderGroup, grid: this };
-  if (isHeaderGroup) {
-    // Header (Group)
-    const columnGroupId = columnheader.getAttribute('column-group-id') as string;
-    const columnGroupData = this.columnGroupDataById(columnGroupId);
-    callbackArgs = {
-      ...callbackArgs,
-      columnGroupId,
-      columnGroupData,
-      rowIndex: 0,
-      columnGroupIndex: this.columnGroupIdxById(columnGroupId),
-    };
-  } else {
-    // Header (Non-Group)
-    const columnId = columnheader.getAttribute('column-id') as string;
-    const columnIndex = this.columnIdxById(columnId);
-    const columnData = this.columns[columnIndex as number];
-    callbackArgs = {
-      ...callbackArgs,
-      columnId,
-      columnIndex,
-      columnData,
-      rowIndex: this.columnGroups ? 1 : 0,
-    };
-  }
-  return callbackArgs;
-}
-
-/**
  * Handle contextmenu.
  * @private
  * @param {IdsDataGrid} this The data grid object.
- * @param {HTMLElementEvent<HTMLElement[]>} e The contextmenu event.
+ * @param {MouseEvent} e The contextmenu event.
  * @param {IdsPopupMenu} menu The contextmenu element.
  * @param {IdsPopupMenu} headerMenu The header contextmenu element.
  * @returns {void}
  */
 function handleContextmenu(
   this: IdsDataGrid,
-  e: HTMLElementEvent<HTMLElement[]>,
+  e: MouseEvent,
   menu?: IdsPopupMenu,
   headerMenu?: IdsPopupMenu,
 ): void {
@@ -239,10 +135,10 @@ function handleContextmenu(
   const cellEl = findInPath(path, '[role="gridcell"]');
 
   if (cellEl && menu) {
-    const callbackArgs = contextmenuBodyCellArgs.apply(this, [path, cellEl]);
+    const callbackArgs = containerBodyCellArgs.apply(this, [path, cellEl]);
     args = { menu, target: cellEl, callbackArgs };
   } else if (columnheader && headerMenu) {
-    const callbackArgs = contextmenuHeaderArgs.apply(this, [path, columnheader]);
+    const callbackArgs = containerHeaderArgs.apply(this, [path, columnheader]);
     args = { menu: headerMenu, target: columnheader, callbackArgs };
   }
 
@@ -294,7 +190,7 @@ export function setContextmenu(this: IdsDataGrid) {
 
     // Contextmenu for header, header group and body cells.
     this.offEvent('contextmenu.datagrid', this.container);
-    this.onEvent('contextmenu.datagrid', this.container, (e: HTMLElementEvent<HTMLElement[]>) => {
+    this.onEvent('contextmenu.datagrid', this.container, (e: MouseEvent) => {
       handleContextmenu.apply(this, [e, menu, headerMenu]);
     });
 

--- a/src/components/ids-data-grid/ids-data-grid-tooltip-mixin.ts
+++ b/src/components/ids-data-grid/ids-data-grid-tooltip-mixin.ts
@@ -82,7 +82,7 @@ const IdsDataGridTooltipMixin = <T extends Constraints>(superclass: T) => class 
    * @private
    * @param {MouseEvent} e The event
    */
-  async #handleTooltip(e: any) {
+  async #handleTooltip(e: MouseEvent) {
     const path = eventPath(e);
 
     // Close if previously showing
@@ -510,7 +510,7 @@ const IdsDataGridTooltipMixin = <T extends Constraints>(superclass: T) => class 
       this.#mouseOut = true;
       this.#hideTooltip();
     }, 250));
-    this.onEvent('mouseover.data-grid', this.container, debounce(async (e: any) => {
+    this.onEvent('mouseover.data-grid', this.container, debounce(async (e: MouseEvent) => {
       this.#mouseOut = false;
       this.#handleTooltip(e);
     }, 250));

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -517,7 +517,7 @@ export default class IdsDataGrid extends Base {
     // Add double click to the container
     this.offEvent('dblclick.container', this.container);
     this.onEvent('dblclick.container', this.container, (e: MouseEvent) => {
-      this.triggerEvent('doubleclick', this, {
+      this.triggerEvent('dblclick', this, {
         bubbles: true,
         detail: {
           ...containerArguments.apply(this, [e]),

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -10,6 +10,7 @@ import IdsDataSource from '../../core/ids-data-source';
 import IdsDataGridFormatters from './ids-data-grid-formatters';
 import { editors } from './ids-data-grid-editors';
 import IdsDataGridFilters, { IdsDataGridFilterConditions } from './ids-data-grid-filters';
+import { containerArguments, containerTypes } from './ids-data-grid-container-arguments';
 import { IdsDataGridContextmenuArgs, setContextmenu, getContextmenuElem } from './ids-data-grid-contextmenu';
 import { IdsDataGridColumn, IdsDataGridColumnGroup } from './ids-data-grid-column';
 
@@ -97,16 +98,8 @@ export default class IdsDataGrid extends Base {
 
   /**
    * Types for contextmenu.
-   * @private
    */
-  contextmenuTypes = {
-    BODY_CELL: 'body-cell',
-    BODY_CELL_EDITOR: 'body-cell-editor',
-    HEADER_TITLE: 'header-title',
-    HEADER_ICON: 'header-icon',
-    HEADER_FILTER: 'header-filter',
-    HEADER_FILTER_BUTTON: 'header-filter-button',
-  };
+  contextmenuTypes = { ...containerTypes };
 
   constructor() {
     super();
@@ -523,18 +516,14 @@ export default class IdsDataGrid extends Base {
       }
     });
 
-    // Add double click to the table body
-    this.offEvent('dblclick.body', body);
-    this.onEvent('dblclick.body', body, (e: MouseEvent) => {
-      const row = (e.target as HTMLElement)?.closest('.ids-data-grid-row');
-      const rowIndex: string | null | undefined = row?.getAttribute('data-index');
-
-      if (!rowIndex) return;
-
-      // Fires for each row that is double clicked
-      this.triggerEvent('rowdoubleclick', this, {
+    // Add double click to the container
+    this.offEvent('dblclick.container', this.container);
+    this.onEvent('dblclick.container', this.container, (e: MouseEvent) => {
+      this.triggerEvent('doubleclick', this, {
+        bubbles: true,
         detail: {
-          elem: this, row, data: this.data[Number(rowIndex)]
+          ...containerArguments.apply(this, [e]),
+          originalEvent: e
         }
       });
     });

--- a/src/utils/ids-event-path-utils/ids-event-path-utils.ts
+++ b/src/utils/ids-event-path-utils/ids-event-path-utils.ts
@@ -2,8 +2,8 @@
  * Extends event type with path.
  */
 export type HTMLElementEvent<T extends HTMLElement[]> = Event & {
-  path: T;
-  orignPath: T;
+  path?: T;
+  orignPath?: T;
 };
 
 /**

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -69,7 +69,8 @@ describe('IdsDataGrid Component', () => {
       id: 'ledger',
       name: 'Ledger',
       field: 'ledger',
-      formatter: formatters.text
+      formatter: formatters.text,
+      filterType: dataGrid.filters.text
     });
     cols.push({
       id: 'publishDate',
@@ -2618,30 +2619,60 @@ describe('IdsDataGrid Component', () => {
   });
 
   describe('Events Tests', () => {
-    it('should fire rowclick and rowdoubleclick events', () => {
+    it('should fire rowclick event', () => {
       const clickCallback = jest.fn((e) => {
-        expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
-      });
-      const dblClickCallback = jest.fn((e) => {
         expect(e.detail.row?.getAttribute('data-index')).toEqual('0');
       });
 
       dataGrid.addEventListener('rowclick', clickCallback);
-      dataGrid.addEventListener('rowdoubleclick', dblClickCallback);
 
       const firstCellInRow = dataGrid.container.querySelector('.ids-data-grid-body .ids-data-grid-cell');
       const clickEvent = new MouseEvent('click', { bubbles: true });
-      const dblClickEvent = new MouseEvent('dblclick', { bubbles: true });
 
       firstCellInRow.dispatchEvent(clickEvent);
-      firstCellInRow.dispatchEvent(dblClickEvent);
 
       // body click edge case
       const body = dataGrid.container.querySelector('.ids-data-grid-body');
       body.dispatchEvent(clickEvent);
-      body.dispatchEvent(dblClickEvent);
       expect(clickCallback.mock.calls.length).toBe(1);
-      expect(dblClickCallback.mock.calls.length).toBe(1);
+    });
+
+    it('should fire double click event', () => {
+      let elemType = '';
+      const dblClickEvent = new MouseEvent('dblclick', { bubbles: true });
+      const dblClickCallback = jest.fn((e) => {
+        expect(e.detail.type).toEqual(elemType);
+      });
+      dataGrid.addEventListener('doubleclick', dblClickCallback);
+
+      elemType = 'header-title';
+      const headerTitle = dataGrid.container.querySelector('.ids-data-grid-header .ids-data-grid-header-cell');
+      headerTitle.dispatchEvent(dblClickEvent);
+
+      elemType = 'header-icon';
+      const headerIcon = dataGrid.container.querySelector('.ids-data-grid-header .ids-data-grid-header-icon');
+      headerIcon.dispatchEvent(dblClickEvent);
+
+      elemType = 'header-filter';
+      const headerFilter = dataGrid.container.querySelector('.ids-data-grid-header .ids-data-grid-header-cell-filter-wrapper');
+      headerFilter.dispatchEvent(dblClickEvent);
+
+      elemType = 'header-filter-button';
+      const headerFilterButton = dataGrid.container.querySelector('.ids-data-grid-header .ids-data-grid-header-cell-filter-wrapper [data-filter-conditions-button]');
+      headerFilterButton.dispatchEvent(dblClickEvent);
+
+      elemType = 'body-cell';
+      const bodyCell = dataGrid.container.querySelector('.ids-data-grid-body .ids-data-grid-cell');
+      bodyCell.dispatchEvent(dblClickEvent);
+
+      elemType = 'body-cell-editor';
+      dataGrid.editable = true;
+      const editableCell = dataGrid.container.querySelector('.ids-data-grid-row:nth-child(2) > .ids-data-grid-cell:nth-child(3)');
+      editableCell.startCellEdit();
+      expect(editableCell.classList.contains('is-editing')).toBeTruthy();
+      editableCell.dispatchEvent(dblClickEvent);
+
+      expect(dblClickCallback.mock.calls.length).toBe(6);
     });
 
     it.skip('should fire scrollstart event', async () => {

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -2643,7 +2643,7 @@ describe('IdsDataGrid Component', () => {
       const dblClickCallback = jest.fn((e) => {
         expect(e.detail.type).toEqual(elemType);
       });
-      dataGrid.addEventListener('doubleclick', dblClickCallback);
+      dataGrid.addEventListener('dblclick', dblClickCallback);
 
       elemType = 'header-title';
       const headerTitle = dataGrid.container.querySelector('.ids-data-grid-header .ids-data-grid-header-cell');


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added support for double click event with data grid

**Related github/jira issue (required)**:
Closes #1154

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-data-grid/double-click.html
- Double click on different parts of grid body cells and header cells
- See console for "doubleclick" event details.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
