### PR TITLE
1222 - IdsPopupMenu Fix the popup menu doesn't move to the clicked location

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Input/TriggerField]` Web component now displays as `inline`, similar to HTMLInputElement. ([#1157](https://github.com/infor-design/enterprise-wc/issues/1157))
 - `[Popup]` Unset text align coming from HTML attribute. ([#1200](https://github.com/infor-design/enterprise-wc/issues/1200))
 - `[PopupMenu]` Added scrollable behavior to `max-height`-enabled popup menus. ([#1205](https://github.com/infor-design/enterprise-wc/issues/1205))
+- `[PopupMenu]` Fixed IdsPopupMenu doesn't move to the clicked location on right click. ([#1222](https://github.com/infor-design/enterprise-wc/issues/1222))
 
 ## 1.0.0-beta.8
 

--- a/src/components/ids-popup-menu/ids-popup-menu.ts
+++ b/src/components/ids-popup-menu/ids-popup-menu.ts
@@ -260,7 +260,9 @@ export default class IdsPopupMenu extends Base {
    * @returns {void}
    */
   show(): void {
-    if (this.popup?.visible) return;
+    if (this.popup?.visible) {
+      this.hide();
+    }
 
     // Trigger a veto-able `beforeshow` event.
     if (!this.triggerVetoableEvent('beforeshow')) {

--- a/src/components/ids-popup-menu/ids-popup-menu.ts
+++ b/src/components/ids-popup-menu/ids-popup-menu.ts
@@ -260,9 +260,7 @@ export default class IdsPopupMenu extends Base {
    * @returns {void}
    */
   show(): void {
-    if (this.popup?.visible) {
-      this.hide();
-    }
+    if (this.popup?.visible) return;
 
     // Trigger a veto-able `beforeshow` event.
     if (!this.triggerVetoableEvent('beforeshow')) {
@@ -438,6 +436,7 @@ export default class IdsPopupMenu extends Base {
   onContextMenu(e: MouseEvent): void {
     e.preventDefault();
     e.stopPropagation();
+    this.hide();
     this.popup?.setPosition(e.pageX, e.pageY);
     this.showIfAble();
     this.setInitialFocus();


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR closes (hides) the popup menu before it opens (shows) so it reposition itself on every right click event

**Related github/jira issue (required)**:
Closes #1222

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-popup-menu/example.html
- right-click the page to activate the context menu
- right-click again in an empty place on the page while the menu is opened
- see the popup menu opens in the new location

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
