### PR TITLE
1175 - Fix text overflow for editable cells with data grid

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.9 Fixes
 
 - `[Button]` Renamed "type" attribute to "appearance", mapped a new "type" attribute that sets HTMLButtonElement's "type" attribute. ([#1062](https://github.com/infor-design/enterprise-wc/issues/1062))
+- `[DataGrid]` Fixed text overflow for editable cells with data grid. ([#1175](https://github.com/infor-design/enterprise-wc/issues/1175))
 - `[Docs]` Added some documentation on ways to customize a component. ([#970](https://github.com/infor-design/enterprise-wc/issues/970))
 - `[Popup]` Unset text align coming from HTML attribute. ([#1200](https://github.com/infor-design/enterprise-wc/issues/1200))
 

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -38,15 +38,12 @@ $cell-border-color: var(--ids-color-palette-slate-30);
     @include m-16();
   }
 
-  // Text ellipsis
   .text-ellipsis {
-    @include inline-flex();
+    @include align-middle();
     @include px-16();
 
-    flex-flow: row nowrap;
-    align-content: center;
-    align-items: center;
-    height: inherit;
+    display: inline-block;
+    height: auto;
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed text overflow for editable cells with data grid

**Related github/jira issue (required)**:
Closes #1175

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-data-grid/editable-inline.html
- Click on any cell in column `Description` to go in edit mode
- Enter some value longer than the column width (`The quick brown fox jumps over the lazy dog`)
- Press `Enter` key to go out edit mode
- See the cell text, should have ellipsis (should not text overflow)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
