### PR TITLE
1062 - IdsButton: change 'type' attribute to 'appearance'

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### 1.0.0-beta.9 Fixes
 
+- `[Button]` Renamed "type" attribute to "appearance", mapped a new "type" attribute that sets HTMLButtonElement's "type" attribute. ([#1062](https://github.com/infor-design/enterprise-wc/issues/1062))
+
 ## 1.0.0-beta.8
 
 ### 1.0.0-beta.8 Fixes
 
 - `[Button/Input/Dropdown]` Added ability to show loading indicator. ([#1048](https://github.com/infor-design/enterprise-wc/issues/1048))
-- `[Button]` Renamed "type" attribute to "appearance", mapped a new "type" attribute that sets HTMLButtonElement's "type" attribute. ([#1062](https://github.com/infor-design/enterprise-wc/issues/1062))
 - `[Card/Widget]` Added borderless setting for card/widget. ([#1169](https://github.com/infor-design/enterprise-wc/issues/1169))
 - `[Datagrid]` Added feature to export data grid to excel xlsx or csv file. ([#153](https://github.com/infor-design/enterprise-wc/issues/153))
 - `[DataGrid]` Added support for double click event. ([#1154](https://github.com/infor-design/enterprise-wc/issues/1154))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 1.0.0-beta.8 Fixes
 
 - `[Button/Input/Dropdown]` Added ability to show loading indicator. ([#1048](https://github.com/infor-design/enterprise-wc/issues/1048))
+- `[Button]` Renamed "type" attribute to "appearance", mapped a new "type" attribute that sets HTMLButtonElement's "type" attribute. ([#1062](https://github.com/infor-design/enterprise-wc/issues/1062))
 - `[Card/Widget]` Added borderless setting for card/widget. ([#1169](https://github.com/infor-design/enterprise-wc/issues/1169))
 - `[Datagrid]` Added feature to export data grid to excel xlsx or csv file. ([#153](https://github.com/infor-design/enterprise-wc/issues/153))
 - `[DataGrid]` Added support for double click event. ([#1154](https://github.com/infor-design/enterprise-wc/issues/1154))

--- a/src/components/ids-about/demos/example.html
+++ b/src/components/ids-about/demos/example.html
@@ -22,7 +22,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="about-example-trigger">Show About Screen</ids-button>
+        <ids-button appearance="secondary" id="about-example-trigger">Show About Screen</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-about/ids-about.ts
+++ b/src/components/ids-about/ids-about.ts
@@ -95,7 +95,7 @@ export default class IdsAbout extends Base {
    * Reusing ids-modal-button component with cancel attribute and extra css class to change appearance
    */
   #attachCloseButton() {
-    const element = `<ids-modal-button cancel slot="buttons" type="tertiary" css-class="ids-icon-button ids-modal-icon-button">
+    const element = `<ids-modal-button cancel slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
       <span class="audible">Close modal</span>
       <ids-icon icon="close"></ids-icon>
     </ids-modal-button>`;

--- a/src/components/ids-action-panel/demos/empty.html
+++ b/src/components/ids-action-panel/demos/empty.html
@@ -11,7 +11,7 @@
 
     <ids-layout-grid>
       <ids-layout-grid-column>
-        <ids-button type="secondary" id="cap-trigger-btn">Open Action Panel</ids-button>
+        <ids-button appearance="secondary" id="cap-trigger-btn">Open Action Panel</ids-button>
       </ids-layout-grid-column>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-action-panel/demos/example.html
+++ b/src/components/ids-action-panel/demos/example.html
@@ -93,7 +93,7 @@
 
     <ids-layout-grid>
       <ids-layout-grid-column>
-        <ids-button type="secondary" id="cap-trigger-btn">Open Action Panel</ids-button>
+        <ids-button appearance="secondary" id="cap-trigger-btn">Open Action Panel</ids-button>
       </ids-layout-grid-column>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-action-sheet/ids-action-sheet.ts
+++ b/src/components/ids-action-sheet/ids-action-sheet.ts
@@ -69,7 +69,7 @@ export default class IdsActionSheet extends Base {
         <ids-overlay opacity=".5"></ids-overlay>
         <div class="ids-action-sheet-inner">
           <slot></slot>
-          <ids-button type="secondary" part="cancel-btn">
+          <ids-button appearance="secondary" part="cancel-btn">
             <span>${this.cancelBtnText}</span>
           </ids-button>
         </div>

--- a/src/components/ids-breadcrumb/demos/sandbox.html
+++ b/src/components/ids-breadcrumb/demos/sandbox.html
@@ -29,8 +29,8 @@
       <ids-layout-grid-cell>
         <ids-text>New Breadcrumb Controls</ids-text>
         <ids-checkbox id="disable-breadcrumb" label="Disable new breadcrumbs"></ids-checkbox>
-        <ids-button id="add-new-breadcrumb" type="secondary">Add to the end</ids-button>
-        <ids-button id="remove-last-breadcrumb" type="secondary">Remove from the end</ids-button>
+        <ids-button id="add-new-breadcrumb" appearance="secondary">Add to the end</ids-button>
+        <ids-button id="remove-last-breadcrumb" appearance="secondary">Remove from the end</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-button/README.md
+++ b/src/components/ids-button/README.md
@@ -26,7 +26,7 @@ The IDS Button component is a simple wrapper around a standard HTMLButtonElement
 Standalone primary buttons could be built this way:
 
 ```html
-<ids-button id="my-button" type="primary">
+<ids-button id="my-button" appearance="primary">
   <span>My Button</span>
 </ids-button>
 ```
@@ -34,7 +34,7 @@ Standalone primary buttons could be built this way:
 Add an icon to the button using the `icon` attribute:
 
 ```html
-<ids-button id="my-button" type="primary" icon="settings">
+<ids-button id="my-button" appearance="primary" icon="settings">
   <span>My Button</span>
 </ids-button>
 ```
@@ -42,14 +42,14 @@ Add an icon to the button using the `icon` attribute:
 IDS Buttons can be designed to make the icon appear by itself, without any visible text.  For accessibility reasons, descriptive text explaining the button's function should always be present.  In this scenario, the text span can have an "audible" class added, which will visually hide the text, but keep it accessible to screen readers:
 
 ```html
-<ids-button id="my-button" type="primary" icon="settings">
+<ids-button id="my-button" appearance="primary" icon="settings">
   <span class="audible">My Button</span>
 </ids-button>
 ```
 
 ### Color Variants
 
-If placing a button inside a container with a contrasting background color, sometimes the "base" styles for Ids Button types aren't adequate for passing contrast checks. To resolve this problem, the `color-variant` property can be used by way of the [IdsColorVariantMixin](../../mixins/ids-color-variant-mixin/README.md):
+If placing a button inside a container with a contrasting background color, sometimes the "base" styles for Ids Button appearances aren't adequate for passing contrast checks. To resolve this problem, the `color-variant` property can be used by way of the [IdsColorVariantMixin](../../mixins/ids-color-variant-mixin/README.md):
 
 ```html
 <!-- Generates a default (Tertiary) Button with white text and focus/hover states --->
@@ -58,12 +58,12 @@ If placing a button inside a container with a contrasting background color, some
 </ids-button>
 
 <!-- Generates a Primary Button with a slightly more bright Azure --->
-<ids-button id="my-button-2" type="primary" color-variant="alternate">
+<ids-button id="my-button-2" appearance="primary" color-variant="alternate">
   <span>My Button</span>
 </ids-button>
 
 <!-- Generates a Secondary Button with a slightly more bright Slate --->
-<ids-button id="my-button-3" type="primary" color-variant="alternate">
+<ids-button id="my-button-3" appearance="primary" color-variant="alternate">
   <span>My Button</span>
 </ids-button>
 
@@ -82,11 +82,11 @@ Standard button states include:
 - Focus
 - Active (pressed)
 - Disabled
-- Color Variant - alternate colors for each button type are available via the [IdsColorVariantMixin](../../src/mixins/ids-color-variant/README.md)
+- Color Variant - alternate colors for each button appearance are available via the [IdsColorVariantMixin](../../src/mixins/ids-color-variant/README.md)
 
-IDS button types include:
+IDS button appearances include:
 
-- `default` (not displayed as a "type" attribute when set)
+- `default` (not displayed as a "appearance" attribute when set)
 - `primary`
 - `primary-destructive`
 - `secondary`
@@ -100,7 +100,7 @@ By default, alignment of text/icons within an IDS Button will occur based on the
 The example below will result in the icon appearing after the text, even though the DOM order is the opposite:
 
 ```html
-<ids-button id="my-button" type="primary" icon="settings" icon-align="end">
+<ids-button id="my-button" appearance="primary" icon="settings" icon-align="end">
   <span>My Button</span>
 </ids-button>
 ```
@@ -115,14 +115,14 @@ The attribute has the following effects:
 
 ## Settings and Attributes
 
+- `appearance` {string} The visual style defining the purpose of the button
 - `colorVariant` {'alternate' | 'alternate-formatter'} Set the variants theme styles
 - `cssClass` {Array<string> | string | null} Contains space-delimited CSS classes (or an array of CSS classes) that will be passed to the Shadow Root button
 - `disabled` {boolean} Sets the internal Button element's `disabled` property to enable/disable the button
 - `icon` {string | null} A string representing an icon to display inside the button.  This string is passed to a slotted [IdsIcon](../ids-icon/README.md) element's `icon` setting to set the desired icon type.
 - `iconAlign` {string} Defines which side to align the Button's icon against, can be 'start' or 'end'
 - `tabIndex` {string | number} Sets the internal Button element's `tabIndex` property for controlling focus
-- `text` {string} API-level method of setting a button's text content. This will become the content of the slotted text node when set.
-- `type` {string} The type/purpose of the button to display
+- `text` {string} API-level method of setting a button's text content. This will become the content of the slotted text node when set
 - `tooltip` {string} Sets up a string based tooltip
 - `square` {boolean} whether the corners of the button as an icon-button are angled/90°
 - `width` {string} Sets width of button. Accepts percent, pixels, rem, etc.
@@ -153,7 +153,7 @@ Be conscious of the layout of content within your buttons when they are present 
 - Change class `inforFormButton` to `btn-secondary
 
 **4.x to 5.x**
-The IDS Button component is now a WebComponent.  Instead of using classes to define the type, it is done directly with a "type" attribute:
+The IDS Button component is now a WebComponent.  Instead of using classes to define a button's purpose or visual style, it's now done directly with an "appearance" attribute:
 
 ```html
 <!-- 4.x button example -->
@@ -165,12 +165,12 @@ The IDS Button component is now a WebComponent.  Instead of using classes to def
 </button>
 
 <!-- this is the same button using the WebComponent -->
-<ids-button id="my-button" type="primary" icon="settings">
+<ids-button id="my-button" appearance="primary" icon="settings">
   <span>My Button</span>
 </ids-button>
 ```
 
-- Markup has changed to a custom element `<ids-button id="my-button" type="primary"></ids-button>`
+- Markup has changed to a custom element `<ids-button id="my-button" appearance="primary"></ids-button>`
 - Can now be imported as a single JS file and used with encapsulated styles.
-- Some button properties are now attributes - "type", "text", "icon", "disabled", etc.
+- Some button properties are now attributes - "appearance", "text", "icon", "disabled", etc.
 - Some components now extend IdsButton, such as [IdsToggleButton](../ids-toggle-button/README.md) and [IdsMenuButton](../ids-menu-button/README.md)...

--- a/src/components/ids-button/README.md
+++ b/src/components/ids-button/README.md
@@ -113,6 +113,16 @@ The attribute has the following effects:
 | 'start'    | icon to the left of text | icon to the right of text |
 | 'end'      | icon to the right of text | icon to the left of text |
 
+### Type
+
+IdsButton's type attribute simply passes through to the Shadow Root's HTMLButtonElement and defines its usage.  For example, this is how you would define a form's `submit` button:
+
+```html
+<ids-button id="my-button" type="submit">
+  <span>My Button</span>
+</ids-button>
+```
+
 ## Settings and Attributes
 
 - `appearance` {string} The visual style defining the purpose of the button
@@ -123,6 +133,7 @@ The attribute has the following effects:
 - `iconAlign` {string} Defines which side to align the Button's icon against, can be 'start' or 'end'
 - `tabIndex` {string | number} Sets the internal Button element's `tabIndex` property for controlling focus
 - `text` {string} API-level method of setting a button's text content. This will become the content of the slotted text node when set
+- `type` {string} Passes a 'type' attribute for a standard HTMLButtonElement into the IdsButton's ShadowRoot-contained button element
 - `tooltip` {string} Sets up a string based tooltip
 - `square` {boolean} whether the corners of the button as an icon-button are angled/90°
 - `width` {string} Sets width of button. Accepts percent, pixels, rem, etc.

--- a/src/components/ids-button/demos/example.html
+++ b/src/components/ids-button/demos/example.html
@@ -18,17 +18,17 @@
           <ids-text font-size="18" type="h2">Primary</ids-text>
         </p>
         <p>
-          <ids-button id="test-button-primary" type="primary">
+          <ids-button id="test-button-primary" appearance="primary">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-primary" type="primary" disabled>
+          <ids-button id="test-disabled-button-primary" appearance="primary" disabled>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-button-icon-primary" type="primary">
+          <ids-button id="test-button-icon-primary" appearance="primary">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
@@ -40,17 +40,17 @@
           <ids-text font-size="18" type="h2">Secondary</ids-text>
         </p>
         <p>
-          <ids-button id="test-button-secondary" type="secondary">
+          <ids-button id="test-button-secondary" appearance="secondary">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-secondary" type="secondary" disabled>
+          <ids-button id="test-disabled-button-secondary" appearance="secondary" disabled>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-button-icon-secondary" type="secondary">
+          <ids-button id="test-button-icon-secondary" appearance="secondary">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
@@ -62,13 +62,13 @@
           <ids-text font-size="18" type="h2">Tertiary</ids-text>
         </p>
         <p>
-          <ids-button id="test-button-tertiary" type="tertiary">
+          <ids-button id="test-button-tertiary" appearance="tertiary">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-tertiary" type="tertiary" disabled>
+          <ids-button id="test-disabled-button-tertiary" appearance="tertiary" disabled>
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
@@ -95,17 +95,17 @@
 
       <ids-layout-grid-cell>
         <p>
-          <ids-text font-size="18" type="h2">Destructive Primary</ids-text>
+          <ids-text font-size="18" appearance="h2">Destructive Primary</ids-text>
         </p>
 
         <p>
-          <ids-button id="test-button-primary-destructive" type="primary-destructive">
+          <ids-button id="test-button-primary-destructive" appearance="primary-destructive">
             <span>Action</span>
           </ids-button>
         </p>
 
         <p>
-          <ids-button id="test-button-disabled-primary-destructive" type="primary-destructive" disabled>
+          <ids-button id="test-button-disabled-primary-destructive" appearance="primary-destructive" disabled>
             <span>Action</span>
           </ids-button>
         </p>
@@ -117,14 +117,14 @@
         </p>
 
         <p>
-          <ids-button id="test-button-tertiary-destructive" type="tertiary-destructive">
+          <ids-button id="test-button-tertiary-destructive" appearance="tertiary-destructive">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
 
         <p>
-          <ids-button id="test-button-disabled-tertiary-destructive" type="tertiary-destructive" disabled>
+          <ids-button id="test-button-disabled-tertiary-destructive" appearance="tertiary-destructive" disabled>
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>

--- a/src/components/ids-button/demos/focus-on-click.html
+++ b/src/components/ids-button/demos/focus-on-click.html
@@ -18,23 +18,23 @@
     <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
         <p>
-          <ids-button type="primary" hide-focus="false">
+          <ids-button appearance="primary" hide-focus="false">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button type="primary" hide-focus="false">
+          <ids-button appearance="primary" hide-focus="false">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button type="secondary" hide-focus="false">
+          <ids-button appearance="secondary" hide-focus="false">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button type="secondary" hide-focus="false">
+          <ids-button appearance="secondary" hide-focus="false">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
@@ -43,7 +43,7 @@
 
       <ids-layout-grid-cell>
         <p>
-          <ids-button type="tertiary" hide-focus="false">
+          <ids-button appearance="tertiary" hide-focus="false">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>
@@ -55,12 +55,12 @@
           </ids-button>
         </p>
         <p>
-          <ids-button type="primary-destructive" hide-focus="false">
+          <ids-button appearance="primary-destructive" hide-focus="false">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button type="tertiary-destructive" hide-focus="false">
+          <ids-button appearance="tertiary-destructive" hide-focus="false">
             <ids-icon icon="folder"></ids-icon>
             <span>Action</span>
           </ids-button>

--- a/src/components/ids-button/demos/matrix.html
+++ b/src/components/ids-button/demos/matrix.html
@@ -47,29 +47,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span">Primary</ids-text></p>
         <p>
-          <ids-button id="test-button-primary" type="primary">
+          <ids-button id="test-button-primary" appearance="primary">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-primary" type="primary" disabled="true">
+          <ids-button id="test-disabled-button-primary" appearance="primary" disabled="true">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-primary" type="primary">
+          <ids-button id="test-icon-only-button-primary" appearance="primary">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-primary" type="primary">
+          <ids-button id="test-icon-button-primary" appearance="primary">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-primary" icon-align="end" type="primary">
+          <ids-button id="test-icon-end-button-primary" icon-align="end" appearance="primary">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -79,29 +79,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span">Secondary</ids-text></p>
         <p>
-          <ids-button id="test-button-secondary" type="secondary">
+          <ids-button id="test-button-secondary" appearance="secondary">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-secondary" type="secondary" disabled="true">
+          <ids-button id="test-disabled-button-secondary" appearance="secondary" disabled="true">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-secondary" type="secondary">
+          <ids-button id="test-icon-only-button-secondary" appearance="secondary">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-secondary" type="secondary">
+          <ids-button id="test-icon-button-secondary" appearance="secondary">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-secondary" icon-align="end" type="secondary">
+          <ids-button id="test-icon-end-button-secondary" icon-align="end" appearance="secondary">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -111,29 +111,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span">Tertiary</ids-text></p>
         <p>
-          <ids-button id="test-button-tertiary" type="tertiary">
+          <ids-button id="test-button-tertiary" appearance="tertiary">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-tertiary" type="tertiary" disabled="true">
+          <ids-button id="test-disabled-button-tertiary" appearance="tertiary" disabled="true">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-tertiary" type="tertiary">
+          <ids-button id="test-icon-only-button-tertiary" appearance="tertiary">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-tertiary" type="tertiary">
+          <ids-button id="test-icon-button-tertiary" appearance="tertiary">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-tertiary" icon-align="end" type="tertiary">
+          <ids-button id="test-icon-end-button-tertiary" icon-align="end" appearance="tertiary">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -143,29 +143,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span">Primary Destructive</ids-text></p>
         <p>
-          <ids-button id="test-button-primary-destructive" type="primary-destructive">
+          <ids-button id="test-button-primary-destructive" appearance="primary-destructive">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-primary-destructive" type="primary-destructive" disabled="true">
+          <ids-button id="test-disabled-button-primary-destructive" appearance="primary-destructive" disabled="true">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-primary-destructive" type="primary-destructive">
+          <ids-button id="test-icon-only-button-primary-destructive" appearance="primary-destructive">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-primary-destructive" type="primary-destructive">
+          <ids-button id="test-icon-button-primary-destructive" appearance="primary-destructive">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-primary-destructive" icon-align="end" type="primary-destructive">
+          <ids-button id="test-icon-end-button-primary-destructive" icon-align="end" appearance="primary-destructive">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -175,29 +175,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span">Tertiary Destructive</ids-text></p>
         <p>
-          <ids-button id="test-button-tertiary-destructive" type="tertiary-destructive">
+          <ids-button id="test-button-tertiary-destructive" appearance="tertiary-destructive">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-tertiary-destructive" type="tertiary-destructive" disabled="true">
+          <ids-button id="test-disabled-button-tertiary-destructive" appearance="tertiary-destructive" disabled="true">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-tertiary-destructive" type="tertiary-destructive">
+          <ids-button id="test-icon-only-button-tertiary-destructive" appearance="tertiary-destructive">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-tertiary-destructive" type="tertiary-destructive">
+          <ids-button id="test-icon-button-tertiary-destructive" appearance="tertiary-destructive">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-tertiary-destructive" icon-align="end" type="tertiary-destructive">
+          <ids-button id="test-icon-end-button-tertiary-destructive" icon-align="end" appearance="tertiary-destructive">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>

--- a/src/components/ids-button/demos/performance.ts
+++ b/src/components/ids-button/demos/performance.ts
@@ -5,7 +5,7 @@ const appendTestItems = () => {
   for (let index = 0; index < 1000; index++) {
     let html = '';
     html += `<ids-layout-grid-cell>
-    <ids-button id="button-${index}" type="secondary">Button ${index}</ids-button>
+    <ids-button id="button-${index}" appearance="secondary">Button ${index}</ids-button>
     </ids-layout-grid-cell>`;
     section.insertAdjacentHTML('beforeend', html);
   }

--- a/src/components/ids-button/demos/responsive.html
+++ b/src/components/ids-button/demos/responsive.html
@@ -14,13 +14,13 @@
 
       <ids-layout-grid>
         <ids-layout-grid-cell col-span="12">
-          <ids-button type="secondary" width="100%">
+          <ids-button appearance="secondary" width="100%">
             <span>100%</span>
           </ids-button>
         </ids-layout-grid-cell>
 
         <ids-layout-grid-cell col-span="12">
-          <ids-button type="secondary" width="50%">
+          <ids-button appearance="secondary" width="50%">
             <span>50%</span>
           </ids-button>
         </ids-layout-grid-cell>
@@ -33,14 +33,14 @@
 
       <ids-layout-grid>
         <ids-layout-grid-cell col-span="12">
-          <ids-button type="secondary" width="500px">
+          <ids-button appearance="secondary" width="500px">
             <ids-icon icon="settings"></ids-icon>
             <span>500px</span>
           </ids-button>
         </ids-layout-grid-cell>
 
         <ids-layout-grid-cell col-span="12">
-          <ids-button type="secondary" width="250px">
+          <ids-button appearance="secondary" width="250px">
             <ids-icon icon="settings"></ids-icon>
             <span>250px</span>
           </ids-button>

--- a/src/components/ids-button/demos/side-by-side.html
+++ b/src/components/ids-button/demos/side-by-side.html
@@ -20,19 +20,19 @@
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-disabled-button-primary" type="primary"  disabled="true">
+        <ids-button id="test-disabled-button-primary" appearance="primary"  disabled="true">
           <span>Primary Button</span>
         </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-disabled-button-secondary" type="secondary"  disabled="true">
+        <ids-button id="test-disabled-button-secondary" appearance="secondary"  disabled="true">
           <span>Secondary Button</span>
         </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-disabled-button-tertiary" type="tertiary"  disabled="true">
+        <ids-button id="test-disabled-button-tertiary" appearance="tertiary"  disabled="true">
           <span>Tertiary Button</span>
         </ids-button>
       </ids-layout-grid-cell>
@@ -47,21 +47,21 @@
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-icon-only-button-primary" type="primary">
+        <ids-button id="test-icon-only-button-primary" appearance="primary">
           <span class="audible">Primary Button</span>
           <ids-icon icon="settings"></ids-icon>
         </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-icon-only-button-secondary" type="secondary">
+        <ids-button id="test-icon-only-button-secondary" appearance="secondary">
           <span class="audible">Secondary Button</span>
           <ids-icon icon="settings"></ids-icon>
         </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-icon-only-button-tertiary" type="tertiary">
+        <ids-button id="test-icon-only-button-tertiary" appearance="tertiary">
           <span class="audible">Tertiary Button</span>
           <ids-icon icon="settings"></ids-icon>
         </ids-button>
@@ -77,21 +77,21 @@
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-icon-button-primary" type="primary">
+        <ids-button id="test-icon-button-primary" appearance="primary">
           <ids-icon icon="settings"></ids-icon>
           <span>Primary Button</span>
         </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-icon-button-secondary" type="secondary">
+        <ids-button id="test-icon-button-secondary" appearance="secondary">
           <ids-icon icon="settings"></ids-icon>
           <span>Secondary Button</span>
         </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-        <ids-button id="test-icon-button-tertiary" type="tertiary">
+        <ids-button id="test-icon-button-tertiary" appearance="tertiary">
           <ids-icon icon="settings"></ids-icon>
           <span>Tertiary Button</span>
         </ids-button>
@@ -107,21 +107,21 @@
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-          <ids-button id="test-icon-end-button-primary" icon-align="end" type="primary">
+          <ids-button id="test-icon-end-button-primary" icon-align="end" appearance="primary">
               <span>Primary Button</span>
               <ids-icon icon="settings"></ids-icon>
           </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-          <ids-button id="test-icon-end-button-secondary" icon-align="end" type="secondary">
+          <ids-button id="test-icon-end-button-secondary" icon-align="end" appearance="secondary">
               <span>Secondary Button</span>
               <ids-icon icon="settings"></ids-icon>
           </ids-button>
       </ids-layout-grid-cell>
 
       <ids-layout-grid-cell>
-          <ids-button id="test-icon-end-button-tertiary" icon-align="end" type="tertiary">
+          <ids-button id="test-icon-end-button-tertiary" icon-align="end" appearance="tertiary">
               <span>Tertiary Button</span>
               <ids-icon icon="settings"></ids-icon>
           </ids-button>

--- a/src/components/ids-button/demos/variant-alternate.html
+++ b/src/components/ids-button/demos/variant-alternate.html
@@ -51,29 +51,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span" color-variant="alternate">Primary</ids-text></p>
         <p>
-          <ids-button id="test-button-primary" type="primary" color-variant="alternate">
+          <ids-button id="test-button-primary" appearance="primary" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-primary" type="primary" disabled="true" color-variant="alternate">
+          <ids-button id="test-disabled-button-primary" appearance="primary" disabled="true" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-primary" type="primary" color-variant="alternate">
+          <ids-button id="test-icon-only-button-primary" appearance="primary" color-variant="alternate">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-primary" type="primary" color-variant="alternate">
+          <ids-button id="test-icon-button-primary" appearance="primary" color-variant="alternate">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-primary" icon-align="end" type="primary" color-variant="alternate">
+          <ids-button id="test-icon-end-button-primary" icon-align="end" appearance="primary" color-variant="alternate">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -83,29 +83,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span" color-variant="alternate">Secondary</ids-text></p>
         <p>
-          <ids-button id="test-button-secondary" type="secondary" color-variant="alternate">
+          <ids-button id="test-button-secondary" appearance="secondary" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-secondary" type="secondary" disabled="true" color-variant="alternate">
+          <ids-button id="test-disabled-button-secondary" appearance="secondary" disabled="true" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-secondary" type="secondary" color-variant="alternate">
+          <ids-button id="test-icon-only-button-secondary" appearance="secondary" color-variant="alternate">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-secondary" type="secondary" color-variant="alternate">
+          <ids-button id="test-icon-button-secondary" appearance="secondary" color-variant="alternate">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-secondary" icon-align="end" type="secondary" color-variant="alternate">
+          <ids-button id="test-icon-end-button-secondary" icon-align="end" appearance="secondary" color-variant="alternate">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -115,29 +115,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span" color-variant="alternate">Tertiary</ids-text></p>
         <p>
-          <ids-button id="test-button-tertiary" type="tertiary" color-variant="alternate">
+          <ids-button id="test-button-tertiary" appearance="tertiary" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-tertiary" type="tertiary" disabled="true" color-variant="alternate">
+          <ids-button id="test-disabled-button-tertiary" appearance="tertiary" disabled="true" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-tertiary" type="tertiary" color-variant="alternate">
+          <ids-button id="test-icon-only-button-tertiary" appearance="tertiary" color-variant="alternate">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-tertiary" type="tertiary" color-variant="alternate">
+          <ids-button id="test-icon-button-tertiary" appearance="tertiary" color-variant="alternate">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-tertiary" icon-align="end" type="tertiary" color-variant="alternate">
+          <ids-button id="test-icon-end-button-tertiary" icon-align="end" appearance="tertiary" color-variant="alternate">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -147,29 +147,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span" color-variant="alternate">Primary Destructive</ids-text></p>
         <p>
-          <ids-button id="test-button-primary-destructive" type="primary-destructive" color-variant="alternate">
+          <ids-button id="test-button-primary-destructive" appearance="primary-destructive" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-primary-destructive" type="primary-destructive" disabled="true" color-variant="alternate">
+          <ids-button id="test-disabled-button-primary-destructive" appearance="primary-destructive" disabled="true" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-primary-destructive" type="primary-destructive" color-variant="alternate">
+          <ids-button id="test-icon-only-button-primary-destructive" appearance="primary-destructive" color-variant="alternate">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-primary-destructive" type="primary-destructive" color-variant="alternate">
+          <ids-button id="test-icon-button-primary-destructive" appearance="primary-destructive" color-variant="alternate">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-primary-destructive" icon-align="end" type="primary-destructive" color-variant="alternate">
+          <ids-button id="test-icon-end-button-primary-destructive" icon-align="end" appearance="primary-destructive" color-variant="alternate">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
@@ -179,29 +179,29 @@
       <ids-layout-grid-cell>
         <p><ids-text font-size="12" type="span" color-variant="alternate">Tertiary Destructive</ids-text></p>
         <p>
-          <ids-button id="test-button-tertiary-destructive" type="tertiary-destructive" color-variant="alternate">
+          <ids-button id="test-button-tertiary-destructive" appearance="tertiary-destructive" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-disabled-button-tertiary-destructive" type="tertiary-destructive" disabled="true" color-variant="alternate">
+          <ids-button id="test-disabled-button-tertiary-destructive" appearance="tertiary-destructive" disabled="true" color-variant="alternate">
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-only-button-tertiary-destructive" type="tertiary-destructive" color-variant="alternate">
+          <ids-button id="test-icon-only-button-tertiary-destructive" appearance="tertiary-destructive" color-variant="alternate">
             <span class="audible">Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-button-tertiary-destructive" type="tertiary-destructive" color-variant="alternate">
+          <ids-button id="test-icon-button-tertiary-destructive" appearance="tertiary-destructive" color-variant="alternate">
             <ids-icon icon="settings"></ids-icon>
             <span>Action</span>
           </ids-button>
         </p>
         <p>
-          <ids-button id="test-icon-end-button-tertiary-destructive" icon-align="end" type="tertiary-destructive" color-variant="alternate">
+          <ids-button id="test-icon-end-button-tertiary-destructive" icon-align="end" appearance="tertiary-destructive" color-variant="alternate">
             <span>Action</span>
             <ids-icon icon="settings"></ids-icon>
           </ids-button>

--- a/src/components/ids-button/ids-button-common.ts
+++ b/src/components/ids-button/ids-button-common.ts
@@ -16,6 +16,13 @@ export const BUTTON_APPEARANCE: Array<IdsButtonAppearance> = [
   'swipe-action-right'
 ];
 
+export type IdsButtonType = HTMLButtonElement['type'];
+
+// HTMLButtonElement types
+export const BUTTON_TYPES: Array<string> = [
+  'button', 'submit', 'reset', 'menu'
+];
+
 // Default Button state values
 export const BUTTON_DEFAULTS: any = {
   cssClass: [],
@@ -23,7 +30,7 @@ export const BUTTON_DEFAULTS: any = {
   hidden: false,
   tabIndex: 0,
   iconAlign: undefined,
-  type: BUTTON_APPEARANCE[0]
+  appearance: BUTTON_APPEARANCE[0]
 };
 
 // Definable attributes

--- a/src/components/ids-button/ids-button-common.ts
+++ b/src/components/ids-button/ids-button-common.ts
@@ -2,10 +2,10 @@ import { attributes } from '../../core/ids-attributes';
 
 export type IdsButtonIconAlignment = undefined | 'start' | 'end';
 
-export type IdsButtonType = 'default' | 'primary' | 'secondary' | 'tertiary' | 'primary-destructive' | 'tertiary-destructive' | 'swipe-action-right' | 'swipe-action-left';
+export type IdsButtonAppearance = 'default' | 'primary' | 'secondary' | 'tertiary' | 'primary-destructive' | 'tertiary-destructive' | 'swipe-action-right' | 'swipe-action-left';
 
-// Button Styles
-export const BUTTON_TYPES: Array<IdsButtonType> = [
+// Button Appearance types
+export const BUTTON_APPEARANCE: Array<IdsButtonAppearance> = [
   'default',
   'primary',
   'secondary',
@@ -23,11 +23,12 @@ export const BUTTON_DEFAULTS: any = {
   hidden: false,
   tabIndex: 0,
   iconAlign: undefined,
-  type: BUTTON_TYPES[0]
+  type: BUTTON_APPEARANCE[0]
 };
 
 // Definable attributes
 export const BUTTON_ATTRIBUTES: string[] = [
+  attributes.APPEARANCE,
   attributes.CSS_CLASS,
   attributes.DISABLED,
   attributes.HIDDEN,

--- a/src/components/ids-button/ids-button.scss
+++ b/src/components/ids-button/ids-button.scss
@@ -340,7 +340,7 @@ button {
   }
 }
 
-:host([show-loading-indicator='true']:not([loading-indicator-only='true']):is([type='primary'], [type='secondary'], [type='primary-destructive'])) {
+:host([show-loading-indicator='true']:not([loading-indicator-only='true']):is([appearance='primary'], [appearance='secondary'], [appearance='primary-destructive'])) {
   &::part(button) {
     padding-inline-start: 20px;
     padding-inline-end: 12px;

--- a/src/components/ids-button/ids-button.ts
+++ b/src/components/ids-button/ids-button.ts
@@ -14,7 +14,7 @@ import IdsLoadingIndicatorMixin from '../../mixins/ids-loading-indicator-mixin/i
 import IdsElement from '../../core/ids-element';
 
 import {
-  BUTTON_TYPES,
+  BUTTON_APPEARANCE,
   BUTTON_DEFAULTS,
   BUTTON_ATTRIBUTES,
   ICON_ALIGN_CLASSNAMES,
@@ -22,7 +22,7 @@ import {
 } from './ids-button-common';
 import type {
   IdsButtonIconAlignment,
-  IdsButtonType
+  IdsButtonAppearance
 } from './ids-button-common';
 
 import styles from './ids-button.scss';
@@ -156,7 +156,7 @@ export default class IdsButton extends Base {
     let protoClasses = '';
     let disabled = '';
     let tabIndex = 'tabindex="0"';
-    let type = '';
+    let appearance = '';
     if (this.state?.cssClass) {
       cssClass = ` ${this.state.cssClass.join(' ')}`;
     }
@@ -166,8 +166,8 @@ export default class IdsButton extends Base {
     if (this.state?.tabIndex) {
       tabIndex = `tabindex="${this.state.tabIndex}"`;
     }
-    if (this.state && this.state?.type !== 'default') {
-      type = ` btn-${this.state.type}`;
+    if (this.state && this.state?.appearance !== 'default') {
+      appearance = ` btn-${this.state.appearance}`;
     }
 
     if (this.hasAttribute(attributes.SQUARE)) {
@@ -185,7 +185,7 @@ export default class IdsButton extends Base {
     let alignCSS = '';
     if (this.state?.iconAlign) alignCSS = ` align-icon-${this.state?.iconAlign}`;
 
-    return `<button part="button" class="${protoClasses}${type}${alignCSS}${cssClass}" ${tabIndex}${disabled}>
+    return `<button part="button" class="${protoClasses}${appearance}${alignCSS}${cssClass}" ${tabIndex}${disabled}>
       <slot></slot>
       <slot name="loading-indicator"></slot>
     </button>`;
@@ -534,25 +534,25 @@ export default class IdsButton extends Base {
   }
 
   /**
-   * Set the button types between 'default', 'primary', 'secondary', 'tertiary', or 'destructive'
-   * @param {IdsButtonType | null} val a valid button "type"
+   * Set the button appearance between 'default', 'primary', 'secondary', 'tertiary', or 'destructive'
+   * @param {IdsButtonAppearance | null} val a valid button "appearance"
    */
-  set type(val: IdsButtonType | null) {
-    if (!val || BUTTON_TYPES.indexOf(val) <= 0) {
-      this.removeAttribute(attributes.TYPE);
-      this.state.type = BUTTON_TYPES[0];
+  set appearance(val: IdsButtonAppearance | null) {
+    if (!val || BUTTON_APPEARANCE.indexOf(val) <= 0) {
+      this.removeAttribute(attributes.APPEARANCE);
+      this.state.appearance = BUTTON_APPEARANCE[0];
     } else {
-      this.setAttribute(attributes.TYPE, val);
-      if (this.state.type !== val) this.state.type = val;
+      this.setAttribute(attributes.APPEARANCE, val);
+      if (this.state.appearance !== val) this.state.appearance = val;
     }
-    this.setTypeClass(val);
+    this.setAppearanceClass(val);
   }
 
   /**
-   * @returns {IdsButtonType} the currently set type
+   * @returns {IdsButtonAppearance} the currently set appearance
    */
-  get type(): IdsButtonType {
-    return this.state.type;
+  get appearance(): IdsButtonAppearance {
+    return this.state.appearance;
   }
 
   /**
@@ -626,22 +626,22 @@ export default class IdsButton extends Base {
   }
 
   /**
-   * Sets the correct type class on the Shadow button.
+   * Sets the correct appearance class on the ShadowRoot button.
    * @private
-   * @param {string | null} val desired type class
+   * @param {string | null} val desired appearance class
    */
-  setTypeClass(val: string | null) {
+  setAppearanceClass(val: string | null) {
     if (this.button) {
-      BUTTON_TYPES.forEach((type) => {
-        const typeClassName = `btn-${type}`;
-        if (val === type) {
-          if (type !== 'default' && !this.button?.classList.contains(typeClassName)) {
-            this.button?.classList.add(typeClassName);
+      BUTTON_APPEARANCE.forEach((app) => {
+        const appClassName = `btn-${app}`;
+        if (val === app) {
+          if (app !== 'default' && !this.button?.classList.contains(appClassName)) {
+            this.button?.classList.add(appClassName);
           }
           return;
         }
-        if (this.button?.classList.contains(typeClassName)) {
-          this.button?.classList.remove(typeClassName);
+        if (this.button?.classList.contains(appClassName)) {
+          this.button?.classList.remove(appClassName);
         }
       });
     }

--- a/src/components/ids-button/ids-button.ts
+++ b/src/components/ids-button/ids-button.ts
@@ -16,13 +16,15 @@ import IdsElement from '../../core/ids-element';
 import {
   BUTTON_APPEARANCE,
   BUTTON_DEFAULTS,
+  BUTTON_TYPES,
   BUTTON_ATTRIBUTES,
   ICON_ALIGN_CLASSNAMES,
   baseProtoClasses
 } from './ids-button-common';
 import type {
   IdsButtonIconAlignment,
-  IdsButtonAppearance
+  IdsButtonAppearance,
+  IdsButtonType
 } from './ids-button-common';
 
 import styles from './ids-button.scss';
@@ -553,6 +555,28 @@ export default class IdsButton extends Base {
    */
   get appearance(): IdsButtonAppearance {
     return this.state.appearance;
+  }
+
+  /**
+   * Sets the HTMLButtonElement 'type' attribute
+   */
+  set type(val: IdsButtonType) {
+    if (val && BUTTON_TYPES.includes(val)) {
+      this.setAttribute(attributes.TYPE, val);
+      this.button?.setAttribute(attributes.TYPE, val);
+      if (this.state.type !== val) this.state.type = val;
+    } else {
+      this.removeAttribute(attributes.TYPE);
+      this.button?.removeAttribute(attributes.TYPE);
+      this.state.type = BUTTON_TYPES[0];
+    }
+  }
+
+  /**
+   * @returns {IdsButtonType} Gets the HTMLButtonElement 'type' attribute
+   */
+  get type(): IdsButtonType {
+    return this.state.type;
   }
 
   /**

--- a/src/components/ids-checkbox/demos/example.html
+++ b/src/components/ids-checkbox/demos/example.html
@@ -38,10 +38,10 @@
       <ids-layout-grid-cell>
         <ids-text font-size="12" type="h1">Ids Indeterminate</ids-text><br />
         <ids-checkbox label="Indeterminate" indeterminate="true" id="cb-indeterminate"></ids-checkbox>
-        <ids-button type="secondary" id="btn-set-indeterminate">
+        <ids-button appearance="secondary" id="btn-set-indeterminate">
           <span>Set</span>
         </ids-button>
-        <ids-button type="secondary" id="btn-remove-indeterminate">
+        <ids-button appearance="secondary" id="btn-remove-indeterminate">
           <span>Remove</span>
         </ids-button>
 

--- a/src/components/ids-data-grid/demos/filter-custom.html
+++ b/src/components/ids-data-grid/demos/filter-custom.html
@@ -15,8 +15,8 @@
     <ids-layout-grid cols="1">
       <ids-layout-grid-cell>
         <ids-input type="text" id="filter-input" label="Color Filter"></ids-input>
-        <ids-button type="secondary" id="set-filter-btn">Set Color Filter</ids-button>
-        <ids-button type="secondary" id="apply-filter-btn">Apply Color Filter</ids-button>
+        <ids-button appearance="secondary" id="set-filter-btn">Set Color Filter</ids-button>
+        <ids-button appearance="secondary" id="apply-filter-btn">Apply Color Filter</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 

--- a/src/components/ids-data-grid/demos/save-settings-manual.html
+++ b/src/components/ids-data-grid/demos/save-settings-manual.html
@@ -13,12 +13,12 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="btn-clear-settings" type="secondary">
+        <ids-button id="btn-clear-settings" appearance="secondary">
           <ids-icon icon="clear-formatting"></ids-icon>
           <span>Clear settings (local storage)</span>
         </ids-button>
         <br /><br />
-        <ids-button id="btn-restore" type="secondary">
+        <ids-button id="btn-restore" appearance="secondary">
           <ids-icon icon="restore-user"></ids-icon>
           <span>Restore settings</span>
         </ids-button>

--- a/src/components/ids-data-grid/ids-data-grid-formatters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-formatters.ts
@@ -166,7 +166,7 @@ export default class IdsDataGridFormatters {
   button(rowData: Record<string, unknown>, columnData: IdsDataGridColumn, index: number): string {
     const value: any = this.#extractValue(rowData, columnData.field);
     // Type / disabled / icon / text
-    return `<ids-button tabindex="-1" ${this.#columnDisabled(index, value, columnData, rowData) ? ' disabled="true"' : ''}${columnData.type ? ` type="${columnData.type}"` : ' type="tertiary"'}>
+    return `<ids-button tabindex="-1" ${this.#columnDisabled(index, value, columnData, rowData) ? ' disabled="true"' : ''}${columnData.type ? ` type="${columnData.type}"` : ' appearance="tertiary"'}>
       <span class="audible">${columnData.text || ' Button'}</span>
       ${columnData.icon ? `<ids-icon icon="${columnData.icon}"></ids-icon>` : ''}
       <span class="audible">${columnData.text || ' Button'}</span>

--- a/src/components/ids-date-picker/ids-date-picker-popup.ts
+++ b/src/components/ids-date-picker/ids-date-picker-popup.ts
@@ -147,7 +147,7 @@ class IdsDatePickerPopup extends Base implements IdsRangeSettingsInterface {
         <ids-modal-button class="popup-btn popup-btn-clear" part="btn-clear" ${this.showClear ? '' : ' hidden'}>
           <ids-text translate-text="true" font-weight="bold">Clear</ids-text>
         </ids-modal-button>
-        <ids-modal-button class="popup-btn popup-btn-apply"${this.useRange || this.expanded ? ' disabled' : ' hidden'} part="btn-apply" type="primary">
+        <ids-modal-button class="popup-btn popup-btn-apply"${this.useRange || this.expanded ? ' disabled' : ' hidden'} part="btn-apply" appearance="primary">
           <ids-text translate-text="true" font-weight="bold">Apply</ids-text>
         </ids-modal-button>
       </div>

--- a/src/components/ids-drawer/demos/example.html
+++ b/src/components/ids-drawer/demos/example.html
@@ -13,13 +13,13 @@
 
     <ids-layout-grid>
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="app-menu-trigger">Open From Left</ids-button>
+        <ids-button appearance="secondary" id="app-menu-trigger">Open From Left</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
     <ids-layout-grid>
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="action-sheet-trigger">Open From Bottom</ids-button>
+        <ids-button appearance="secondary" id="action-sheet-trigger">Open From Bottom</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 

--- a/src/components/ids-editor/ids-editor-templates.ts
+++ b/src/components/ids-editor/ids-editor-templates.ts
@@ -145,7 +145,7 @@ export const errorMessageTemplate = `
   <ids-message id="errormessage-modal" status="error">
     <ids-text slot="title" font-size="24" type="h2" id="errormessage-modal-title">No Selection!</ids-text>
     <ids-text class="demo-contents" align="left">Please make some selection to complete this task.</ids-text>
-    <ids-modal-button slot="buttons" type="primary" id="errormessage-modal-ok">OK</ids-modal-button>
+    <ids-modal-button slot="buttons" appearance="primary" id="errormessage-modal-ok">OK</ids-modal-button>
   </ids-message>`;
 
 // Hyperlink modal template
@@ -163,10 +163,10 @@ export const hyperlinkModalTemplate = `
         </div>
       </ids-layout-grid-cell>
     </ids-layout-grid>
-    <ids-modal-button slot="buttons" id="{key}-modal-cancel-btn" type="secondary">
+    <ids-modal-button slot="buttons" id="{key}-modal-cancel-btn" appearance="secondary">
       <span>Cancel</span>
     </ids-modal-button>
-    <ids-modal-button slot="buttons" id="{key}-modal-apply-btn" type="primary">
+    <ids-modal-button slot="buttons" id="{key}-modal-apply-btn" appearance="primary">
       <span>Apply</span>
     </ids-modal-button>
   </ids-modal>`;
@@ -182,10 +182,10 @@ export const insertimageModalTemplate = `
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
-    <ids-modal-button slot="buttons" id="{key}-modal-cancel-btn" type="secondary">
+    <ids-modal-button slot="buttons" id="{key}-modal-cancel-btn" appearance="secondary">
       <span>Cancel</span>
     </ids-modal-button>
-    <ids-modal-button slot="buttons" id="{key}-modal-apply-btn" type="primary">
+    <ids-modal-button slot="buttons" id="{key}-modal-apply-btn" appearance="primary">
       <span>Apply</span>
     </ids-modal-button>
   </ids-modal>`;

--- a/src/components/ids-empty-message/README.MD
+++ b/src/components/ids-empty-message/README.MD
@@ -25,7 +25,7 @@ A simple implementation of the empty-message component
   <ids-empty-message icon="empty-no-tasks">
     <ids-text type="h2" font-size="20" label="true" slot="label">Document Management</ids-text>
     <ids-text label="true" slot="description">Description of empty message that explains why and possible contain a hyperlink.</ids-text>
-    <ids-button class="action-button" slot="button" type="primary">
+    <ids-button class="action-button" slot="button" appearance="primary">
       <span>BUTTON NAME</span>
     </ids-button>
   </ids-empty-message>

--- a/src/components/ids-empty-message/demos/example.html
+++ b/src/components/ids-empty-message/demos/example.html
@@ -22,7 +22,7 @@
             <ids-empty-message icon="empty-no-tasks-new">
               <ids-text type="h2" font-size="20" label="true" slot="label">Document Management</ids-text>
               <ids-text label="true" slot="description">Description of empty message that explains why and possible contain a hyperlink.</ids-text>
-              <ids-button class="action-button" slot="button" type="primary">
+              <ids-button class="action-button" slot="button" appearance="primary">
                 <span>Action</span>
               </ids-button>
             </ids-empty-message>

--- a/src/components/ids-empty-message/demos/example.ts
+++ b/src/components/ids-empty-message/demos/example.ts
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <ids-empty-message icon="${emptyIcons[i][0]}">
           <ids-text type="h2" font-size="20" label="true" slot="label">Alert Label</ids-text>
           <ids-text label="true" slot="description">Description of empty message that explains why and possible contain a hyperlink.</ids-text>
-          <ids-button class="action-button" slot="button" type="primary">Action</ids-button>
+          <ids-button class="action-button" slot="button" appearance="primary">Action</ids-button>
         </ids-empty-message>
       </div>
 

--- a/src/components/ids-error-page/ids-error-page.ts
+++ b/src/components/ids-error-page/ids-error-page.ts
@@ -55,7 +55,7 @@ export default class IdsErrorPage extends IdsModal {
           <ids-text label="true" slot="description">
             ${this.description ?? 'Add Description'}
           </ids-text>
-          <ids-button class="action-button" slot="button" type="primary">
+          <ids-button class="action-button" slot="button" appearance="primary">
             <span>${this.buttonText ?? 'Action'}</span>
           </ids-button>
         </ids-empty-message>

--- a/src/components/ids-fieldset/README.md
+++ b/src/components/ids-fieldset/README.md
@@ -24,7 +24,7 @@ An IdsFieldset inside a form element. Best practice is to use an IdsText element
     <ids-input type="text" label="Company Type" id="type"></ids-input>
     <ids-input type="text" label="Company Address" id="company-address"></ids-input>
     <ids-checkbox label="Checked" checked="true"></ids-checkbox>
-    <ids-button type="primary">Submit</ids-button>
+    <ids-button appearance="primary">Submit</ids-button>
   </ids-fieldset>
 </form>
 ```

--- a/src/components/ids-fieldset/demos/example.html
+++ b/src/components/ids-fieldset/demos/example.html
@@ -23,7 +23,7 @@
           <ids-input type="text" label="Company Type" id="type"></ids-input>
           <ids-input type="text" label="Company Address" id="company-address"></ids-input>
           <ids-checkbox label="Checked" checked="true"></ids-checkbox>
-          <ids-button type="primary">Submit</ids-button>
+          <ids-button appearance="primary">Submit</ids-button>
         </ids-fieldset>
       </form>
     </ids-layout-grid>

--- a/src/components/ids-fieldset/demos/side-by-side.html
+++ b/src/components/ids-fieldset/demos/side-by-side.html
@@ -19,7 +19,7 @@
           <ids-input type="text" label="Company Type" id="type"></ids-input>
           <ids-input type="text" label="Company Address" id="company-address"></ids-input>
           <ids-checkbox label="Checked" checked="true"></ids-checkbox>
-          <ids-button type="primary">Submit</ids-button>
+          <ids-button appearance="primary">Submit</ids-button>
         </ids-fieldset>
       </form>
     </ids-layout-grid>

--- a/src/components/ids-form/README.md
+++ b/src/components/ids-form/README.md
@@ -27,7 +27,7 @@ A simple form web component would have an `id` and a `submit-button` property th
           <ids-input id="field-1" label="Field One"></ids-input>
           <ids-input id="field-2" label="Field Two"></ids-input>
 
-          <ids-button id="btn-submit" type="primary">
+          <ids-button id="btn-submit" appearance="primary">
             <span>Submit</span>
           </ids-button>
         </ids-layout-grid-cell>

--- a/src/components/ids-form/demos/example.html
+++ b/src/components/ids-form/demos/example.html
@@ -12,7 +12,7 @@
     </ids-layout-grid>
 
     <ids-layout-grid-cell>
-      <ids-button id="btn-toggle-compact" type="tertiary">
+      <ids-button id="btn-toggle-compact" appearance="tertiary">
         <ids-icon icon="settings"></ids-icon>
         <span>Toggle Compact</span>
       </ids-button>
@@ -33,7 +33,7 @@
           <ids-upload label="Attachments" id="attachments" dirty-tracker validate="required" size="md"></ids-upload>
           <ids-checkbox id="freight" label="Freight" checked dirty-tracker validate="required" no-margin></ids-checkbox>
           <ids-textarea id="notes" label="Notes" dirty-tracker validate="required" size="md"></ids-textarea>
-          <ids-button id="btn-submit" type="primary">
+          <ids-button id="btn-submit" appearance="primary">
             <span>Submit</span>
           </ids-button>
         </ids-layout-grid-cell>

--- a/src/components/ids-form/demos/example.html
+++ b/src/components/ids-form/demos/example.html
@@ -33,7 +33,7 @@
           <ids-upload label="Attachments" id="attachments" dirty-tracker validate="required" size="md"></ids-upload>
           <ids-checkbox id="freight" label="Freight" checked dirty-tracker validate="required" no-margin></ids-checkbox>
           <ids-textarea id="notes" label="Notes" dirty-tracker validate="required" size="md"></ids-textarea>
-          <ids-button id="btn-submit" appearance="primary">
+          <ids-button id="btn-submit" appearance="primary" type="submit">
             <span>Submit</span>
           </ids-button>
         </ids-layout-grid-cell>

--- a/src/components/ids-header/demos/button-types.html
+++ b/src/components/ids-header/demos/button-types.html
@@ -19,17 +19,17 @@
           <ids-text font-size="14" color-variant="alternate">With some extra information below</ids-text>
         </ids-toolbar-section>
         <ids-toolbar-section type="buttonset" align="end">
-          <ids-button id="button-1" role="button" type="primary" color-variant="alternate">
+          <ids-button id="button-1" role="button" appearance="primary" color-variant="alternate">
             <ids-icon icon="filter"></ids-icon>
             <span>My Filters</span>
           </ids-button>
 
-          <ids-button id="button-2" type="secondary" color-variant="alternate">
+          <ids-button id="button-2" appearance="secondary" color-variant="alternate">
             <ids-icon icon="settings"></ids-icon>
             <span>My Settings</span>
           </ids-button>
 
-          <ids-button id="button-3" type="tertiary" color-variant="alternate">
+          <ids-button id="button-3" appearance="tertiary" color-variant="alternate">
             <ids-icon icon="delete"></ids-icon>
             <span>Trash</span>
           </ids-button>

--- a/src/components/ids-home-page/demos/add-remove-card.html
+++ b/src/components/ids-home-page/demos/add-remove-card.html
@@ -10,7 +10,7 @@
       <ids-layout-grid-cell>
         <ids-text font-size="12" type="h1">Home Page - Add/Remove Card</ids-text>
         <br />
-        <ids-button id="btn-home-page-toggle-card" type="secondary">
+        <ids-button id="btn-home-page-toggle-card" appearance="secondary">
           <span>Add Card</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-input/demos/example.html
+++ b/src/components/ids-input/demos/example.html
@@ -42,13 +42,13 @@
         <ids-text font-size="12" type="h2">Input - Enable/ Disable/ Readonly</ids-text>
         <br>
         <ids-input id="input-toggle-state" label="Text Field" value="Some text"></ids-input>
-        <ids-button id="btn-input-enable" type="secondary">
+        <ids-button id="btn-input-enable" appearance="secondary">
           <span>Enable</span>
         </ids-button>
-        <ids-button id="btn-input-disable" type="secondary">
+        <ids-button id="btn-input-disable" appearance="secondary">
           <span>Disable</span>
         </ids-button>
-        <ids-button id="btn-input-readonly" type="secondary">
+        <ids-button id="btn-input-readonly" appearance="secondary">
           <span>Readonly</span>
         </ids-button>
         <br><br>

--- a/src/components/ids-input/demos/validation-message.html
+++ b/src/components/ids-input/demos/validation-message.html
@@ -16,10 +16,10 @@
         <ids-text font-size="12" type="h2">Single Messages</ids-text>
         <br />
 
-        <ids-button id="btn-add-messages" type="secondary">
+        <ids-button id="btn-add-messages" appearance="secondary">
           <span>Add Messages</span>
         </ids-button>
-        <ids-button id="btn-remove-messages" type="secondary">
+        <ids-button id="btn-remove-messages" appearance="secondary">
           <span>Remove Messages</span>
         </ids-button>
         <br/><br/>
@@ -56,7 +56,7 @@
 
         <ids-text font-size="12" type="h2">Multiple Messages</ids-text>
         <br />
-        <ids-button id="btn-add-multiple-messages" type="secondary">
+        <ids-button id="btn-add-multiple-messages" appearance="secondary">
           <span>Add Multiple Messages</span>
         </ids-button>
         <br />
@@ -72,7 +72,7 @@
           <br />
           <ids-radio value="all" label="Add all"></ids-radio>
         </ids-radio-group>
-        <ids-button id="btn-remove-multiple-messages" type="secondary">
+        <ids-button id="btn-remove-multiple-messages" appearance="secondary">
           <span>Remove Multiple Messages</span>
         </ids-button>
         <ids-text font-size="14" font-weight="bold">Choose option to remove by and click button above:</ids-text>

--- a/src/components/ids-loading-indicator/demos/slotted.html
+++ b/src/components/ids-loading-indicator/demos/slotted.html
@@ -24,23 +24,23 @@
           <ids-text font-size="18" type="h2">With Text</ids-text>
         </p>
         <p>
-          <ids-button show-loading-indicator="true" type="primary">
+          <ids-button show-loading-indicator="true" appearance="primary">
             <span>Primary</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" type="secondary">
+          <ids-button show-loading-indicator="true" appearance="secondary">
             <span>Secondary</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" type="tertiary">
+          <ids-button show-loading-indicator="true" appearance="tertiary">
             <span>Tertiary</span>
           </ids-button>
           <ids-button show-loading-indicator="true">
             <ids-icon icon="folder"></ids-icon>
             <span class="audible">Icon</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" type="primary-destructive">
+          <ids-button show-loading-indicator="true" appearance="primary-destructive">
             <span>Primary Destructive</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" type="tertiary-destructive">
+          <ids-button show-loading-indicator="true" appearance="tertiary-destructive">
             <span>Tertiary Destructive</span>
           </ids-button>
         </p>
@@ -48,13 +48,13 @@
           <ids-text font-size="18" type="h2">Without Text</ids-text>
         </p>
         <p>
-          <ids-button show-loading-indicator="true" loading-indicator-only="true" type="primary">
+          <ids-button show-loading-indicator="true" loading-indicator-only="true" appearance="primary">
             <span>Primary</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" loading-indicator-only="true" type="secondary">
+          <ids-button show-loading-indicator="true" loading-indicator-only="true" appearance="secondary">
             <span>Secondary</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" loading-indicator-only="true" type="tertiary">
+          <ids-button show-loading-indicator="true" loading-indicator-only="true" appearance="tertiary">
             <ids-icon icon="folder"></ids-icon>
             <span>Tertiary</span>
           </ids-button>
@@ -62,10 +62,10 @@
             <ids-icon icon="folder"></ids-icon>
             <span class="audible">Icon</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" loading-indicator-only="true" type="primary-destructive">
+          <ids-button show-loading-indicator="true" loading-indicator-only="true" appearance="primary-destructive">
             <span>Primary Destructive</span>
           </ids-button>
-          <ids-button show-loading-indicator="true" loading-indicator-only="true" type="tertiary-destructive">
+          <ids-button show-loading-indicator="true" loading-indicator-only="true" appearance="tertiary-destructive">
             <span>Tertiary Destructive</span>
           </ids-button>
         </p>
@@ -74,13 +74,13 @@
         <p>
           <ids-text font-size="18" type="h2">Click To Start/Stop Loading</ids-text>
         </p>
-        <ids-button type="primary" class="btn-click-to-load">
+        <ids-button appearance="primary" class="btn-click-to-load">
           <span>Action</span>
         </ids-button>
-        <ids-button type="primary" class="btn-click-to-load" loading-indicator-only="true">
+        <ids-button appearance="primary" class="btn-click-to-load" loading-indicator-only="true">
           <span>Action</span>
         </ids-button>
-        <ids-button type="tertiary" class="btn-click-to-load">
+        <ids-button appearance="tertiary" class="btn-click-to-load">
           <span>Action</span>
         </ids-button>
       </ids-layout-grid-cell>
@@ -88,7 +88,7 @@
     <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
         <ids-input type="text" label="Input" placeholder="Normal text Field"></ids-input>
-        <ids-button type="primary" class="btn-trigger-to-load">
+        <ids-button appearance="primary" class="btn-trigger-to-load">
           <span>Load</span>
         </ids-button>
       </ids-layout-grid-cell>
@@ -99,7 +99,7 @@
             <ids-icon icon="camera"></ids-icon>
           </ids-trigger-button>
         </ids-trigger-field>
-        <ids-button type="primary" class="btn-trigger-to-load">
+        <ids-button appearance="primary" class="btn-trigger-to-load">
           <span>Load</span>
         </ids-button>
       </ids-layout-grid-cell>
@@ -114,7 +114,7 @@
             <ids-list-box-option value="opt6" id="opt6-d2">Option Six</ids-list-box-option>
           </ids-list-box>
         </ids-dropdown>
-        <ids-button type="primary" class="btn-trigger-to-load">
+        <ids-button appearance="primary" class="btn-trigger-to-load">
           <span>Load</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-lookup/README.md
+++ b/src/components/ids-lookup/README.md
@@ -29,7 +29,7 @@ If necessary you can provide your own custom modal to the lookup. When doing thi
 <ids-lookup id="custom-lookup" label="Custom Lookup">
     <ids-modal slot="lookup-modal" id="custom-lookup-modal" aria-labelledby="custom-lookup-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="lookup-modal-title">Custom Lookup Modal</ids-text>
-    <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
+    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
         <span>Apply</span>
     </ids-modal-button>
     </ids-modal>

--- a/src/components/ids-lookup/demos/example.html
+++ b/src/components/ids-lookup/demos/example.html
@@ -20,7 +20,7 @@
         <ids-lookup id="lookup-5" label="Custom Lookup">
           <ids-modal slot="lookup-modal" id="custom-lookup-modal" aria-labelledby="custom-lookup-modal-title">
             <ids-text slot="title" font-size="24" type="h2" id="lookup-modal-title">Custom Lookup Modal</ids-text>
-            <ids-modal-button slot="buttons" id="modal-cancel-btn" type="primary">
+            <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="primary">
               <span>Apply</span>
             </ids-modal-button>
           </ids-modal>

--- a/src/components/ids-lookup/ids-lookup.ts
+++ b/src/components/ids-lookup/ids-lookup.ts
@@ -193,10 +193,10 @@ export default class IdsLookup extends Base {
           </ids-layout-grid-cell>
         </ids-layout-grid>
 
-      <ids-modal-button slot="buttons" id="modal-cancel-btn" type="secondary">
+      <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="secondary">
         <span>Cancel</span>
         </ids-modal-button>
-        <ids-modal-button slot="buttons" id="modal-apply-btn" type="primary">
+        <ids-modal-button slot="buttons" id="modal-apply-btn" appearance="primary">
           <span>Apply</span>
         </ids-modal-button>
       </ids-modal>

--- a/src/components/ids-menu-button/demos/disabled.html
+++ b/src/components/ids-menu-button/demos/disabled.html
@@ -24,7 +24,7 @@
 
     <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
-        <ids-menu-button id="menu-button" icon="settings" type="tertiary" menu="my-menu" dropdown-icon>
+        <ids-menu-button id="menu-button" icon="settings" appearance="tertiary" menu="my-menu" dropdown-icon>
           <span>Settings</span>
         </ids-menu-button>
         <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click">

--- a/src/components/ids-menu-button/demos/display-selected.html
+++ b/src/components/ids-menu-button/demos/display-selected.html
@@ -17,7 +17,7 @@
     <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
 
-        <ids-menu-button id="menu-button" icon="settings" type="tertiary" menu="my-menu" dropdown-icon>
+        <ids-menu-button id="menu-button" icon="settings" appearance="tertiary" menu="my-menu" dropdown-icon>
           <span>Choose a Program Type...</span>
         </ids-menu-button>
         <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click">

--- a/src/components/ids-menu-button/demos/example.html
+++ b/src/components/ids-menu-button/demos/example.html
@@ -12,7 +12,7 @@
     </ids-layout-grid>
     <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
-          <ids-menu-button id="menu-button" icon="settings" type="tertiary" menu="my-menu" dropdown-icon>
+          <ids-menu-button id="menu-button" icon="settings" appearance="tertiary" menu="my-menu" dropdown-icon>
             <span>Settings</span>
           </ids-menu-button>
           <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click">

--- a/src/components/ids-menu-button/demos/side-by-side.html
+++ b/src/components/ids-menu-button/demos/side-by-side.html
@@ -14,7 +14,7 @@
     </ids-layout-grid>
     <ids-layout-grid cols="4" gap="md">
       <ids-layout-grid-cell>
-          <ids-menu-button id="menu-button" type="tertiary" menu="my-menu" dropdown-icon>
+          <ids-menu-button id="menu-button" appearance="tertiary" menu="my-menu" dropdown-icon>
             <span>Normal Menu</span>
           </ids-menu-button>
           <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click">

--- a/src/components/ids-message/README.md
+++ b/src/components/ids-message/README.md
@@ -33,8 +33,8 @@ Messages can have titles and buttons (just the same as [Modals](../ids-modal/REA
 <ids-message id="my-message">
     <ids-text slot="title" font-size="24" type="h2">My Message Title</ids-text>
     <p>This is my message</p>
-    <ids-modal-button slot="buttons" type="secondary">OK</ids-modal-button>
-    <ids-modal-button slot="buttons" type="primary" cancel>Cancel</ids-modal-button>
+    <ids-modal-button slot="buttons" appearance="secondary">OK</ids-modal-button>
+    <ids-modal-button slot="buttons" appearance="primary" cancel>Cancel</ids-modal-button>
 </ids-message>
 ```
 
@@ -61,11 +61,11 @@ You can also use the Modal's `target` property to activate a Message component b
 <ids-message id="my-message">
     <ids-text slot="title" font-size="24" type="h2">My Message Title</ids-text>
     <p>This is my message</p>
-    <ids-modal-button slot="buttons" type="secondary">OK</ids-modal-button>
-    <ids-modal-button slot="buttons" type="primary" cancel>Cancel</ids-modal-button>
+    <ids-modal-button slot="buttons" appearance="secondary">OK</ids-modal-button>
+    <ids-modal-button slot="buttons" appearance="primary" cancel>Cancel</ids-modal-button>
 </ids-message>
 
-<ids-button id="trigger-button" type="secondary">
+<ids-button id="trigger-button" appearance="secondary">
     <span>Show Message</span>
     <ids-icon icon="launch"></ids-icon>
 </ids-button>

--- a/src/components/ids-message/demos/events.html
+++ b/src/components/ids-message/demos/events.html
@@ -10,8 +10,8 @@
     <ids-message id="message-example-event" status="info">
       <ids-text slot="title" font-size="24" type="h2" id="my-message-title">Modal Event Trigger</ids-text>
       <ids-text id="my-message-contents" align="left">Modal events will be triggered on this message.</ids-text>
-      <ids-modal-button slot="buttons" type="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
-      <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Confirm</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Confirm</ids-modal-button>
     </ids-message>
 
     <ids-layout-grid auto="true">
@@ -22,7 +22,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-example-event-trigger">Events Example</ids-button>
+        <ids-button appearance="secondary" id="message-example-event-trigger">Events Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-message/demos/example.html
+++ b/src/components/ids-message/demos/example.html
@@ -11,8 +11,8 @@
       <ids-text slot="title" font-size="24" type="h2" id="my-message-title">Lost connection</ids-text>
       <ids-text id="my-message-contents" align="left">This application has experienced a system error due to the lack of internet access. Please restart the
         application in order to proceed.</ids-text>
-      <ids-modal-button slot="buttons" type="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
-      <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Restart</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Restart</ids-modal-button>
     </ids-message>
 
     <ids-layout-grid auto="true">
@@ -23,7 +23,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-example-error-trigger">Error Example</ids-button>
+        <ids-button appearance="secondary" id="message-example-error-trigger">Error Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-message/demos/overlay-opacity.html
+++ b/src/components/ids-message/demos/overlay-opacity.html
@@ -12,7 +12,7 @@
       <ids-text slot="title" font-size="24" type="h2" id="message-opacity-2-title">Opacity 20%</ids-text>
       <ids-text class="demo-contents" align="left">This application has experienced a system error due to the lack of internet access.
         Please restart the application in order to proceed.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-opacity-2-ok">OK</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-opacity-2-ok">OK</ids-modal-button>
     </ids-message>
 
     <!-- Opacity 0.4 Message -->
@@ -20,7 +20,7 @@
       <ids-text slot="title" font-size="24" type="h2" id="message-opacity-4-title">Opacity 40%</ids-text>
       <ids-text class="demo-contents" align="left">This application has experienced a system error due to the lack of internet access.
         Please restart the application in order to proceed.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-opacity-4-ok">OK</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-opacity-4-ok">OK</ids-modal-button>
     </ids-message>
 
     <!-- Opacity 0.6 Message -->
@@ -28,7 +28,7 @@
       <ids-text slot="title" font-size="24" type="h2" id="message-opacity-6-title">Opacity 60%</ids-text>
       <ids-text class="demo-contents" align="left">This application has experienced a system error due to the lack of internet access.
         Please restart the application in order to proceed.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-opacity-6-ok">OK</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-opacity-6-ok">OK</ids-modal-button>
     </ids-message>
 
     <!-- Opacity 0.8 Message -->
@@ -36,7 +36,7 @@
       <ids-text slot="title" font-size="24" type="h2" id="message-opacity-8-title">Opacity 80%</ids-text>
       <ids-text class="demo-contents" align="left">This application has experienced a system error due to the lack of internet access.
         Please restart the application in order to proceed.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-opacity-8-ok">OK</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-opacity-8-ok">OK</ids-modal-button>
     </ids-message>
 
     <!-- Opacity 1 Message -->
@@ -44,7 +44,7 @@
       <ids-text slot="title" font-size="24" type="h2" id="message-opacity-10-title">Opacity 100%</ids-text>
       <ids-text class="demo-contents" align="left">This application has experienced a system error due to the lack of internet access.
         Please restart the application in order to proceed.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-opacity-10-ok">OK</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-opacity-10-ok">OK</ids-modal-button>
     </ids-message>
 
     <!-- In-page controls for the messages are below -->
@@ -57,19 +57,19 @@
 
     <ids-layout-grid auto="true" cols="1" gap="md">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-opacity-2-trigger">Opacity 0.2</ids-button>
+        <ids-button appearance="secondary" id="message-opacity-2-trigger">Opacity 0.2</ids-button>
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-opacity-4-trigger">Opacity 0.4</ids-button>
+        <ids-button appearance="secondary" id="message-opacity-4-trigger">Opacity 0.4</ids-button>
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-opacity-6-trigger">Opacity 0.6</ids-button>
+        <ids-button appearance="secondary" id="message-opacity-6-trigger">Opacity 0.6</ids-button>
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-opacity-8-trigger">Opacity 0.8</ids-button>
+        <ids-button appearance="secondary" id="message-opacity-8-trigger">Opacity 0.8</ids-button>
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-opacity-10-trigger">Opacity 1</ids-button>
+        <ids-button appearance="secondary" id="message-opacity-10-trigger">Opacity 1</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-message/demos/side-by-side.html
+++ b/src/components/ids-message/demos/side-by-side.html
@@ -18,12 +18,12 @@
     <ids-message id="message-example" status="info">
       <ids-text slot="title" font-size="24" type="h2" id="my-message-title">Active IDS Message</ids-text>
       <ids-text id="my-message-contents" align="left">This is an active IDS Message component.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Confirm</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Confirm</ids-modal-button>
     </ids-message>
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-example-trigger">Trigger Message</ids-button>
+        <ids-button appearance="secondary" id="message-example-trigger">Trigger Message</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 

--- a/src/components/ids-message/demos/types.html
+++ b/src/components/ids-message/demos/types.html
@@ -12,29 +12,29 @@
       <ids-text slot="title" font-size="24" type="h2" id="message-error-title">Lost connection</ids-text>
       <ids-text class="demo-contents" align="left">This application has experienced a system error due to the lack of internet access.
         Please restart the application in order to proceed.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-error-restart">Restart Now</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-error-restart">Restart Now</ids-modal-button>
     </ids-message>
 
     <!-- Alert Message -->
     <ids-message id="message-alert" status="alert">
       <ids-text slot="title" font-size="24" type="h2" id="message-alert-title">Application Alert</ids-text>
       <ids-text class="demo-contents" align="left">This application has experienced a security alert. Please acknowledge the alert to proceed or cancel to abort.</ids-text>
-      <ids-modal-button slot="buttons" type="secondary" id="message-alert-cancel" cancel>Cancel</ids-modal-button>
-      <ids-modal-button slot="buttons" type="primary" id="message-alert-try-again">Try Again</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="secondary" id="message-alert-cancel" cancel>Cancel</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-alert-try-again">Try Again</ids-modal-button>
     </ids-message>
 
     <!-- Alert Message -->
     <ids-message id="message-success" status="success">
       <ids-text slot="title" font-size="24" type="h2" id="message-success-title">Application Success</ids-text>
       <ids-text class="demo-contents">Success! You've done the thing! Here's a <ids-hyperlink href="http://www.example.com" target="_blank">link</ids-hyperlink>.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-success-done">Done</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-success-done">Done</ids-modal-button>
     </ids-message>
 
     <!-- Info Message -->
     <ids-message id="message-info" status="info">
       <ids-text slot="title" font-size="24" type="h2" id="message-info-title">File Upload Complete</ids-text>
       <ids-text class="demo-contents" align="left">Your file "<em>photo.png</em>" was successfully uploaded to your personal folder, and is now <strong>public for viewing</strong>.</ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-info-done">Done</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-info-done">Done</ids-modal-button>
     </ids-message>
 
     <!-- Default (Confirmation) Message -->
@@ -42,16 +42,16 @@
       <ids-text slot="title" font-size="24" type="h2" id="message-confirmation-title">Delete this Application</ids-text>
       <ids-text class="demo-contents" align="left">You are about to delete this application permanently.<br /><br />
         Would you like to proceed?</ids-text>
-      <ids-modal-button slot="buttons" type="secondary" id="message-confirmation-cancel" cancel>Cancel</ids-modal-button>
-      <ids-modal-button slot="buttons" type="primary" id="message-confirmation-delete">Delete</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="secondary" id="message-confirmation-cancel" cancel>Cancel</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-confirmation-delete">Delete</ids-modal-button>
     </ids-message>
 
     <!-- Huge Text Message -->
     <ids-message id="message-huge-text">
       <ids-text slot="title" font-size="24" type="h2" id="message-huge-text-title">Message with huge text</ids-text>
       <ids-text class="demo-contents" align="left">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?<br /><br /></ids-text>
-      <ids-modal-button slot="buttons" type="secondary" id="message-huge-text-cancel" cancel>Cancel</ids-modal-button>
-      <ids-modal-button slot="buttons" type="primary" id="message-huge-text-done">Done</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="secondary" id="message-huge-text-cancel" cancel>Cancel</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-huge-text-done">Done</ids-modal-button>
     </ids-message>
 
     <!-- "No Buttons" Message -->
@@ -70,7 +70,7 @@
         <sub>are</sub>
         <sup>default allowed</sup>.
       </ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-allow-tags-ok">Done</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-allow-tags-ok">Done</ids-modal-button>
     </ids-message>
 
     <!-- "Disallow Tags" Message (has the same tags as above, but they are stripped out by the sanitizer) -->
@@ -81,7 +81,7 @@
         <em>from</em> <i>appearing</i> <ins>in</ins> <mark>this</mark> <small>message</small>. <strong>All</strong>
         <sub>are</sub> <sup>stripped</sup>.
       </ids-text>
-      <ids-modal-button slot="buttons" type="primary" id="message-disallow-tags-ok">Done</ids-modal-button>
+      <ids-modal-button slot="buttons" appearance="primary" id="message-disallow-tags-ok">Done</ids-modal-button>
     </ids-message>
 
     <!-- In-page controls for the messages are below -->
@@ -94,32 +94,32 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-error-trigger">Error Example</ids-button>
+        <ids-button appearance="secondary" id="message-error-trigger">Error Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
     <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-alert-trigger">Alert Example</ids-button>
+        <ids-button appearance="secondary" id="message-alert-trigger">Alert Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
     <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-success-trigger">Success Example</ids-button>
+        <ids-button appearance="secondary" id="message-success-trigger">Success Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
     <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-info-trigger">Info Example</ids-button>
+        <ids-button appearance="secondary" id="message-info-trigger">Info Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
     <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-confirmation-trigger">Confirmation Example</ids-button>
+        <ids-button appearance="secondary" id="message-confirmation-trigger">Confirmation Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
     <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-huge-text-trigger">Huge Text Example</ids-button>
+        <ids-button appearance="secondary" id="message-huge-text-trigger">Huge Text Example</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
@@ -131,12 +131,12 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-allow-tags-trigger">Allow Tags</ids-button>
+        <ids-button appearance="secondary" id="message-allow-tags-trigger">Allow Tags</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
     <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-disallow-tags-trigger">Disallow Tags</ids-button>
+        <ids-button appearance="secondary" id="message-disallow-tags-trigger">Disallow Tags</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
@@ -148,7 +148,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="message-no-buttons-trigger">No Buttons</ids-button>
+        <ids-button appearance="secondary" id="message-no-buttons-trigger">No Buttons</ids-button>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-modal-button/README.md
+++ b/src/components/ids-modal-button/README.md
@@ -17,10 +17,10 @@ The IdsModalButton Component is an extension of the regular [IdsButton Component
 Modal Buttons extend regular buttons and are constructed with similar markup.
 
 ```html
-<ids-modal-button id="button-ok" type="primary">
+<ids-modal-button id="button-ok" appearance="primary">
     <ids-text>OK</ids-text>
 </ids-modal-button>
-<ids-modal-button id="button-ok" type="secondary" cancel>
+<ids-modal-button id="button-ok" appearance="secondary" cancel>
     <ids-text>Cancel</ids-text>
 </ids-modal-button>
 ```

--- a/src/components/ids-modal/README.md
+++ b/src/components/ids-modal/README.md
@@ -56,7 +56,7 @@ Other elements on the page, such as an [Ids Button](../ids-button/README.md) can
     <p>This is a simple Modal component</p>
 </ids-modal>
 
-<ids-button id="trigger-button" type="secondary">
+<ids-button id="trigger-button" appearance="secondary">
     <span>Trigger Modal</span>
     <ids-icon icon="launch"></ids-icon>
 </ids-button>
@@ -81,8 +81,8 @@ It's possible to append a Message Title to add more context, and Buttons to crea
 <ids-modal id="my-modal">
     <ids-text slot="title" font-size="24" type="h2">This is the Title</ids-text>
     <p>This is a simple Modal component</p>
-    <ids-modal-button slot="buttons" id="ok" type="primary">OK</ids-modal-button>
-    <ids-modal-button slot="buttons" id="cancel" type="secondary" cancel>Cancel</ids-modal-button>
+    <ids-modal-button slot="buttons" id="ok" appearance="primary">OK</ids-modal-button>
+    <ids-modal-button slot="buttons" id="cancel" appearance="secondary" cancel>Cancel</ids-modal-button>
 </ids-modal>
 ```
 
@@ -94,8 +94,8 @@ IdsModal can alter its display mode to take up 100% of the browser viewport's wi
 <ids-modal id="my-modal" fullsize="lg">
     <ids-text slot="title" font-size="24" type="h2">Fullsize Modal</ids-text>
     <p>This modal will transform when below the `lg` breakpoint</p>
-    <ids-modal-button slot="buttons" id="ok" type="primary">OK</ids-modal-button>
-    <ids-modal-button slot="buttons" id="cancel" type="secondary" cancel>Cancel</ids-modal-button>
+    <ids-modal-button slot="buttons" id="ok" appearance="primary">OK</ids-modal-button>
+    <ids-modal-button slot="buttons" id="cancel" appearance="secondary" cancel>Cancel</ids-modal-button>
 </ids-modal>
 ```
 

--- a/src/components/ids-modal/demos/example.html
+++ b/src/components/ids-modal/demos/example.html
@@ -9,7 +9,7 @@
     <ids-theme-switcher mode="light"></ids-theme-switcher>
     <ids-modal id="my-modal" aria-labelledby="my-modal-title">
       <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-      <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
+      <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
         <span>OK</span>
       </ids-modal-button>
       <ids-text align="left">This is an active IDS Modal component</ids-text>
@@ -20,7 +20,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="modal-trigger-btn" type="secondary">
+        <ids-button id="modal-trigger-btn" appearance="secondary">
           <span>Trigger a Modal</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-modal/demos/focus.html
+++ b/src/components/ids-modal/demos/focus.html
@@ -15,10 +15,10 @@
       <ids-checkbox id="setting-capture" label="Capture Focus" checked></ids-checkbox>
       <ids-checkbox id="setting-cycle" label="Cycle Focus" checked></ids-checkbox>
 
-      <ids-modal-button slot="buttons" id="modal-cancel-btn" type="secondary" cancel>
+      <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="secondary" cancel>
         <span>Cancel</span>
       </ids-modal-button>
-      <ids-modal-button slot="buttons" id="modal-save-btn" type="primary">
+      <ids-modal-button slot="buttons" id="modal-save-btn" appearance="primary">
         <span>Save</span>
       </ids-modal-button>
     </ids-modal>
@@ -28,7 +28,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="modal-trigger-btn" type="secondary">
+        <ids-button id="modal-trigger-btn" appearance="secondary">
           <span>Observe Focus Capture Behavior</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-modal/demos/fullsize.html
+++ b/src/components/ids-modal/demos/fullsize.html
@@ -13,7 +13,7 @@
     <ids-theme-switcher mode="light"></ids-theme-switcher>
     <ids-modal id="my-modal" aria-labelledby="my-modal-title">
       <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-      <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
+      <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
         <span>OK</span>
       </ids-modal-button>
       <ids-text>This modal will appear fullsize when the browser viewport is below the <span id="break">"sm (600px)"</span> breakpoint.<br /><br />
@@ -38,7 +38,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="modal-trigger-btn" type="secondary">
+        <ids-button id="modal-trigger-btn" appearance="secondary">
           <span>Trigger a Modal</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-modal/demos/keep-open.html
+++ b/src/components/ids-modal/demos/keep-open.html
@@ -13,7 +13,7 @@
     <ids-theme-switcher mode="light"></ids-theme-switcher>
     <ids-modal id="my-modal" aria-labelledby="my-modal-title">
       <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-      <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
+      <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
         <span>OK</span>
       </ids-modal-button>
       <ids-text>The checkbox below controls whether or not a user can click in the overlay to close this Modal</ids-text>
@@ -26,7 +26,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="modal-trigger-btn" type="secondary">
+        <ids-button id="modal-trigger-btn" appearance="secondary">
           <span>Trigger a Modal</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-modal/demos/nested.html
+++ b/src/components/ids-modal/demos/nested.html
@@ -10,10 +10,10 @@
     <ids-modal id="parent-modal" aria-labelledby="parent-modal-title">
       <ids-text slot="title" font-size="24" type="h2" id="parent-modal-title">Parent Modal</ids-text>
       <ids-text>This is the Parent IDS Modal</ids-text><br>
-      <ids-modal-button slot="buttons" id="parent-modal-close-btn" type="secondary" cancel>
+      <ids-modal-button slot="buttons" id="parent-modal-close-btn" appearance="secondary" cancel>
         <span>Close</span>
       </ids-modal-button>
-      <ids-modal-button slot="buttons" id="nested-modal-trigger-btn" type="primary">
+      <ids-modal-button slot="buttons" id="nested-modal-trigger-btn" appearance="primary">
         <span>Open Another</span>
       </ids-modal-button>
     </ids-modal>
@@ -21,7 +21,7 @@
     <ids-modal id="nested-modal" aria-labelledby="nested-modal-title">
       <ids-text slot="title" font-size="24" type="h2" id="nested-modal-title">Nested Modal</ids-text>
       <ids-text>This is the Nested IDS Modal</ids-text><br>
-      <ids-modal-button slot="buttons" id="nested-modal-close-btn" type="secondary" cancel>
+      <ids-modal-button slot="buttons" id="nested-modal-close-btn" appearance="secondary" cancel>
         <span>Close</span>
       </ids-modal-button>
     </ids-modal>
@@ -31,7 +31,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="parent-modal-trigger-btn" type="secondary">
+        <ids-button id="parent-modal-trigger-btn" appearance="secondary">
           <span>Trigger a Modal</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-modal/demos/side-by-side.html
+++ b/src/components/ids-modal/demos/side-by-side.html
@@ -17,7 +17,7 @@
 
     <ids-modal id="my-modal" aria-labelledby="my-modal-title">
       <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-      <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
+      <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
         <span>OK</span>
       </ids-modal-button>
       <ids-text>This is an active IDS Modal component</ids-text>
@@ -25,7 +25,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="modal-trigger-btn" type="secondary">
+        <ids-button id="modal-trigger-btn" appearance="secondary">
           <span>Trigger a Modal</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-modal/demos/visible.html
+++ b/src/components/ids-modal/demos/visible.html
@@ -10,7 +10,7 @@
     <ids-modal id="my-modal" visible="true" aria-labelledby="my-modal-title">
       <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
       <ids-text>This is an active IDS Modal component</ids-text>
-      <ids-modal-button slot="buttons" id="modal-close-btn" type="secondary" cancel>
+      <ids-modal-button slot="buttons" id="modal-close-btn" appearance="secondary" cancel>
         <span>OK</span>
       </ids-modal-button>
     </ids-modal>
@@ -23,7 +23,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="modal-trigger-btn" type="secondary">
+        <ids-button id="modal-trigger-btn" appearance="secondary">
           <span>Trigger a Modal</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-notification-banner/ids-notification-banner.ts
+++ b/src/components/ids-notification-banner/ids-notification-banner.ts
@@ -91,7 +91,7 @@ export default class IdsNotificationBanner extends Base {
         </div>` : ''}
 
         <div class="ids-notification-banner-button" part="button">
-          <ids-button type="tertiary">
+          <ids-button appearance="tertiary">
             <span class="audible">Close Button</span>
             <ids-icon icon="close" size="small"></ids-icon>
           </ids-button>

--- a/src/components/ids-popup/demos/example.html
+++ b/src/components/ids-popup/demos/example.html
@@ -12,7 +12,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="popup-trigger-btn" type="secondary">
+        <ids-button id="popup-trigger-btn" appearance="secondary">
           <span>Trigger a Popup</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-popup/demos/on-place.html
+++ b/src/components/ids-popup/demos/on-place.html
@@ -19,7 +19,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="popup-trigger-btn" type="secondary">
+        <ids-button id="popup-trigger-btn" appearance="secondary">
           <span>Trigger a Popup</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-popup/demos/sandbox.html
+++ b/src/components/ids-popup/demos/sandbox.html
@@ -28,7 +28,7 @@
       <div slot="content">
         <div class="demo-popup">
           <ids-text font-size="14" font-weight="bold">My Test Popup</ids-text>
-          <ids-button type="primary">This is Focusable</ids-button>
+          <ids-button appearance="primary">This is Focusable</ids-button>
         </div>
       </div>
     </ids-popup>
@@ -74,7 +74,7 @@
           <ids-input id="x-control" value="0" label="X:" size="sm" compact></ids-input>
           <ids-input id="y-control" value="0" label="Y:" size="sm" compact></ids-input>
           <ids-checkbox id="xy-click-to-set-option" label="Click page to set coords"></ids-checkbox>
-          <ids-button type="secondary" id="xy-controls-reset">Reset</ids-button>
+          <ids-button appearance="secondary" id="xy-controls-reset">Reset</ids-button>
         </ids-layout-grid-cell>
         <ids-layout-grid-cell>
           <ids-text id="other-controls">Other</ids-text><br />

--- a/src/components/ids-popup/demos/scrolling.html
+++ b/src/components/ids-popup/demos/scrolling.html
@@ -16,7 +16,7 @@
           <pre>position: relative;</pre> to control Popup placement
         </ids-text>
         <div class="demo-content-spacer"></div>
-        <ids-button id="popup-test-trigger-1" type="secondary">
+        <ids-button id="popup-test-trigger-1" appearance="secondary">
           <span>Trigger Popup One</span>
         </ids-button>
         <ids-popup x="15" y="0" align-target="#popup-test-trigger-1" align="right" animated="true" type="menu"
@@ -34,7 +34,7 @@
           <pre>position: relative;</pre> to control Popup placement
         </ids-text>
         <div class="demo-content-spacer"></div>
-        <ids-button id="popup-test-trigger-2" type="secondary">
+        <ids-button id="popup-test-trigger-2" appearance="secondary">
           <span>Trigger Popup Two</span>
         </ids-button>
         <ids-popup x="15" y="0" align-target="#popup-test-trigger-2" align="right" animated="true" type="menu"
@@ -53,7 +53,7 @@
             This draggable container is using <pre>position: absolute;</pre><br />
             IdsPopup can be used in absolute-positioned containers when reset by wrapping with another <pre>position: relative;</pre> container inside</ids-text>
           <div class="demo-content-spacer"></div>
-          <ids-button id="popup-test-trigger-3" type="secondary">
+          <ids-button id="popup-test-trigger-3" appearance="secondary">
             <span>Trigger Popup Three</span>
           </ids-button>
           <ids-popup x="15" y="0" align-target="#popup-test-trigger-3" align="right" animated="true" type="menu" id="popup-test-3"

--- a/src/components/ids-popup/demos/side-by-side.html
+++ b/src/components/ids-popup/demos/side-by-side.html
@@ -15,7 +15,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="popup-trigger-btn" type="secondary">
+        <ids-button id="popup-trigger-btn" appearance="secondary">
           <span>Trigger a Popup</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-progress-bar/demos/side-by-side.html
+++ b/src/components/ids-progress-bar/demos/side-by-side.html
@@ -15,7 +15,7 @@
     <ids-layout-grid cols="3" gap="md">
       <ids-layout-grid-cell>
         <ids-progress-bar id="elem-progress" label="Percent complete" value="10"></ids-progress-bar>
-        <ids-button id="test-button-secondary" type="secondary">
+        <ids-button id="test-button-secondary" appearance="secondary">
           <span>Secondary Button</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-radio/demos/example.html
+++ b/src/components/ids-radio/demos/example.html
@@ -59,10 +59,10 @@
           <ids-radio value="opt2" label="Option two"></ids-radio>
           <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>
         </ids-radio-group>
-        <ids-button type="secondary" id="btn-radio-clear">
+        <ids-button appearance="secondary" id="btn-radio-clear">
           <span>Clear</span>
         </ids-button>
-        <ids-button type="secondary" id="btn-radio-validate">
+        <ids-button appearance="secondary" id="btn-radio-validate">
           <span>Validate</span>
         </ids-button>
 

--- a/src/components/ids-splitter/demos/sandbox.html
+++ b/src/components/ids-splitter/demos/sandbox.html
@@ -152,7 +152,7 @@
     </ids-layout-grid>
     <ids-layout-grid>
       <ids-layout-grid-cell>
-        <ids-button id="btn-splitter-disable-enable" type="secondary">
+        <ids-button id="btn-splitter-disable-enable" appearance="secondary">
           <span>Enable Splitter</span>
         </ids-button>
       </ids-layout-grid-cell>
@@ -201,7 +201,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="btn-splitter-collapse-expand" type="secondary">
+        <ids-button id="btn-splitter-collapse-expand" appearance="secondary">
           <span>Collapse</span>
         </ids-button>
       </ids-layout-grid-cell>
@@ -226,7 +226,7 @@
     </ids-layout-grid>
     <ids-layout-grid>
       <ids-layout-grid-cell>
-        <ids-menu-button type="secondary" id="btn-splitter-save-clear" menu="menu-splitter-save-clear" trigger-type="click" dropdown-icon>
+        <ids-menu-button appearance="secondary" id="btn-splitter-save-clear" menu="menu-splitter-save-clear" trigger-type="click" dropdown-icon>
           <span>Clear saved position</span>
         </ids-menu-button>
         <ids-popup-menu id="menu-splitter-save-clear" target="#btn-splitter-save-clear">

--- a/src/components/ids-tabs/demos/action-panel.html
+++ b/src/components/ids-tabs/demos/action-panel.html
@@ -110,7 +110,7 @@
 
     <ids-layout-grid>
       <ids-layout-grid-column>
-        <ids-button type="secondary" id="cap-trigger-btn">Open Action Panel</ids-button>
+        <ids-button appearance="secondary" id="cap-trigger-btn">Open Action Panel</ids-button>
       </ids-layout-grid-column>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-textarea/demos/example.html
+++ b/src/components/ids-textarea/demos/example.html
@@ -37,22 +37,22 @@
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
         <ids-textarea label="Toggle State" id="textarea-toggle-state">Line One</ids-textarea>
-        <ids-button id="btn-textarea-enable" type="secondary">
+        <ids-button id="btn-textarea-enable" appearance="secondary">
           <span>Enable</span>
         </ids-button>
-        <ids-button id="btn-textarea-disable" type="secondary">
+        <ids-button id="btn-textarea-disable" appearance="secondary">
           <span>Disable</span>
         </ids-button>
-        <ids-button id="btn-textarea-readonly" type="secondary">
+        <ids-button id="btn-textarea-readonly" appearance="secondary">
           <span>Readonly</span>
         </ids-button>
       </ids-layout-grid-cell>
       <ids-layout-grid-cell>
         <ids-textarea label="Update Value" id="textarea-update-value">Line One</ids-textarea>
-        <ids-button id="btn-textarea-update-value" type="secondary">
+        <ids-button id="btn-textarea-update-value" appearance="secondary">
           <span>Update Value</span>
         </ids-button>
-        <ids-button id="btn-textarea-reset-value" type="secondary">
+        <ids-button id="btn-textarea-reset-value" appearance="secondary">
           <span>Reset Value</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-time-picker/ids-time-picker-popup.ts
+++ b/src/components/ids-time-picker/ids-time-picker-popup.ts
@@ -68,7 +68,7 @@ class IdsTimePickerPopup extends Base {
     return `<ids-popup class="ids-time-picker-popup" type="menu" tabIndex="-1" align="bottom, left" arrow="bottom" part="popup" y="12" animated>
       <section slot="content">
         ${dropdownHTML}
-        <ids-modal-button class="popup-btn" hidden="${this.autoupdate}" part="btn-set" type="primary">
+        <ids-modal-button class="popup-btn" hidden="${this.autoupdate}" part="btn-set" appearance="primary">
           <ids-text translate-text="true" font-weight="bold">SetTime</ids-text>
         </ids-modal-button>
       </section>

--- a/src/components/ids-toast/README.MD
+++ b/src/components/ids-toast/README.MD
@@ -21,7 +21,7 @@ Toasts are used to display confirmations of success, failure, or other statuses 
 A normal toast used as a web component.
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Toast Message</span>
 </ids-button>
 ```
@@ -48,7 +48,7 @@ btnToast?.addEventListener('click', () => {
 Set position of the toast container in specific place
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Position</span>
 </ids-button>
 ```
@@ -76,7 +76,7 @@ btnToast?.addEventListener('click', () => {
 Set user to allows drag/drop the toast container
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Draggable</span>
 </ids-button>
 ```
@@ -103,7 +103,7 @@ btnToast?.addEventListener('click', () => {
 Save toast container position to local storage, apply only when draggable set to true
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Save position</span>
 </ids-button>
 ```
@@ -135,7 +135,7 @@ btnToast?.addEventListener('click', () => {
 Clear the saved position from local storage
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Clear saved position</span>
 </ids-button>
 ```
@@ -154,7 +154,7 @@ btnToast?.addEventListener('click', () => {
 Clear all toast related saved position from local storage
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Clear (all) saved positions</span>
 </ids-button>
 ```
@@ -171,7 +171,7 @@ btnToast?.addEventListener('click', () => {
 Set to not destroy after complete all the toast messages
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>No destroy after complete</span>
 </ids-button>
 ```
@@ -198,7 +198,7 @@ btnToast?.addEventListener('click', () => {
 Set to put links in the toast message
 
 ```html
-ids-button id="btn-toast" type="secondary">
+ids-button id="btn-toast" appearance="secondary">
   <span>Allow link</span>
 </ids-button>
 ```
@@ -225,7 +225,7 @@ btnToast?.addEventListener('click', () => {
 Set the amount of time (2 seconds), the toast should be present on-screen
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Timeout (2 seconds)</span>
 </ids-button>
 ```
@@ -252,7 +252,7 @@ btnToast?.addEventListener('click', () => {
 Custom text that use for close button label in the toast message
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Close button custom label text</span>
 </ids-button>
 ```
@@ -279,7 +279,7 @@ btnToast?.addEventListener('click', () => {
 Hide the progress bar in toast message
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Progress bar (hidden)</span>
 </ids-button>
 ```
@@ -306,7 +306,7 @@ btnToast?.addEventListener('click', () => {
 Let toast message to be invisible on the screen
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Audible only</span>
 </ids-button>
 ```
@@ -333,7 +333,7 @@ btnToast?.addEventListener('click', () => {
 Toast message by markup
 
 ```html
-<ids-button id="btn-toast" type="secondary">
+<ids-button id="btn-toast" appearance="secondary">
   <span>Toast message by markup</span>
 </ids-button>
 <ids-toast id="toast-markup" destroy-on-complete="false">

--- a/src/components/ids-toast/demos/example.html
+++ b/src/components/ids-toast/demos/example.html
@@ -13,7 +13,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="btn-toast-demo" type="secondary">
+        <ids-button id="btn-toast-demo" appearance="secondary">
           <span>Toast Message</span>
         </ids-button>
       </ids-layout-grid-cell>

--- a/src/components/ids-toast/demos/sandbox.html
+++ b/src/components/ids-toast/demos/sandbox.html
@@ -15,7 +15,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="btn-toast-variant" type="secondary">
+        <ids-button id="btn-toast-variant" appearance="secondary">
           <span>Show Toast (choose settings below)</span>
         </ids-button>
         <br /><br />
@@ -84,21 +84,21 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-            <ids-button id="btn-toast-save-position-1" type="secondary">
+            <ids-button id="btn-toast-save-position-1" appearance="secondary">
               <span>Show Toast(1)</span>
             </ids-button>
-            <ids-button id="btn-toast-clear-position-1" type="secondary">
+            <ids-button id="btn-toast-clear-position-1" appearance="secondary">
               <span>Clear position for saved Toast(1)</span>
             </ids-button>
             <br/><br/>
-            <ids-button id="btn-toast-save-position-2" type="secondary">
+            <ids-button id="btn-toast-save-position-2" appearance="secondary">
               <span>Show Toast(2)</span>
             </ids-button>
-            <ids-button id="btn-toast-clear-position-2" type="secondary">
+            <ids-button id="btn-toast-clear-position-2" appearance="secondary">
               <span>Clear position for saved Toast(2)</span>
             </ids-button>
             <br /><br />
-            <ids-button id="btn-toast-clear-position-all" type="secondary">
+            <ids-button id="btn-toast-clear-position-all" appearance="secondary">
               <span>Clear all</span>
             </ids-button>
             <ids-text class="inline">Clear all toast related saved position from local storage</ids-text>
@@ -112,7 +112,7 @@
 
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="btn-toast-markup" type="secondary">
+        <ids-button id="btn-toast-markup" appearance="secondary">
           <span>Toast - By markup</span>
           <span></span>
         </ids-button>

--- a/src/components/ids-toast/demos/side-by-side.html
+++ b/src/components/ids-toast/demos/side-by-side.html
@@ -15,7 +15,7 @@
     <ids-layout-grid cols="3" gap="md">
       <ids-layout-grid-cell>
 
-        <ids-button id="btn-toast-wc" type="secondary">
+        <ids-button id="btn-toast-wc" appearance="secondary">
           <span>Toast Message (wc)</span>
         </ids-button>
 

--- a/src/components/ids-toggle-button/README.md
+++ b/src/components/ids-toggle-button/README.md
@@ -45,9 +45,9 @@ In addition to having the same states as Buttons, Toggle Buttons can also have:
 - Pressed (on)
 - Unpressed (off)
 
-### "Default" Type
+### "Default" Appearance
 
-Toggle buttons can only be displayed in the "default" button type
+Toggle buttons can only be displayed in the "default" button appearance
 
 ## Keyboard Guidelines
 

--- a/src/components/ids-toggle-button/ids-toggle-button.ts
+++ b/src/components/ids-toggle-button/ids-toggle-button.ts
@@ -2,8 +2,8 @@ import { attributes } from '../../core/ids-attributes';
 import { customElement, scss } from '../../core/ids-decorators';
 import IdsButton from '../ids-button/ids-button';
 
-import { BUTTON_ATTRIBUTES, BUTTON_TYPES } from '../ids-button/ids-button-common';
-import type { IdsButtonType } from '../ids-button/ids-button-common';
+import { BUTTON_ATTRIBUTES, BUTTON_APPEARANCE } from '../ids-button/ids-button-common';
+import type { IdsButtonAppearance } from '../ids-button/ids-button-common';
 
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 import '../ids-icon/ids-icon';
@@ -74,19 +74,19 @@ export default class IdsToggleButton extends IdsButton {
   }
 
   /**
-   * Override setting the "type" on Toggle Buttons, since they can only be the default style
-   * @param {IdsButtonType | null} val a valid type
+   * Override setting the "appearance" on Toggle Buttons, since they can only be the default style
+   * @param {IdsButtonAppearance | null} val a valid appearance attribute
    */
-  set type(val: IdsButtonType | null) {
-    val = BUTTON_TYPES[0];
-    super.type = val;
+  set appearance(val: IdsButtonAppearance | null) {
+    val = BUTTON_APPEARANCE[0];
+    super.appearance = val;
   }
 
   /**
-   * @returns {IdsButtonType} the currently set type
+   * @returns {IdsButtonAppearance} the currently set appearance attribute
    */
-  get type(): IdsButtonType {
-    return super.type;
+  get appearance(): IdsButtonAppearance {
+    return super.appearance;
   }
 
   /**

--- a/src/components/ids-tooltip/demos/example.html
+++ b/src/components/ids-tooltip/demos/example.html
@@ -12,7 +12,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="button-1" type="secondary">Hover to show a Tooltip</ids-button>
+        <ids-button id="button-1" appearance="secondary">Hover to show a Tooltip</ids-button>
         <ids-tooltip target="#button-1" id="tooltip-example" data-automation-id="tooltip-example">Additional Information</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>

--- a/src/components/ids-tooltip/demos/performance.ts
+++ b/src/components/ids-tooltip/demos/performance.ts
@@ -11,7 +11,7 @@ const appendTestItems = () => {
     for (let index = 0; index < 1000; index++) {
       let html = '';
       html += `<ids-layout-grid-cell>
-      <ids-button id="button-${index}" type="secondary" tooltip="Tooltip ${index}">Button ${index}</ids-button>
+      <ids-button id="button-${index}" appearance="secondary" tooltip="Tooltip ${index}">Button ${index}</ids-button>
       </ids-layout-grid-cell>`;
       section.insertAdjacentHTML('beforeend', html);
     }

--- a/src/components/ids-tooltip/demos/sandbox.html
+++ b/src/components/ids-tooltip/demos/sandbox.html
@@ -12,13 +12,13 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="tooltip-top" type="secondary">Tooltip on Top</ids-button>
+        <ids-button id="tooltip-top" appearance="secondary">Tooltip on Top</ids-button>
         <ids-tooltip target="#tooltip-top" placement="top">Additional Information</ids-tooltip>
-        <ids-button id="tooltip-bottom" type="secondary">Tooltip on Bottom</ids-button>
+        <ids-button id="tooltip-bottom" appearance="secondary">Tooltip on Bottom</ids-button>
         <ids-tooltip target="#tooltip-bottom" placement="bottom">Additional Information</ids-tooltip>
-        <ids-button id="tooltip-left" type="secondary">Tooltip on Left</ids-button>
+        <ids-button id="tooltip-left" appearance="secondary">Tooltip on Left</ids-button>
         <ids-tooltip target="#tooltip-left" placement="left">Additional Information</ids-tooltip>
-        <ids-button id="tooltip-right" type="secondary">Tooltip on Right</ids-button>
+        <ids-button id="tooltip-right" appearance="secondary">Tooltip on Right</ids-button>
         <ids-tooltip target="#tooltip-right" placement="right">Additional Information</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>
@@ -28,7 +28,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="tooltip-disabed" type="secondary" disabled="true">Tooltip on Disabled</ids-button>
+        <ids-button id="tooltip-disabed" appearance="secondary" disabled="true">Tooltip on Disabled</ids-button>
         <ids-tooltip target="#tooltip-disabed" placement="top">Additional Information</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>
@@ -38,9 +38,9 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="tooltip-click" type="secondary">Tooltip on Click</ids-button>
+        <ids-button id="tooltip-click" appearance="secondary">Tooltip on Click</ids-button>
         <ids-tooltip target="#tooltip-click" trigger="click">Additional Information 1</ids-tooltip>
-        <ids-button id="tooltip-focus" type="secondary">Tooltip on Focus</ids-button>
+        <ids-button id="tooltip-focus" appearance="secondary">Tooltip on Focus</ids-button>
         <ids-tooltip target="#tooltip-focus" trigger="focus">Additional Information 2</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>
@@ -50,7 +50,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="tooltip-parts" type="secondary">Custom Tooltip Css</ids-button>
+        <ids-button id="tooltip-parts" appearance="secondary">Custom Tooltip Css</ids-button>
         <ids-tooltip target="#tooltip-parts" placement="top">Customized Text</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>
@@ -60,8 +60,8 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="tooltip-shared-1" type="secondary">Button 1</ids-button>
-        <ids-button id="tooltip-shared-2" type="secondary">Button 2</ids-button>
+        <ids-button id="tooltip-shared-1" appearance="secondary">Button 1</ids-button>
+        <ids-button id="tooltip-shared-2" appearance="secondary">Button 2</ids-button>
         <ids-tooltip target="#tooltip-shared-1, #tooltip-shared-2" placement="top">Shared Tooltip</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>
@@ -71,7 +71,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="tooltip-async" type="secondary">Ajax Tooltip Content</ids-button>
+        <ids-button id="tooltip-async" appearance="secondary">Ajax Tooltip Content</ids-button>
         <ids-tooltip target="#tooltip-async" placement="top">Shared Tooltip</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>
@@ -81,7 +81,7 @@
     </ids-layout-grid>
     <ids-layout-grid cols="2" gap="md">
       <ids-layout-grid-cell>
-        <ids-button type="secondary" id="test-button-mixin" tooltip="Additional Information">Normal Button</ids-button>
+        <ids-button appearance="secondary" id="test-button-mixin" tooltip="Additional Information">Normal Button</ids-button>
         <br/>
         <br/>
         <ids-input type="text" label="Text Field" tooltip="Additional Information"></ids-input>

--- a/src/components/ids-tooltip/demos/side-by-side.html
+++ b/src/components/ids-tooltip/demos/side-by-side.html
@@ -14,7 +14,7 @@
     </ids-layout-grid>
     <ids-layout-grid auto="true">
       <ids-layout-grid-cell>
-        <ids-button id="new-button" type="secondary">New Button</ids-button>
+        <ids-button id="new-button" appearance="secondary">New Button</ids-button>
         <ids-tooltip target="#new-button" id="new-tooltip">Additional Information</ids-tooltip>
       </ids-layout-grid-cell>
     </ids-layout-grid>

--- a/src/components/ids-tree/demos/sandbox.html
+++ b/src/components/ids-tree/demos/sandbox.html
@@ -57,7 +57,7 @@
           <ids-radio value="expand-all" label="Expand All"></ids-radio>
           <ids-radio value="collapse-all" label="Collapse All" checked="true"></ids-radio>
         </ids-radio-group>
-        <ids-button id="btn-tree-expandcollapse" type="secondary">
+        <ids-button id="btn-tree-expandcollapse" appearance="secondary">
           <span>Expand/Collapse Action</span>
         </ids-button>
         <br/><br/>
@@ -69,7 +69,7 @@
       <ids-layout-grid-cell>
         <ids-text font-size="12" type="h2">Selection</ids-text>
         <br/>
-        <ids-button id="btn-tree-toggle-selection" type="secondary">
+        <ids-button id="btn-tree-toggle-selection" appearance="secondary">
           <span>Toggle Selection (Public Folders)</span>
         </ids-button>
         <br/><br/>
@@ -81,7 +81,7 @@
       <ids-layout-grid-cell>
         <ids-text font-size="12" type="h2">Disable / Enable</ids-text>
         <br/>
-        <ids-button id="btn-tree-disable-enable" type="secondary">
+        <ids-button id="btn-tree-disable-enable" appearance="secondary">
           <span>Enable Tree</span>
         </ids-button>
         <br/><br/>

--- a/src/components/ids-upload-advanced/README.md
+++ b/src/components/ids-upload-advanced/README.md
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
 Set an arbitrary error message.
 
 ```html
-<ids-button id="error-btn" type="secondary">
+<ids-button id="error-btn" appearance="secondary">
   <span>Set Error</span>
 </ids-button>
 <ids-upload-advanced id="error-el"></ids-upload-advanced>
@@ -177,7 +177,7 @@ Set an arbitrary error message on each file.
 -Add file/s to upload before apply error. It can only be apply before `completed` state.
 
 ```html
-<ids-button id="error-files-btn" type="secondary">
+<ids-button id="error-files-btn" appearance="secondary">
   <span>Set Error on each file</span>
 </ids-button>
 <ids-upload-advanced id="error-files-el"></ids-upload-advanced>

--- a/src/components/ids-upload-advanced/demos/sandbox.html
+++ b/src/components/ids-upload-advanced/demos/sandbox.html
@@ -120,7 +120,7 @@
     <ids-layout-grid cols="3" gap="md">
 
       <ids-layout-grid-cell>
-        <ids-button id="upload-advanced-set-error-btn" type="secondary">
+        <ids-button id="upload-advanced-set-error-btn" appearance="secondary">
           <span>Set Error</span>
         </ids-button>
         <ids-text font-size="12">Arbitrary error message</ids-text>
@@ -131,7 +131,7 @@
     <ids-layout-grid cols="3" gap="md">
 
       <ids-layout-grid-cell>
-        <ids-button id="upload-advanced-set-error-on-files-btn" type="secondary">
+        <ids-button id="upload-advanced-set-error-on-files-btn" appearance="secondary">
           <span>Set Error on each file</span>
         </ids-button>
         <ids-text font-size="14">Add file/s to upload before apply error. It can only be apply before `completed` state.</ids-text><br />

--- a/src/mixins/ids-loading-indicator-mixin/README.md
+++ b/src/mixins/ids-loading-indicator-mixin/README.md
@@ -17,13 +17,13 @@ To use this mixin in your component:
 Show with attribute
 
 ```html
-<ids-button type="primary" show-loading-indicator="true">
+<ids-button appearance="primary" show-loading-indicator="true">
   <span>Button</span>
 </ids-button>
 ```
 
 ```html
-<ids-button type="primary" show-loading-indicator="true" loading-indicator-only="true">
+<ids-button appearance="primary" show-loading-indicator="true" loading-indicator-only="true">
   <span>Button</span>
 </ids-button>
 ```
@@ -31,7 +31,7 @@ Show with attribute
 Show custom loading indicator with slot
 
 ```html
-<ids-button type="primary" show-loading-indicator="true">
+<ids-button appearance="primary" show-loading-indicator="true">
   <span>Button</span>
   <ids-alert slot="loading-indicator" icon="in-progress"></ids-alert>
 </ids-button>

--- a/src/mixins/ids-loading-indicator-mixin/ids-loading-indicator-mixin.ts
+++ b/src/mixins/ids-loading-indicator-mixin/ids-loading-indicator-mixin.ts
@@ -76,7 +76,7 @@ const IdsLoadingIndicatorMixin = <T extends IdsBaseConstructor>(superclass: T) =
 
   #attachLoadingIndicator() {
     if (this.showLoadingIndicator && this.#getSlottedElements()?.length === 0) {
-      const type: string | null = this.getAttribute('type');
+      const type: string | null = this.getAttribute(attributes.APPEARANCE);
 
       this.insertAdjacentHTML(
         'beforeend',

--- a/test/ids-about/ids-about-func-test.ts.snap
+++ b/test/ids-about/ids-about-func-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IdsAbout Component (using properties) should render 1`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" type="tertiary" css-class="ids-icon-button ids-modal-icon-button">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary css-class="ids-icon-button ids-modal-icon-button">
       <span class="audible">Close modal</span>
       <ids-icon icon="close"></ids-icon>
     </ids-modal-button><ids-text slot="device" type="p">
@@ -16,7 +16,7 @@ exports[`IdsAbout Component (using properties) should render 1`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 2`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" visible="" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" type="tertiary" css-class="ids-icon-button ids-modal-icon-button">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" visible="" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary css-class="ids-icon-button ids-modal-icon-button">
       <span class="audible">Close modal</span>
       <ids-icon icon="close"></ids-icon>
     </ids-modal-button><ids-text slot="device" type="p">
@@ -31,7 +31,7 @@ exports[`IdsAbout Component (using properties) should render 2`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 3`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" type="tertiary" css-class="ids-icon-button ids-modal-icon-button">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary css-class="ids-icon-button ids-modal-icon-button">
       <span class="audible">Close modal</span>
       <ids-icon icon="close"></ids-icon>
     </ids-modal-button><ids-text slot="device" type="p">

--- a/test/ids-about/ids-about-func-test.ts.snap
+++ b/test/ids-about/ids-about-func-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IdsAbout Component (using properties) should render 1`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary css-class="ids-icon-button ids-modal-icon-button">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
       <span class="audible">Close modal</span>
       <ids-icon icon="close"></ids-icon>
     </ids-modal-button><ids-text slot="device" type="p">
@@ -16,7 +16,7 @@ exports[`IdsAbout Component (using properties) should render 1`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 2`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" visible="" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary css-class="ids-icon-button ids-modal-icon-button">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" visible="" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
       <span class="audible">Close modal</span>
       <ids-icon icon="close"></ids-icon>
     </ids-modal-button><ids-text slot="device" type="p">
@@ -31,7 +31,7 @@ exports[`IdsAbout Component (using properties) should render 2`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 3`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary css-class="ids-icon-button ids-modal-icon-button">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" style="z-index: 1020;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
       <span class="audible">Close modal</span>
       <ids-icon icon="close"></ids-icon>
     </ids-modal-button><ids-text slot="device" type="p">

--- a/test/ids-button/ids-button-e2e-test.ts
+++ b/test/ids-button/ids-button-e2e-test.ts
@@ -22,7 +22,7 @@ describe('Ids Button e2e Tests', () => {
   it.skip('should not have memory leaks', async () => {
     const numberOfObjects = await countObjects(page);
     await page.evaluate(() => {
-      document.body.insertAdjacentHTML('beforeend', `<ids-button id="test" type="primary" icon="settings">My Button</ids-button>`);
+      document.body.insertAdjacentHTML('beforeend', `<ids-button id="test" appearance="primary" icon="settings">My Button</ids-button>`);
       document.querySelector('#test')?.remove();
     });
     expect(await countObjects(page)).toEqual(numberOfObjects);
@@ -45,7 +45,7 @@ describe('Ids Button e2e Tests', () => {
     try {
       await page.evaluate(() => {
         const elem: any = document.createElement('ids-button');
-        elem.type = 'primary';
+        elem.appearance = 'primary';
         document.body.appendChild(elem);
       });
     } catch (err) {
@@ -60,7 +60,7 @@ describe('Ids Button e2e Tests', () => {
       await page.evaluate(() => {
         const elem: any = document.createElement('ids-button');
         document.body.appendChild(elem);
-        elem.type = 'primary';
+        elem.appearance = 'primary';
       });
     } catch (err) {
       hasError = true;
@@ -74,13 +74,13 @@ describe('Ids Button e2e Tests', () => {
       await page.evaluate(() => {
         document.body.insertAdjacentHTML('beforeend', `<ids-button id="test"></ids-button>`);
         const elem: any = document.querySelector('#test');
-        elem.type = 'primary';
+        elem.appearance = 'primary';
       });
     } catch (err) {
       hasError = true;
     }
 
-    const value = await page.evaluate('document.querySelector("#test").getAttribute("type")');
+    const value = await page.evaluate('document.querySelector("#test").getAttribute("appearance")');
     await expect(value).toEqual('primary');
     await expect(hasError).toEqual(false);
   });

--- a/test/ids-button/ids-button-func-test.ts
+++ b/test/ids-button/ids-button-func-test.ts
@@ -43,7 +43,7 @@ describe('IdsButton Component', () => {
     elem.disabled = true;
     elem.icon = 'add';
     elem.text = 'test';
-    elem.state.type = 'icon';
+    elem.state.appearance = 'icon';
     expect(elem.outerHTML).toMatchSnapshot();
   });
 
@@ -175,35 +175,35 @@ describe('IdsButton Component', () => {
     expect(btn.button?.classList.contains('four')).toBeFalsy();
   });
 
-  it('can change its type', () => {
-    btn.type = 'primary';
+  it('can change its appearance', () => {
+    btn.appearance = 'primary';
 
-    expect(btn.getAttribute('type')).toBe('primary');
-    expect(btn.type).toBe('primary');
+    expect(btn.getAttribute('appearance')).toBe('primary');
+    expect(btn.appearance).toBe('primary');
     expect(btn.button?.classList.contains('btn-primary')).toBeTruthy();
-    expect(btn.state.type).toBe('primary');
+    expect(btn.state.appearance).toBe('primary');
 
-    btn.type = 'secondary';
+    btn.appearance = 'secondary';
 
-    expect(btn.getAttribute('type')).toBe('secondary');
-    expect(btn.type).toBe('secondary');
+    expect(btn.getAttribute('appearance')).toBe('secondary');
+    expect(btn.appearance).toBe('secondary');
     expect(btn.button?.classList.contains('btn-secondary')).toBeTruthy();
-    expect(btn.state.type).toBe('secondary');
+    expect(btn.state.appearance).toBe('secondary');
 
-    btn.type = 'tertiary';
+    btn.appearance = 'tertiary';
 
-    expect(btn.getAttribute('type')).toBe('tertiary');
-    expect(btn.type).toBe('tertiary');
+    expect(btn.getAttribute('appearance')).toBe('tertiary');
+    expect(btn.appearance).toBe('tertiary');
     expect(btn.button?.classList.contains('btn-tertiary')).toBeTruthy();
-    expect(btn.state.type).toBe('tertiary');
+    expect(btn.state.appearance).toBe('tertiary');
 
     // Default buttons don't have additional styles
-    btn.type = 'default';
+    btn.appearance = 'default';
 
-    expect(btn.getAttribute('type')).toBe(null);
-    expect(btn.type).toBe('default');
+    expect(btn.getAttribute('appearance')).toBe(null);
+    expect(btn.appearance).toBe('default');
     expect(btn.button?.classList.contains('default')).toBeFalsy();
-    expect(btn.state.type).toBe('default');
+    expect(btn.state.appearance).toBe('default');
   });
 
   it('can change its text via attribute', () => {
@@ -279,7 +279,7 @@ describe('IdsButton Component', () => {
     btn.icon = 'check';
     btn.disabled = true;
     btn.tabIndex = -1;
-    btn.type = 'secondary';
+    btn.appearance = 'secondary';
     btn.cssClass = ['awesome'];
     btn.iconAlign = 'end';
 

--- a/test/ids-button/ids-button-func-test.ts
+++ b/test/ids-button/ids-button-func-test.ts
@@ -345,4 +345,11 @@ describe('IdsButton Component', () => {
       defaultValue: null
     });
   });
+
+  it('can set a type attribute on its inner button', () => {
+    btn.type = 'submit';
+    expect(btn.type).toBe('submit');
+    expect(btn.getAttribute('type')).toBe('submit');
+    expect(btn.container?.getAttribute('type')).toBe('submit');
+  });
 });

--- a/test/ids-button/ids-toggle-button-func-test.ts
+++ b/test/ids-button/ids-toggle-button-func-test.ts
@@ -84,19 +84,19 @@ describe('IdsToggleButton Component', () => {
     expect(btn.text).toBe('Test Button (Off)');
   });
 
-  it('cannot be any other type but "default"', () => {
-    btn.type = 'primary';
+  it('cannot be any other appearance but "default"', () => {
+    btn.appearance = 'primary';
 
-    expect(btn.getAttribute('type')).toBe(null);
-    expect(btn.type).toBe('default');
-    expect(btn.state.type).toBe('default');
+    expect(btn.getAttribute('appearance')).toBe(null);
+    expect(btn.appearance).toBe('default');
+    expect(btn.state.appearance).toBe('default');
     expect(btn.button.classList.contains('primary')).toBeFalsy();
 
-    btn.setAttribute('type', 'secondary');
+    btn.setAttribute('appearance', 'secondary');
 
-    expect(btn.getAttribute('type')).toBe(null);
-    expect(btn.type).toBe('default');
-    expect(btn.state.type).toBe('default');
+    expect(btn.getAttribute('appearance')).toBe(null);
+    expect(btn.appearance).toBe('default');
+    expect(btn.state.appearance).toBe('default');
     expect(btn.button.classList.contains('secondary')).toBeFalsy();
   });
 

--- a/test/ids-data-grid/ids-data-grid-func-formatters-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-formatters-test.ts
@@ -438,7 +438,7 @@ describe('IdsDataGrid Component', () => {
 
       const button = dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row')[1].querySelector('.ids-data-grid-cell ids-button');
       expect(button.textContent).toContain('Button');
-      expect(button.type).toBe('tertiary');
+      expect(button.appearance).toBe('tertiary');
       expect(button.querySelector('ids-icon')).toBeFalsy();
     });
 

--- a/test/ids-empty-message/ids-empty-message-func-test.ts
+++ b/test/ids-empty-message/ids-empty-message-func-test.ts
@@ -23,7 +23,7 @@ describe('Ids Empty Message Tests', () => {
       `<ids-empty-message icon="empty-generic">
         <ids-text type="h2" font-size="20" label="true" slot="label">Alert Label</ids-text>
         <ids-text label="true" slot="description">Description of empty message that explains why and possible contain a hyperlink.</ids-text>
-        <ids-button slot="button" type="primary">BUTTON NAME</ids-button>
+        <ids-button slot="button" appearance="primary">BUTTON NAME</ids-button>
       </ids-empty-message>`
     );
   });

--- a/test/ids-error-page/ids-error-page-func-test.ts.snap
+++ b/test/ids-error-page/ids-error-page-func-test.ts.snap
@@ -10,7 +10,7 @@ exports[`Ids Error Page Tests renders correctly 1`] = `
           <ids-text label="true" slot="description">
             Add Description
           </ids-text>
-          <ids-button class="action-button" slot="button" type="primary">
+          <ids-button class="action-button" slot="button" appearance="prima">
             <span>Action</span>
           </ids-button>
         </ids-empty-message>

--- a/test/ids-error-page/ids-error-page-func-test.ts.snap
+++ b/test/ids-error-page/ids-error-page-func-test.ts.snap
@@ -10,7 +10,7 @@ exports[`Ids Error Page Tests renders correctly 1`] = `
           <ids-text label="true" slot="description">
             Add Description
           </ids-text>
-          <ids-button class="action-button" slot="button" appearance="prima">
+          <ids-button class="action-button" slot="button" appearance="primary">
             <span>Action</span>
           </ids-button>
         </ids-empty-message>

--- a/test/ids-lookup/ids-lookup-func-test.ts
+++ b/test/ids-lookup/ids-lookup-func-test.ts
@@ -438,7 +438,7 @@ describe('IdsLookup Component', () => {
     lookup = await createFromTemplate(lookup, `<ids-lookup id="lookup-5" label="Custom Lookup">
       <ids-modal slot="lookup-modal" id="custom-lookup-modal" aria-labelledby="custom-lookup-modal-title">
         <ids-text slot="title" font-size="24" type="h2" id="lookup-modal-title">Custom Lookup Modal</ids-text>
-        <ids-modal-button slot="buttons" id="modal-cancel-btn" type="primary">
+        <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="primary">
           <span>Apply</span>
         </ids-modal-button>
       </ids-modal>

--- a/test/ids-lookup/ids-lookup-func-test.ts.snap
+++ b/test/ids-lookup/ids-lookup-func-test.ts.snap
@@ -20,10 +20,10 @@ exports[`IdsLookup Component renders correctly 2`] = `
           </ids-layout-grid-cell>
         </ids-layout-grid>
 
-      <ids-modal-button slot="buttons" id="modal-cancel-btn" type="secondary">
+      <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="secondary">
         <span>Cancel</span>
         </ids-modal-button>
-        <ids-modal-button slot="buttons" id="modal-apply-btn" type="primary">
+        <ids-modal-button slot="buttons" id="modal-apply-btn" appearance="primary">
           <span>Apply</span>
         </ids-modal-button>
       </ids-modal>

--- a/test/ids-masthead/ids-masthead-func-test.ts
+++ b/test/ids-masthead/ids-masthead-func-test.ts
@@ -113,7 +113,7 @@ describe('IdsMasthead Component', () => {
     buttons.forEach((button) => {
       expect(button.colorVariant).toBe('alternate');
       expect(button.square).toBe(true);
-      expect(button.type).toBe('default');
+      expect(button.appearance).toBe('default');
     });
   });
 

--- a/test/ids-menu-button/ids-menu-button-e2e-test.ts
+++ b/test/ids-menu-button/ids-menu-button-e2e-test.ts
@@ -22,7 +22,7 @@ describe('Ids Menu Button e2e Tests', () => {
   it.skip('should not have memory leaks', async () => {
     const numberOfObjects = await countObjects(page);
     await page.evaluate(() => {
-      document.body.insertAdjacentHTML('beforeend', `<ids-menu-button id="test" icon="settings" type="tertiary" menu="my-menu" dropdown-icon>
+      document.body.insertAdjacentHTML('beforeend', `<ids-menu-button id="test" icon="settings" appearance="tertiary menu="my-menu" dropdown-icon>
         <span>Settings</span>
       </ids-menu-button>`);
       document.querySelector('#test')?.remove();

--- a/test/ids-message/ids-message-func-test.ts
+++ b/test/ids-message/ids-message-func-test.ts
@@ -17,8 +17,8 @@ const messageTitle = 'Lost Connection';
 const message = `This application has experienced a system error
   due to the lack of internet access. Please restart the application in order to proceed.`;
 const modalButtonHTML = `
-  <ids-modal-button slot="buttons" type="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
-  <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Confirm</ids-modal-button>`;
+  <ids-modal-button slot="buttons" appearance="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
+  <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Confirm</ids-modal-button>`;
 
 describe('IdsMessage Component (using properties)', () => {
   let messageEl: IdsMessage;

--- a/test/ids-message/ids-message-func-test.ts.snap
+++ b/test/ids-message/ids-message-func-test.ts.snap
@@ -3,20 +3,20 @@
 exports[`IdsMessage Component (using properties) should render 1`] = `
 "<ids-message id="test-message" message-title="Lost Connection" aria-label="error: Lost Connection" status="error" role="dialog" fullsize="sm" respond-down="sm"><ids-text slot="title" type="h2" font-size="24">Lost Connection</ids-text><div>This application has experienced a system error
   due to the lack of internet access. Please restart the application in order to proceed.</div>
-  <ids-modal-button slot="buttons" type="secondary" id="my-message-cancel" cancel="">Cancel</ids-modal-button>
-  <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Confirm</ids-modal-button></ids-message>"
+  <ids-modal-button slot="buttons" appearance="secondary" id="my-message-cancel" cancel="">Cancel</ids-modal-button>
+  <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Confirm</ids-modal-button></ids-message>"
 `;
 
 exports[`IdsMessage Component (using properties) should render 2`] = `
 "<ids-message id="test-message" message-title="Lost Connection" aria-label="error: Lost Connection" status="error" role="dialog" fullsize="sm" respond-down="sm" visible="" style="z-index: 1020;"><ids-text slot="title" type="h2" font-size="24">Lost Connection</ids-text><div>This application has experienced a system error
   due to the lack of internet access. Please restart the application in order to proceed.</div>
-  <ids-modal-button slot="buttons" type="secondary" id="my-message-cancel" cancel="">Cancel</ids-modal-button>
-  <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Confirm</ids-modal-button></ids-message>"
+  <ids-modal-button slot="buttons" appearance="secondary" id="my-message-cancel" cancel="">Cancel</ids-modal-button>
+  <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Confirm</ids-modal-button></ids-message>"
 `;
 
 exports[`IdsMessage Component (using properties) should render 3`] = `
 "<ids-message id="test-message" message-title="Lost Connection" aria-label="error: Lost Connection" status="error" role="dialog" fullsize="sm" respond-down="sm" style="z-index: 1020;"><ids-text slot="title" type="h2" font-size="24">Lost Connection</ids-text><div>This application has experienced a system error
   due to the lack of internet access. Please restart the application in order to proceed.</div>
-  <ids-modal-button slot="buttons" type="secondary" id="my-message-cancel" cancel="">Cancel</ids-modal-button>
-  <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Confirm</ids-modal-button></ids-message>"
+  <ids-modal-button slot="buttons" appearance="secondary" id="my-message-cancel" cancel="">Cancel</ids-modal-button>
+  <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Confirm</ids-modal-button></ids-message>"
 `;

--- a/test/ids-modal-button/ids-modal-button-func-test.ts
+++ b/test/ids-modal-button/ids-modal-button-func-test.ts
@@ -10,8 +10,8 @@ import '../../src/components/ids-text/ids-text';
 import '../../src/components/ids-modal-button/ids-modal-button';
 
 const modalButtonHTML = `
-  <ids-modal-button slot="buttons" type="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
-  <ids-modal-button slot="buttons" type="primary" id="my-message-confirm">Confirm</ids-modal-button>`;
+  <ids-modal-button slot="buttons" appearance="secondary" id="my-message-cancel" cancel>Cancel</ids-modal-button>
+  <ids-modal-button slot="buttons" appearance="primary" id="my-message-confirm">Confirm</ids-modal-button>`;
 
 describe('IdsModal Component (with buttons)', () => {
   let modal: any;

--- a/test/ids-modal/ids-modal-e2e-test.ts
+++ b/test/ids-modal/ids-modal-e2e-test.ts
@@ -49,7 +49,7 @@ describe('Ids Modal e2e Tests', () => {
     await page.evaluate(() => {
       document.body.insertAdjacentHTML('beforeend', `<ids-modal id="test" aria-labelledby="my-modal-title">
         <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-        <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
+        <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
           <span>OK</span>
         </ids-modal-button>
       </ids-modal>`);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR changes IdsButton's API in a couple ways:
- The previous `type` attribute has been renamed to `appearance`.
- A new `type` attribute has been added that simply passes the value through to the HTMLButtonElement used as the shadow root container (for example, `type="submit"` now works on buttons).
- All files in this project referencing the type attribute (components/examples/docs/tests) have been updated to reflect these changes

**Related github/jira issue (required)**:
Closes #1062 

**Steps necessary to review your pull request (required)**:

_Test appearance changes:_
Smoke test all button-related components for accuracy:
- http://localhost:4300/ids-button/matrix.html
- http://localhost:4300/ids-button
- http://localhost:4300/ids-menu-button
- http://localhost:4300/ids-toggle-button (should appear "default")
- http://localhost:4300/ids-trigger-field/example.html (trigger buttons should appear "default")
- http://localhost:4300/ids-about/example.html
- http://localhost:4300/ids-message/example.html (two separately-styled buttons)
- http://localhost:4300/ids-action-sheet/example.html (see cancel button on mobile view)

_Test the new `type` setting:_
- Open http://localhost:4300/ids-form/example.html
- Use dev tools to inspect the Submit button.  The host element and the inner HTMLButtonElement should both have a `type` attribute of "submit":

![Screen Shot 2023-03-23 at 12 57 32 PM](https://user-images.githubusercontent.com/3249601/227278585-85540c43-e997-4f01-bae4-be5d6a19f446.png)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
