### PR TITLE
1236 - IdsDropdown Close the popup if selecting with the keyboard

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[ColorPicker]` Fix change event firing multiple times. ([#1181](https://github.com/infor-design/enterprise-wc/issues/1181))
 - `[DataGrid]` Fixed text overflow for editable cells with data grid. ([#1175](https://github.com/infor-design/enterprise-wc/issues/1175))
 - `[Docs]` Added some documentation on ways to customize a component. ([#970](https://github.com/infor-design/enterprise-wc/issues/970))
+- `[Dropdown]` Fixed unable to close the popup if selecting with the keyboard. ([#1236](https://github.com/infor-design/enterprise-wc/issues/1236))
 - `[Input/TriggerField]` Web component now displays as `inline`, similar to HTMLInputElement. ([#1157](https://github.com/infor-design/enterprise-wc/issues/1157))
 - `[Popup]` Unset text align coming from HTML attribute. ([#1200](https://github.com/infor-design/enterprise-wc/issues/1200))
 - `[PopupMenu]` Added scrollable behavior to `max-height`-enabled popup menus. ([#1205](https://github.com/infor-design/enterprise-wc/issues/1205))

--- a/src/components/ids-dropdown/ids-dropdown-list.ts
+++ b/src/components/ids-dropdown/ids-dropdown-list.ts
@@ -152,6 +152,7 @@ export default class IdsDropdownList extends Base {
     if (!this.isMultiSelect) {
       // Select or Open on space/enter
       this.listen([' ', 'Enter'], this, (e: KeyboardEvent) => {
+        e.stopPropagation();
         // Excluding space key when typing
         if (e.key === ' ' && this.typeahead) return;
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR stops propagation of the dropdownList's keyboard event what fixes the issue with closing the popup on selection

**Related github/jira issue (required)**:
Closes #1236 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-dropdown/example.html
- focus on the fist dropdown
- hit enter to open
- down arrow a few times and hit enter
- see the popup closes

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
