### PR TITLE
1157 - IdsInput/IdsTriggerField - fix box model

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[DataGrid]` Fixed text overflow for editable cells with data grid. ([#1175](https://github.com/infor-design/enterprise-wc/issues/1175))
 - `[Docs]` Added some documentation on ways to customize a component. ([#970](https://github.com/infor-design/enterprise-wc/issues/970))
 - `[Popup]` Unset text align coming from HTML attribute. ([#1200](https://github.com/infor-design/enterprise-wc/issues/1200))
+- `[Input/TriggerField]` Web component now displays as `inline`, similar to HTMLInputElement. ([#1157](https://github.com/infor-design/enterprise-wc/issues/1157))
 
 ## 1.0.0-beta.8
 

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -805,6 +805,7 @@ export default class IdsDataGridFilters {
         dateOrTimePopup.setAttribute(attributes.TARGET, `#${triggerField.getAttribute('id')}`);
         dateOrTimePopup.setAttribute(attributes.TRIGGER_ELEM, `#${triggerBtn.getAttribute('id')}`);
         dateOrTimePopup.popup.setAttribute(attributes.ARROW_TARGET, `#${triggerBtn.getAttribute('id')}`);
+        dateOrTimePopup.popup.y = 16;
         dateOrTimePopup.setAttribute(attributes.ATTACHMENT, menuAttachment);
         dateOrTimePopup.refreshTriggerEvents();
       }

--- a/src/components/ids-date-picker/ids-date-picker-popup.ts
+++ b/src/components/ids-date-picker/ids-date-picker-popup.ts
@@ -112,7 +112,7 @@ class IdsDatePickerPopup extends Base implements IdsRangeSettingsInterface {
    * @returns {string} The template
    */
   template(): string {
-    return `<ids-popup class="ids-date-picker-popup" type="menu" align="bottom, left" arrow="bottom" tabIndex="-1" y="12" animated>
+    return `<ids-popup class="ids-date-picker-popup" type="menu" align="bottom, left" arrow="bottom" tabIndex="-1" y="0" animated>
       <slot slot="content" name="toolbar">
         ${this.toolbarTemplate()}
       </slot>

--- a/src/components/ids-date-picker/ids-date-picker-popup.ts
+++ b/src/components/ids-date-picker/ids-date-picker-popup.ts
@@ -112,7 +112,7 @@ class IdsDatePickerPopup extends Base implements IdsRangeSettingsInterface {
    * @returns {string} The template
    */
   template(): string {
-    return `<ids-popup class="ids-date-picker-popup" type="menu" align="bottom, left" arrow="bottom" tabIndex="-1" y="0" animated>
+    return `<ids-popup class="ids-date-picker-popup" type="menu" align="bottom, left" arrow="bottom" tabIndex="-1" animated>
       <slot slot="content" name="toolbar">
         ${this.toolbarTemplate()}
       </slot>

--- a/src/components/ids-date-picker/ids-date-picker.scss
+++ b/src/components/ids-date-picker/ids-date-picker.scss
@@ -1,13 +1,41 @@
 @import '../../core/ids-base';
 
+:host {
+  display: block;
+}
+
 :host([size='full']) {
   @include w-full();
+
+  ::part(container) {
+    display: block;
+  }
 }
 
 .ids-date-picker {
+  display: inline-block;
+  max-width: 100%;
+
   // Fixes input doesn't stretch to lg size and up
-  ids-input {
+  ids-trigger-field,
+  .ids-trigger-field {
+    display: inline-block;
     max-width: 100%;
+  }
+
+  ids-trigger-field {
+    &[size='full'] {
+      display: block;
+    }
+  }
+
+  &.full {
+    display: block;
+
+    ids-trigger-field,
+    .ids-trigger-field {
+      display: block;
+    }
   }
 
   // Is calendar toolbar

--- a/src/components/ids-date-picker/ids-date-picker.ts
+++ b/src/components/ids-date-picker/ids-date-picker.ts
@@ -14,7 +14,7 @@ import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsValidationInputMixin from '../../mixins/ids-validation-mixin/ids-validation-input-mixin';
 import IdsElement from '../../core/ids-element';
 
-import type { IdsPopupXYSwitchResult } from '../ids-popup/ids-popup-attributes';
+import { onPickerPopupXYSwitch } from '../ids-picker-popup/ids-picker-popup-common';
 
 import {
   buildClassAttrib,
@@ -342,12 +342,7 @@ class IdsDatePicker extends Base {
 
         // Detect switch of X/Y values due to alignment settings,
         // and account for extra width needed to be displayed outside of IdsDatePicker fields
-        this.#picker.popup.onXYSwitch = (results: IdsPopupXYSwitchResult) => {
-          if (results.shouldSwitchXY) {
-            if (['bottom', 'top'].includes(results.targetEdge)) results.x = 12;
-          }
-          return results;
-        };
+        this.#picker.popup.onXYSwitch = onPickerPopupXYSwitch;
       }
 
       this.#picker.refreshTriggerEvents();

--- a/src/components/ids-date-picker/ids-date-picker.ts
+++ b/src/components/ids-date-picker/ids-date-picker.ts
@@ -876,9 +876,11 @@ class IdsDatePicker extends Base {
     if (val) {
       this.setAttribute(attributes.SIZE, val);
       this.#triggerField?.setAttribute(attributes.SIZE, val);
+      if (val === 'full') this.container?.classList.add('full');
     } else {
       this.removeAttribute(attributes.SIZE);
       this.#triggerField?.setAttribute(attributes.SIZE, 'sm');
+      this.container?.classList.remove('full');
     }
   }
 

--- a/src/components/ids-dropdown/ids-dropdown-attributes-mixin.ts
+++ b/src/components/ids-dropdown/ids-dropdown-attributes-mixin.ts
@@ -102,8 +102,13 @@ const IdsDropdownAttributeMixin = <T extends Constraints>(superclass: T) => clas
    * @param {string} value The value
    */
   set size(value: string) {
-    if (value) this.setAttribute(attributes.SIZE, value);
-    else this.removeAttribute(attributes.SIZE);
+    if (value) {
+      this.setAttribute(attributes.SIZE, value);
+      if (value === 'full') this.container?.classList.add('full');
+    } else {
+      this.removeAttribute(attributes.SIZE);
+      this.container?.classList.remove('full');
+    }
 
     if (typeof this.onSizeChange === 'function') this.onSizeChange(value);
   }

--- a/src/components/ids-dropdown/ids-dropdown.scss
+++ b/src/components/ids-dropdown/ids-dropdown.scss
@@ -4,12 +4,32 @@
 
 :host {
   display: block;
+
+  .ids-dropdown {
+    display: inline-block;
+    max-width: 100%;
+  }
 }
 
 // Most Styles are in list-box, popup and trigger field
 .ids-dropdown {
-  display: inline-block;
+  display: block;
   position: relative;
+
+  ids-trigger-field {
+    &[size='full'] {
+      display: block;
+    }
+  }
+
+  &.full {
+    display: block;
+
+    ids-trigger-field,
+    .ids-trigger-field {
+      display: block;
+    }
+  }
 }
 
 // Icon Placement

--- a/src/components/ids-dropdown/ids-dropdown.scss
+++ b/src/components/ids-dropdown/ids-dropdown.scss
@@ -168,11 +168,3 @@
 :host([list]:not([disabled])) {
   cursor: pointer;
 }
-
-// Override trigger field display type
-/*
-ids-trigger-field,
-.ids-dropdown .ids-trigger-field {
-  display: inline-block;
-}
-*/

--- a/src/components/ids-dropdown/ids-dropdown.scss
+++ b/src/components/ids-dropdown/ids-dropdown.scss
@@ -2,8 +2,13 @@
 @import '../../mixins/sass/ids-validation-mixin';
 @import '../../core/ids-base';
 
+:host {
+  display: block;
+}
+
 // Most Styles are in list-box, popup and trigger field
 .ids-dropdown {
+  display: inline-block;
   position: relative;
 }
 
@@ -143,3 +148,11 @@
 :host([list]:not([disabled])) {
   cursor: pointer;
 }
+
+// Override trigger field display type
+/*
+ids-trigger-field,
+.ids-dropdown .ids-trigger-field {
+  display: inline-block;
+}
+*/

--- a/src/components/ids-input/demos/standalone-css.html
+++ b/src/components/ids-input/demos/standalone-css.html
@@ -11,52 +11,52 @@
     </div>
   </div>
 
-  <div class="ids-layout-grid">
+  <div class="ids-layout-grid ids-layout-grid-cols-1">
     <div class="ids-layout-grid-cell">
 
-      <div class="ids-input field-height-md">
+      <div class="ids-input field-height-md md">
         <label for="input-first-name" class="ids-label-text">First Name</label>
         <div class="field-container">
           <input class="ids-input-field" id="input-first-name" name="input-first-name" placeholder="Normal text Field"/>
         </div>
       </div>
 
-      <div class="ids-input disabled field-height-md">
+      <div class="ids-input disabled field-height-md md">
         <label for="input-disabled" class="ids-label-text">Disabled</label>
         <div class="field-container">
           <input class="ids-input-field" disabled id="input-disabled" name="input-disabled" value="Field not editable"/>
         </div>
       </div>
 
-      <div class="ids-input readonly field-height-md">
+      <div class="ids-input readonly field-height-md md">
         <label for="input-readonly" class="ids-label-text">Readonly</label>
         <div class="field-container">
           <input class="ids-input-field" readonly id="input-readonly" name="input-readonly" value="02006"/>
         </div>
       </div>
 
-      <div class="ids-input field-height-md">
+      <div class="ids-input field-height-md md">
         <label for="input-default-align" class="ids-label-text">Default align (left)</label>
         <div class="field-container">
           <input class="ids-input-field" id="input-default-align" name="input-default-align" value="Default align"/>
         </div>
       </div>
 
-      <div class="ids-input field-height-md">
+      <div class="ids-input field-height-md md">
         <label for="input-left-align" class="ids-label-text">Left align</label>
         <div class="field-container">
           <input class="ids-input-field left" id="input-left-align" name="input-left-align" value="Left align"/>
         </div>
       </div>
 
-      <div class="ids-input field-height-md">
+      <div class="ids-input field-height-md md">
         <label for="input-center-align" class="ids-label-text">Center align</label>
         <div class="field-container">
           <input class="ids-input-field center" id="input-center-align" name="input-center-align" value="Center align"/>
         </div>
       </div>
 
-      <div class="ids-input field-height-md">
+      <div class="ids-input field-height-md md">
         <label for="input-right-align" class="ids-label-text">Right align</label>
         <div class="field-container">
           <input class="ids-input-field right" id="input-right-align" name="input-right-align" value="Right align"/>
@@ -73,7 +73,7 @@
   <div class="ids-layout-grid">
     <div class="ids-layout-grid-cell">
 
-      <div class="ids-input compact">
+      <div class="ids-input compact md">
         <label for="input-compact" class="ids-label-text">Compact</label>
         <div class="field-container compact">
           <input class="ids-input-field" id="input-compact" name="input-compact"/>
@@ -91,28 +91,28 @@
   <div class="ids-layout-grid">
     <div class="ids-layout-grid-cell">
 
-      <div class="ids-input field-height-xs">
+      <div class="ids-input field-height-xs md">
         <label for="input-height-extra-small" class="ids-label-text">Extra Small</label>
         <div class="field-container">
           <input class="ids-input-field" id="input-height-extra-small" name="input-height-extra-small"/>
         </div>
       </div>
 
-      <div class="ids-input field-height-sm">
+      <div class="ids-input field-height-sm md">
         <label for="input-height-small" class="ids-label-text">Small</label>
         <div class="field-container">
           <input class="ids-input-field" id="input-height-small" name="input-height-small"/>
         </div>
       </div>
 
-      <div class="ids-input field-height-md">
+      <div class="ids-input field-height-md md">
         <label for="input-height-medium" class="ids-label-text">Medium (default)</label>
         <div class="field-container">
           <input class="ids-input-field" id="input-height-medium" name="input-height-medium"/>
         </div>
       </div>
 
-      <div class="ids-input field-height-lg">
+      <div class="ids-input field-height-lg md">
         <label for="input-height-large" class="ids-label-text">Large</label>
         <div class="field-container">
           <input class="ids-input-field" id="input-height-large" name="input-height-large"/>

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -101,10 +101,10 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   @include antialiased();
   @include font-sans();
   @include text-slate-60();
+  @include block();
   @include mb-8();
 
   align-items: baseline;
-  display: block;
 
   // Ability to center label from parent element
   justify-content: inherit;
@@ -120,7 +120,6 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
     &::after {
       @include relative();
       @include font-sans();
-      @include mx-2();
       @include text-20();
       @include text-alert-error();
 
@@ -136,6 +135,11 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
     &.empty::after {
       content: '';
     }
+  }
+
+  ids-text::part(text),
+  .ids-text {
+    display: inline;
   }
 }
 

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -5,7 +5,7 @@
 @import '../../mixins/sass/ids-validation-mixin';
 
 // Set default
-$input-size-default: $input-size-md;
+$input-size-default: 100%;
 $input-field-height-default: $input-field-height-md;
 $input-compact-height: $input-field-height-xs + 2;
 
@@ -178,6 +178,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   @include mb-16();
 
   display: inline-block;
+  max-width: 100%;
 
   // Applied to the wrapper element that wraps the input and other interactable elements
   .field-container {
@@ -195,7 +196,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
     display: flex;
     resize: none;
     text-align: left;
-    // max-width: $input-size-default;
+    max-width: $input-size-default;
   }
 
   &:focus-within,

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -171,7 +171,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
 
 :host {
   display: block;
-  max-width: 100%;
+  max-width: calc($input-size-default - 2px);
 
   .ids-input {
     display: inline-block;

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -104,7 +104,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   @include mb-8();
 
   align-items: baseline;
-  display: inline-flex;
+  display: block;
 
   // Ability to center label from parent element
   justify-content: inherit;
@@ -178,7 +178,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   @include mb-16();
 
   display: inline-block;
-  max-width: 100%;
+  max-width: $input-size-default;
 
   // Applied to the wrapper element that wraps the input and other interactable elements
   .field-container {

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -104,7 +104,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   @include mb-8();
 
   align-items: baseline;
-  display: flex;
+  display: inline-flex;
 
   // Ability to center label from parent element
   justify-content: inherit;

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -171,6 +171,11 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
 
 :host {
   display: block;
+  max-width: 100%;
+
+  .ids-input {
+    display: inline-block;
+  }
 }
 
 :host([size='full']) {
@@ -181,7 +186,7 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   @include relative();
   @include mb-16();
 
-  display: inline-block;
+  display: block;
   max-width: $input-size-default;
 
   // Applied to the wrapper element that wraps the input and other interactable elements

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -165,14 +165,19 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   }
 }
 
+:host {
+  display: block;
+}
+
 :host([size='full']) {
   @include w-full();
 }
 
 .ids-input {
   @include relative();
-  @include block();
   @include mb-16();
+
+  display: inline-block;
 
   // Applied to the wrapper element that wraps the input and other interactable elements
   .field-container {
@@ -187,10 +192,10 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
     border-collapse: separate;
     border-radius: 2px;
     color: inherit;
+    display: flex;
     resize: none;
     text-align: left;
-    display: flex;
-    max-width: $input-size-default;
+    // max-width: $input-size-default;
   }
 
   &:focus-within,
@@ -291,27 +296,31 @@ $border-input-field-height-lg: $input-field-height-lg - 2;
   // input sizes: [xs, sm, mm, md, lg, full]
   // Subtracting 2 takes into account that the width includes the `.field-container` border on both sides.
   &.xs .field-container {
-    max-width: $border-input-size-xs;
+    width: $border-input-size-xs;
   }
 
   &.sm .field-container {
-    max-width: $border-input-size-sm;
+    width: $border-input-size-sm;
   }
 
   &.mm .field-container {
-    max-width: $border-input-size-mm;
+    width: $border-input-size-mm;
   }
 
   &.md .field-container {
-    max-width: $border-input-size-md;
+    width: $border-input-size-md;
   }
 
   &.lg .field-container {
-    max-width: $border-input-size-lg;
+    width: $border-input-size-lg;
   }
 
-  &.full .field-container {
-    max-width: $input-size-full;
+  &.full {
+    display: block;
+
+    .field-container {
+      width: $input-size-full;
+    }
   }
 
   // input field-heights: [xs, sm, md, lg]

--- a/src/components/ids-pager/ids-pager-input.scss
+++ b/src/components/ids-pager/ids-pager-input.scss
@@ -34,3 +34,9 @@ ids-input::part(field-container) {
 ids-text {
   @include mx-4();
 }
+
+// Remove automatic width on "xs"-sized pager inputs
+ids-input[size='xs']::part(field-container),
+.ids-input.xs .field-container {
+  width: auto;
+}

--- a/src/components/ids-picker-popup/ids-picker-popup-common.ts
+++ b/src/components/ids-picker-popup/ids-picker-popup-common.ts
@@ -1,0 +1,20 @@
+import type { IdsPopupXYSwitchResult } from '../ids-popup/ids-popup-attributes';
+
+const X_FIELD_ADJUSTMENT = 12;
+const TOP_FIELD_ADJUSTMENT = -8;
+
+/**
+ * Runs on the Picker Popup's `onXYSwitch` callback, and makes minor
+ * corrections to IdsPopup placement to account for IdsInput/IdsTriggerField labels,
+ * which aren't symmetrical for placement purposes.
+ * @param {IdsPopupXYSwitchResult} results contains settings related to the x/y adjustment.
+ * @returns {IdsPopupXYSwitchResult} provides further modifications.
+ */
+export const onPickerPopupXYSwitch = (results: IdsPopupXYSwitchResult) => {
+  if (results.shouldSwitchXY) {
+    if (['bottom', 'top'].includes(results.targetEdge)) results.x = X_FIELD_ADJUSTMENT;
+  } else if (results.flip) {
+    results.y = TOP_FIELD_ADJUSTMENT;
+  }
+  return results;
+};

--- a/src/components/ids-popup/README.md
+++ b/src/components/ids-popup/README.md
@@ -213,8 +213,9 @@ The `popupRect` argument provides access to the editable [`DOMRect`](https://dev
 When using `alignTarget` and offsets, occasionally it may be necessary for a 'top' or 'bottom'-aligned IdsPopup to switch axes and become aligned 'right' or 'left', for the purposes of remaining inside a container area.  After this occurs, an `onXYSwitch` callback is fired with an object containing several parameters.  You can modify this object and return it to provide additional changes to the placement algorithm:
 
 - `x/y`: number values that will be used for offsets
+- `flip`: boolean true if a flip occurs at all
+- `shouldSwitchXY`: boolean true if the flip that occured also swiched the x/y axes
 - `targetEdge`: the original target edge
-- `shouldSwitchXY`: boolean true if the flip that occured also swiched the x/y axes.
 - `oppositeEdge`: the edge that will be used in the case of a normal, same-axis flip
 
 For example, this occurs when [`IdsDatePicker`]('../ids-date-picker/README.md')'s popup flips to align on the X axis, which requires more space away from its target.

--- a/src/components/ids-popup/README.md
+++ b/src/components/ids-popup/README.md
@@ -208,6 +208,17 @@ popup.onPlace = (popupRect) => {
 
 The `popupRect` argument provides access to the editable [`DOMRect`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect) object that the IdsPopup uses to place itself.  The callback returns the DOMRect with modified values.
 
+#### onXYSwitch callback
+
+When using `alignTarget` and offsets, occasionally it may be necessary for a 'top' or 'bottom'-aligned IdsPopup to switch axes and become aligned 'right' or 'left', for the purposes of remaining inside a container area.  After this occurs, an `onXYSwitch` callback is fired with an object containing several parameters.  You can modify this object and return it to provide additional changes to the placement algorithm:
+
+- `x/y`: number values that will be used for offsets
+- `targetEdge`: the original target edge
+- `shouldSwitchXY`: boolean true if the flip that occured also swiched the x/y axes.
+- `oppositeEdge`: the edge that will be used in the case of a normal, same-axis flip
+
+For example, this occurs when [`IdsDatePicker`]('../ids-date-picker/README.md')'s popup flips to align on the X axis, which requires more space away from its target.
+
 ## Usage Tips
 
 - When making a Popup that is placed in reference to an adjacent element, it must be placed AFTER it in the DOM. Placing it BEFORE the adjacent element can cause its placement to be incorrect on its first render.

--- a/src/components/ids-popup/ids-popup-attributes.ts
+++ b/src/components/ids-popup/ids-popup-attributes.ts
@@ -55,6 +55,17 @@ const POPUP_PROPERTIES = [
 ];
 
 /**
+ * Defines XY Switch results
+ */
+export type IdsPopupXYSwitchResult = {
+  oppositeEdge: string,
+  shouldSwitchXY: boolean,
+  targetEdge: string,
+  x: number,
+  y: number
+};
+
+/**
  * Formats the text value of the `align` attribute.
  * @private
  * @param {string} alignX matches a value from the ALIGNMENTS_X array

--- a/src/components/ids-popup/ids-popup-attributes.ts
+++ b/src/components/ids-popup/ids-popup-attributes.ts
@@ -58,6 +58,7 @@ const POPUP_PROPERTIES = [
  * Defines XY Switch results
  */
 export type IdsPopupXYSwitchResult = {
+  flip: boolean,
   oppositeEdge: string,
   shouldSwitchXY: boolean,
   targetEdge: string,

--- a/src/components/ids-popup/ids-popup.ts
+++ b/src/components/ids-popup/ids-popup.ts
@@ -1211,6 +1211,7 @@ export default class IdsPopup extends Base {
     const shouldSwitchXY = this.alignEdge !== this.#targetAlignEdge
       && this.#getOppositeEdge(this.alignEdge) !== this.#targetAlignEdge;
     let switchResult = {
+      flip: this.alignEdge !== this.#targetAlignEdge && !shouldSwitchXY,
       oppositeEdge,
       shouldSwitchXY,
       targetEdge: this.#alignEdge,

--- a/src/components/ids-popup/ids-popup.ts
+++ b/src/components/ids-popup/ids-popup.ts
@@ -15,7 +15,7 @@ import IdsThemeMixin from '../../mixins/ids-theme-mixin/ids-theme-mixin';
 import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsElement from '../../core/ids-element';
 
-import type { IdsPopupElementRef } from './ids-popup-attributes';
+import type { IdsPopupElementRef, IdsPopupXYSwitchResult } from './ids-popup-attributes';
 
 import {
   CENTER,
@@ -1207,11 +1207,23 @@ export default class IdsPopup extends Base {
 
     this.#targetAlignEdge = this.#getPlacementEdge(popupRect);
 
+    const oppositeEdge = this.#getOppositeEdge(this.alignEdge);
     const shouldSwitchXY = this.alignEdge !== this.#targetAlignEdge
       && this.#getOppositeEdge(this.alignEdge) !== this.#targetAlignEdge;
+    let switchResult = {
+      oppositeEdge,
+      shouldSwitchXY,
+      targetEdge: this.#alignEdge,
+      x: shouldSwitchXY ? this.y : this.x,
+      y: shouldSwitchXY ? this.x : this.y
+    };
 
-    let x = shouldSwitchXY ? this.y : this.x;
-    let y = shouldSwitchXY ? this.x : this.y;
+    if (typeof this.onXYSwitch === 'function') {
+      switchResult = this.onXYSwitch(switchResult);
+    }
+
+    let x = switchResult.x;
+    let y = switchResult.y;
 
     const targetRect = this.alignTarget.getBoundingClientRect();
     const alignEdge = this.#targetAlignEdge || this.alignEdge;
@@ -1329,6 +1341,17 @@ export default class IdsPopup extends Base {
    */
   onPlace(popupRect: DOMRect): DOMRect {
     return popupRect;
+  }
+
+  /**
+   * Optional callback that can be used to further adjust the Popup's x/y offsets
+   * if a flip or other modification is made to the alignment edge
+   * when being placed in alignment mode.
+   * @param {IdsPopupXYSwitchResult} result contains settings related to the x/y adjustment.
+   * @returns {IdsPopupXYSwitchResult} provides further modifications.
+   */
+  onXYSwitch(result: IdsPopupXYSwitchResult) {
+    return result;
   }
 
   /**

--- a/src/components/ids-time-picker/demos/picker-only.ts
+++ b/src/components/ids-time-picker/demos/picker-only.ts
@@ -61,8 +61,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (picker.popup) {
       picker.popup.align = 'bottom, left';
       picker.popup.arrow = 'bottom';
+      /*
       picker.popup.x = 0;
       picker.popup.y = 12;
+      */
     }
 
     // Fix onOutsideClick to consider clicking on trigger buttons

--- a/src/components/ids-time-picker/demos/picker-only.ts
+++ b/src/components/ids-time-picker/demos/picker-only.ts
@@ -61,10 +61,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (picker.popup) {
       picker.popup.align = 'bottom, left';
       picker.popup.arrow = 'bottom';
-      /*
-      picker.popup.x = 0;
-      picker.popup.y = 12;
-      */
     }
 
     // Fix onOutsideClick to consider clicking on trigger buttons

--- a/src/components/ids-time-picker/ids-time-picker-popup.ts
+++ b/src/components/ids-time-picker/ids-time-picker-popup.ts
@@ -77,7 +77,7 @@ class IdsTimePickerPopup extends Base {
       return `<div class="ids-time-picker-popup embedded" part="container">${dropdownHTML}</div>`;
     }
 
-    return `<ids-popup class="ids-time-picker-popup" type="menu" tabIndex="-1" align="bottom, left" arrow="bottom" part="popup" y="12" animated>
+    return `<ids-popup class="ids-time-picker-popup" type="menu" tabIndex="-1" align="bottom, left" arrow="bottom" part="popup" animated>
       <section slot="content">
         ${dropdownHTML}
         <ids-modal-button class="popup-btn" hidden="${this.autoupdate}" part="btn-set" appearance="primary">

--- a/src/components/ids-time-picker/ids-time-picker.scss
+++ b/src/components/ids-time-picker/ids-time-picker.scss
@@ -1,7 +1,13 @@
 @import '../../core/ids-base';
 @import '../../mixins/sass/ids-hide-mixin';
 
+:host {
+  display: block;
+}
+
 .ids-time-picker {
+  display: inline-block;
+
   .popup-btn {
     @include w-full();
 
@@ -90,6 +96,11 @@
     .separator {
       display: none;
     }
+  }
+
+  // "Full" size timepickers are display: block
+  &.full {
+    display: block;
   }
 
   // Time Picker Editor Borderless

--- a/src/components/ids-time-picker/ids-time-picker.scss
+++ b/src/components/ids-time-picker/ids-time-picker.scss
@@ -7,6 +7,29 @@
 
 .ids-time-picker {
   display: inline-block;
+  max-width: 100%;
+
+  // Fixes input doesn't stretch to lg size and up
+  ids-trigger-field,
+  .ids-trigger-field {
+    display: inline-block;
+    max-width: 100%;
+  }
+
+  ids-trigger-field {
+    &[size='full'] {
+      display: block;
+    }
+  }
+
+  &.full {
+    display: block;
+
+    ids-trigger-field,
+    .ids-trigger-field {
+      display: block;
+    }
+  }
 
   .popup-btn {
     @include w-full();
@@ -96,11 +119,6 @@
     .separator {
       display: none;
     }
-  }
-
-  // "Full" size timepickers are display: block
-  &.full {
-    display: block;
   }
 
   // Time Picker Editor Borderless

--- a/src/components/ids-time-picker/ids-time-picker.ts
+++ b/src/components/ids-time-picker/ids-time-picker.ts
@@ -592,7 +592,7 @@ export default class IdsTimePicker extends Base {
       if (this.picker.popup) {
         this.picker.popup.align = `bottom, ${this.localeAPI.isRTL() || ['md', 'lg', 'full'].includes(this.size) ? 'right' : 'left'}`;
         this.picker.popup.arrow = 'bottom';
-        this.picker.popup.y = 16;
+        // this.picker.popup.y = 16;
       }
     }
 

--- a/src/components/ids-time-picker/ids-time-picker.ts
+++ b/src/components/ids-time-picker/ids-time-picker.ts
@@ -14,6 +14,7 @@ import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsValidationInputMixin from '../../mixins/ids-validation-mixin/ids-validation-input-mixin';
 import IdsElement from '../../core/ids-element';
 
+import { onPickerPopupXYSwitch } from '../ids-picker-popup/ids-picker-popup-common';
 import { IdsTimePickerCommonAttributes, IdsTimePickerMixinAttributes, range } from './ids-time-picker-common';
 
 import '../ids-dropdown/ids-dropdown';
@@ -241,6 +242,7 @@ export default class IdsTimePicker extends Base {
         if (picker.popup) {
           picker.popup.x = 0;
           picker.popup.setAttribute(attributes.ARROW_TARGET, `#${btnId}`);
+          picker.popup.onXYSwitch = onPickerPopupXYSwitch;
         }
 
         picker.onOutsideClick = (e: any) => {

--- a/src/components/ids-time-picker/ids-time-picker.ts
+++ b/src/components/ids-time-picker/ids-time-picker.ts
@@ -834,10 +834,11 @@ export default class IdsTimePicker extends Base {
   set size(value: string) {
     if (value) {
       this.setAttribute(attributes.SIZE, value);
+      this.container?.classList.add(value);
     } else {
       this.removeAttribute(attributes.SIZE);
+      this.container?.classList.remove(value);
     }
-
     this.input?.setAttribute(attributes.SIZE, this.size);
   }
 

--- a/src/components/ids-time-picker/ids-time-picker.ts
+++ b/src/components/ids-time-picker/ids-time-picker.ts
@@ -592,7 +592,6 @@ export default class IdsTimePicker extends Base {
       if (this.picker.popup) {
         this.picker.popup.align = `bottom, ${this.localeAPI.isRTL() || ['md', 'lg', 'full'].includes(this.size) ? 'right' : 'left'}`;
         this.picker.popup.arrow = 'bottom';
-        // this.picker.popup.y = 16;
       }
     }
 

--- a/test/ids-toolbar/ids-toolbar-percy-test.ts
+++ b/test/ids-toolbar/ids-toolbar-percy-test.ts
@@ -36,6 +36,7 @@ describe('Ids Toolbar Percy Tests', () => {
     await page.waitForSelector('ids-toolbar-more-actions');
     await page.click('ids-toolbar-more-actions');
     await page.waitForFunction(`document.querySelector('ids-toolbar-more-actions').hasAttribute('visible')`);
+    await page.waitForTimeout(200);
     await percySnapshot(page, 'ids-toolbar-overflow');
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes some changes to the box model of input/trigger fields for a few reasons:
- Some inner elements of these web components were displaying "too wide"
- Extra width was causing hit area issues (it was possible to click outside these fields and activate them unexpectedly)
- Extra width was also causing attached elements like popups to display in the wrong place on "long enough" input fields

Some changes made include:
- Normalization of host elements, or "outer" elements (css-only) to be `display: block;`
- Changing internal elements (shadow root or nested components) to be `display: inline-block;` in some cases
- Added `max-width` to control size on some elements
- In some cases, needed to support the "full" size attribute with a CSS class on some field types (arguably need to move this behavior to a mixin and DRY it up, but out of scope for this)
- Normalized some internal IdsPopup x/y offsets being automatically set by some components (arguably need an API for doing this at the IdsPopupMenu/IdsPickerPopup level)

The end result of all this should be more accurate field layout, and more accurate popup placement.

**Related github/jira issue (required)**:
Closes #1157

**Steps necessary to review your pull request (required)**:
_Test popup placement on wide input fields:_
- Open http://localhost:4300/ids-date-picker/sizes.html and http://localhost:4300/ids-time-picker/sizes.html
- Stretch the browser window to be wide
- Open the "Large" example on each page.  The Popup should appear aligned against the field (arrow shouldn't be separated)
- Open the "Full" example, and the same should be true
- Shrink the browser viewport to make sure all field sizes that are too big for the column width collapse and fit nicely into the column.

_Test hit area adjustments:_

- Open http://localhost:4300/ids-input/test-sizes.html
- Click the "empty space" at the top-right of where the label should be on any of the IdsInput fields.  Focus should move to the corresponding input field
- Click the "empty space" outside of the "red box" in the screenshot below.  This should NOT focus the field.

<img src="https://user-images.githubusercontent.com/3249601/229858235-fc4c596e-67c6-405a-8688-b925677888b6.jpg" width="450">

Also try this on other component "size" pages and label-state examples:
- http://localhost:4300/ids-dropdown/sizes.html
- http://localhost:4300/ids-date-picker/sizes.html
- http://localhost:4300/ids-time-picker/sizes.html
- http://localhost:4300/ids-lookup/sizes.html

_General smoke test:_
Pick your favorite IdsInput examples, or choose the ones below.  This change hit a lot of low-level code so its possible some changes cascaded that I haven't yet addressed.  So far, I've looked at the examples below and haven't seen anything drastically different (its possible padding/margins/borders adjusted slightly):
- http://localhost:4300/ids-input/example.html
- http://localhost:4300/ids-input/label-state.html
- http://localhost:4300/ids-input/test-sizes.html
- http://localhost:4300/ids-input/standalone-css.html
- http://localhost:4300/ids-trigger-field/example.html
- http://localhost:4300/ids-data-grid/filter-trigger-fields.html
- http://localhost:4300/ids-dropdown/sizes.html
- http://localhost:4300/ids-date-picker/picker-only.html
- http://localhost:4300/ids-time-picker/picker-only.html

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
