### PR TITLE
926 - Fix drag and more issues with list builder

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Datagrid]` Fixed broken validation styling in editable cells. ([#1171](https://github.com/infor-design/enterprise-wc/issues/1171))
 - `[DatePicker]` Fixed broken date parsing in different locales. ([#1114](https://github.com/infor-design/enterprise-wc/issues/1114))
 - `[Dropdown]` Added functionality to select an option by keyboard input. ([#1144](https://github.com/infor-design/enterprise-wc/issues/1144))
+- `[ListBuilder]` Fixed drag to first row, drag multi select items, toolbar styles, added support to drag while in edit mode, and added support to custom toolbar. ([#926](https://github.com/infor-design/enterprise-wc/issues/926))
 - `[ListView]` Added support for search to filter list. ([#763](https://github.com/infor-design/enterprise-wc/issues/763)
 - `[Menu/Popup Menu]` Added Shortcut Key display feature to IdsMenuItem. ([#1108](https://github.com/infor-design/enterprise-wc/issues/1108))
 

--- a/src/components/ids-list-builder/README.md
+++ b/src/components/ids-list-builder/README.md
@@ -82,11 +82,47 @@ and if you want to display more data you could modify the template like so:
 </ids-list-builder>
 ```
 
+Show this list builder as a customized toolbar buttons
+
+```html
+  <ids-list-builder>
+    <ids-toolbar slot="toolbar" type="formatter" tabbable="true">
+      <ids-toolbar-section type="buttonset">
+        <ids-button list-builder-action="edit" tooltip="Edit" color-variant="alternate-formatter">
+          <span class="audible">Edit list item</span>
+          <ids-icon icon="edit"></ids-icon>
+        </ids-button>
+        <ids-separator vertical></ids-separator>
+        <ids-button list-builder-action="move-up" tooltip="Move Up" color-variant="alternate-formatter">
+          <span class="audible">Move up list item</span>
+          <ids-icon icon="arrow-up"></ids-icon>
+        </ids-button>
+        <ids-button list-builder-action="move-down" tooltip="Move Down" color-variant="alternate-formatter">
+          <span class="audible">Move down list item</span>
+          <ids-icon icon="arrow-down"></ids-icon>
+        </ids-button>
+      </ids-toolbar-section>
+    </ids-toolbar>
+    <template>
+      <ids-text font-size="16" type="span">${manufacturerName}</ids-text>
+    </template>
+  </ids-list-builder>
+```
+
 ## Settings (Attributes)
 
 Since this component inherits [IdsListView](../ids-list-view/README.md), it will have all of its properties. The only property that should be of concern, and overrides that of its super class, is `data`.
 
 - `data` {array} the list of items to populate the list builder with
+
+## Methods
+
+- `add()` Let insert a new list item, will deselect if selected more than one item
+- `delete()` It will remove selected list items
+- `edit()` Edit the selected list item, will edit first if selected more than one item
+- `moveUp()` Move up the selected list item, if selected more than one item will move up to the first selected and move together if selected not next to each other
+- `moveDown()` Move down the selected list item, if selected more than one item will move down to the last selected and move together if selected not next to each other
+
 
 ## Responsive Guidelines
 

--- a/src/components/ids-list-builder/README.md
+++ b/src/components/ids-list-builder/README.md
@@ -123,7 +123,6 @@ Since this component inherits [IdsListView](../ids-list-view/README.md), it will
 - `moveUp()` Move up the selected list item, if selected more than one item will move up to the first selected and move together if selected not next to each other
 - `moveDown()` Move down the selected list item, if selected more than one item will move down to the last selected and move together if selected not next to each other
 
-
 ## Responsive Guidelines
 
 - This component stretches to 100% width of its container

--- a/src/components/ids-list-builder/demos/custom-toolbar.html
+++ b/src/components/ids-list-builder/demos/custom-toolbar.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto="true">
+      <ids-text font-size="12" type="h1">List Builder - Custom Toolbar</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid cols="2">
+      <ids-layout-grid-cell>
+        <ids-list-builder height="310px" selectable="single" id="list-builder-custom-toolbar">
+          <ids-toolbar slot="toolbar" type="formatter" tabbable="true">
+            <ids-toolbar-section type="buttonset">
+              <ids-button list-builder-action="edit" tooltip="Edit" color-variant="alternate-formatter">
+                <span class="audible">Edit list item</span>
+                <ids-icon icon="edit"></ids-icon>
+              </ids-button>
+              <ids-separator vertical></ids-separator>
+              <ids-button list-builder-action="move-up" tooltip="Move Up" color-variant="alternate-formatter">
+                <span class="audible">Move up list item</span>
+                <ids-icon icon="arrow-up"></ids-icon>
+              </ids-button>
+              <ids-button list-builder-action="move-down" tooltip="Move Down" color-variant="alternate-formatter">
+                <span class="audible">Move down list item</span>
+                <ids-icon icon="arrow-down"></ids-icon>
+              </ids-button>
+            </ids-toolbar-section>
+          </ids-toolbar>
+          <template>
+            <ids-text font-size="16" type="span">${manufacturerName}</ids-text>
+          </template>
+        </ids-list-builder>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-list-builder/demos/custom-toolbar.ts
+++ b/src/components/ids-list-builder/demos/custom-toolbar.ts
@@ -1,0 +1,14 @@
+import bikesJSON from '../../../assets/data/bikes.json';
+
+// Example for populating the List Builder with Ajax
+const listBuilder1: any = document.querySelector('#list-builder-custom-toolbar');
+
+// Do an ajax request and apply the data to the list
+const setData = async () => {
+  const res = await fetch((bikesJSON as any));
+  const data = await res.json();
+
+  listBuilder1.data = data;
+};
+
+setData();

--- a/src/components/ids-list-builder/demos/example.ts
+++ b/src/components/ids-list-builder/demos/example.ts
@@ -5,10 +5,14 @@ const listBuilder1: any = document.querySelector('#list-builder-1');
 
 const addEventListeners = (element: any) => {
   const eventList = [
-    'itemClick', 'itemSelect',
-    'itemAdd', 'itemDelete',
-    'itemMoveUp', 'itemMoveDown',
-    'listDataChange', 'itemChange',
+    'itemClick',
+    'itemSelect',
+    'itemAdd',
+    'itemDelete',
+    'itemMoveUp',
+    'itemMoveDown',
+    'listDataChange',
+    'itemChange',
   ];
 
   eventList.forEach((eventName: string) => {

--- a/src/components/ids-list-builder/demos/index.yaml
+++ b/src/components/ids-list-builder/demos/index.yaml
@@ -11,3 +11,6 @@
   - link: selection-multiple.html
     type: Example
     description: Showing a multiple select list builder
+  - link: custom-toolbar.html
+    type: Example
+    description: Showing a ist builder with custom toolbar

--- a/src/components/ids-list-builder/ids-list-builder.scss
+++ b/src/components/ids-list-builder/ids-list-builder.scss
@@ -6,51 +6,10 @@
   border-radius: 2px;
   border: 1px solid var(--ids-color-palette-slate-40);
 
-  ids-toolbar-section .separator {
-    height: 24px;
-    margin: 6px 11px 0 7px;
-    background-color: var(--ids-color-palette-slate-80);
-    width: 1px;
-  }
-
-  .header {
-    background-color: var(--ids-color-palette-slate-50);
-
-    ids-icon {
-      color: white;
-    }
-  }
-
   // Editing State
   .ids-list-view-body div[part='list-item'].is-editing > ids-text,
   .ids-list-view-body .list-item-content.is-editing > ids-text {
     display: none;
-  }
-
-  // Dark theme
-  &[mode='dark'] {
-    .header {
-      background-color: var(--ids-color-palette-slate-20);
-
-      ids-icon {
-        color: var(--ids-color-palette-slate-70);
-      }
-    }
-  }
-
-  // High Contrast theme
-  &[mode='contrast'] {
-    .header {
-      background-color: var(--ids-color-palette-slate-90);
-
-      ids-icon {
-        color: var(--ids-color-palette-slate-20);
-      }
-    }
-
-    .ids-list-view {
-      background-color: var(--ids-color-palette-white);
-    }
   }
 
   .ids-list-view {

--- a/src/components/ids-swappable/ids-swappable-item.scss
+++ b/src/components/ids-swappable/ids-swappable-item.scss
@@ -41,6 +41,10 @@
   cursor: move;
 }
 
+:host([dragging]) {
+  opacity: 0.4;
+}
+
 :host([dragging]:not(.slotted-ids-tab)),
 :host([selected]:not(.slotted-ids-tab)) {
   background-color: var(--ids-color-brand-primary-base);

--- a/src/components/ids-swappable/ids-swappable-item.ts
+++ b/src/components/ids-swappable/ids-swappable-item.ts
@@ -45,7 +45,6 @@ export default class IdsSwappableItem extends Base {
     if (!this.hasAttribute(attributes.DRAG_MODE)) {
       this.setAttribute(attributes.DRAG_MODE, 'select');
     }
-    this.setAttribute(attributes.DRAGGABLE, this.dragMode === 'select' ? 'false' : 'true');
     this.attachEventListeners();
     this.#addCssClasses();
   }
@@ -211,6 +210,7 @@ export default class IdsSwappableItem extends Base {
       (elem as HTMLElement).focus();
     });
     this.removeAttribute(attributes.OVER);
+    this.triggerEvent('afterdragend', this, { bubbles: true, detail: { elem: this } });
   }
 
   /**

--- a/test/ids-list-builder/ids-list-builder-e2e-test.ts
+++ b/test/ids-list-builder/ids-list-builder-e2e-test.ts
@@ -65,7 +65,7 @@ describe('Ids List Builder e2e Tests', () => {
   });
 
   it('can click the toolbar buttons', async () => {
-    const btn = (opt: string) => `document.querySelector('ids-list-builder').shadowRoot.querySelector('[list-builder-action="${opt}"]')`;
+    const btn = (opt: string) => `document.querySelector('ids-list-builder').querySelector('[list-builder-action="${opt}"]')`;
 
     const editButton = await (await page.evaluateHandle(btn('edit'))).asElement();
     const addButton = await (await page.evaluateHandle(btn('add'))).asElement();

--- a/test/ids-list-builder/ids-list-builder-e2e-test.ts
+++ b/test/ids-list-builder/ids-list-builder-e2e-test.ts
@@ -65,15 +65,12 @@ describe('Ids List Builder e2e Tests', () => {
   });
 
   it('can click the toolbar buttons', async () => {
-    const jsPathToolbarButtonEdit = `document.querySelector("ids-list-builder").shadowRoot.querySelector("#button-edit")`;
-    const jsPathToolbarButtonAdd = `document.querySelector("ids-list-builder").shadowRoot.querySelector("#button-add")`;
-    const jsPathToolbarButtonUp = `document.querySelector("ids-list-builder").shadowRoot.querySelector("#button-up")`;
-    const jsPathToolbarButtonDown = `document.querySelector("ids-list-builder").shadowRoot.querySelector("#button-down")`;
+    const btn = (opt: string) => `document.querySelector('ids-list-builder').shadowRoot.querySelector('[list-builder-action="${opt}"]')`;
 
-    const editButton = await (await page.evaluateHandle(jsPathToolbarButtonEdit)).asElement();
-    const addButton = await (await page.evaluateHandle(jsPathToolbarButtonAdd)).asElement();
-    const upButton = await (await page.evaluateHandle(jsPathToolbarButtonUp)).asElement();
-    const downButton = await (await page.evaluateHandle(jsPathToolbarButtonDown)).asElement();
+    const editButton = await (await page.evaluateHandle(btn('edit'))).asElement();
+    const addButton = await (await page.evaluateHandle(btn('add'))).asElement();
+    const upButton = await (await page.evaluateHandle(btn('move-up'))).asElement();
+    const downButton = await (await page.evaluateHandle(btn('move-down'))).asElement();
 
     await addButton.click();
     await addButton.click();
@@ -110,7 +107,7 @@ describe('Ids List Builder e2e Tests', () => {
 
   it.skip('should update inner text on edit keyup', async () => {
     const firstItemSelector = createListItemSelector(1);
-    const editButtonSelector = 'pierce/#button-edit';
+    const editButtonSelector = 'pierce/[list-builder-action="edit"]';
 
     // click first list item, wait for selected state
     await page.click(firstItemSelector);

--- a/test/ids-list-builder/ids-list-builder-func-test.ts.snap
+++ b/test/ids-list-builder/ids-list-builder-func-test.ts.snap
@@ -2,5 +2,42 @@
 
 exports[`IdsListBuilder Component renders correctly 1`] = `
 "<ids-list-builder selectable="single" sortable="true">
+      <ids-toolbar slot="toolbar" type="formatter" tabbable="true" role="toolbar">
+        <ids-toolbar-section type="buttonset" toolbar-type="formatter">
+          
+      <ids-button list-builder-action="add" tooltip="Add New" color-variant="alternate-formatter">
+        <span class="audible">Add New</span>
+        <ids-icon icon="add"></ids-icon>
+      </ids-button>
+    
+          <ids-separator vertical=""></ids-separator>
+          
+      <ids-button list-builder-action="move-up" tooltip="Move Up" color-variant="alternate-formatter">
+        <span class="audible">Move Up</span>
+        <ids-icon icon="arrow-up"></ids-icon>
+      </ids-button>
+    
+          
+      <ids-button list-builder-action="move-down" tooltip="Move Down" color-variant="alternate-formatter">
+        <span class="audible">Move Down</span>
+        <ids-icon icon="arrow-down"></ids-icon>
+      </ids-button>
+    
+          <ids-separator vertical=""></ids-separator>
+          
+      <ids-button list-builder-action="edit" tooltip="Edit" color-variant="alternate-formatter">
+        <span class="audible">Edit</span>
+        <ids-icon icon="edit"></ids-icon>
+      </ids-button>
+    
+          
+      <ids-button list-builder-action="delete" tooltip="Delete" color-variant="alternate-formatter">
+        <span class="audible">Delete</span>
+        <ids-icon icon="delete"></ids-icon>
+      </ids-button>
+    
+        </ids-toolbar-section>
+      </ids-toolbar>
+    
    </ids-list-builder>"
 `;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed some issues found as below with IdsListBuilder
- Fixed dragging was not able to drag to the first row
- Fixed multi selected items were not able to drag
- Toolbar styles were not right
- Added support to custom toolbar
- Added support to drag while in edit mode
- Added api for `add()`, `delete()`, `edit()`, `moveDown()`, `moveUp()` (tests should pass)
- More tests and coverage
- Update docs and other cleanup

**Related github/jira issue (required)**:
Closes #926

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-data-grid/double-click.html
- See the toolbar styles should be consistent with other toolbars like `IdsEditor`
- Add another row using `+` button
- Type something to update newly added item's text
- Press `Enter` key to go out of edit mode
- Drag the new row to the first row
- Should move fine

Should drag while in edit mode
- Add new item, or select any item
- Click `Edit` button to go in edit mode
- Drag this edited item to some other item
- Should move fine

Should drag multi selected items
- Navigate to: http://localhost:4300/ids-list-builder/selection-multiple.html
- Click on multiple items to make them selected
- Drag selected items to some other item
- Should move fine

Should able to custom toolbar
- Navigate to: http://localhost:4300/ids-list-builder/custom-toolbar.html
- See should have only three buttons in toolbar (edit, move-up, and move-down)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
