### PR TITLE
1200 - IdsPopup Unset text align

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Button]` Renamed "type" attribute to "appearance", mapped a new "type" attribute that sets HTMLButtonElement's "type" attribute. ([#1062](https://github.com/infor-design/enterprise-wc/issues/1062))
 - `[Docs]` Added some documentation on ways to customize a component. ([#970](https://github.com/infor-design/enterprise-wc/issues/970))
+- `[Popup]` Unset text align coming from HTML attribute. ([#1200](https://github.com/infor-design/enterprise-wc/issues/1200))
 
 ## 1.0.0-beta.8
 

--- a/src/components/ids-popup/ids-popup.scss
+++ b/src/components/ids-popup/ids-popup.scss
@@ -4,6 +4,7 @@
 :host {
   display: block;
   z-index: 3000;
+  text-align: unset;
 }
 
 :host([position-style='absolute']) {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
There is a native HTML attribute `align` what specifies the alignment of data in the element which we also use to specify the alignment of the `ids-popup` component.  We either change the attribute or unset the `text-align`. This PR unsets the text alignment

**Related github/jira issue (required)**:
Closes #1200 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-action-panel/example.html
- open action panel and check dropdowns options
- see the text is left aligned

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
