### PR TITLE
1199 - Added row-start attribute to datagrid to indicate first row to load

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 1.0.0-beta.9 Fixes
 
+- `[DataGrid]` Added rowStart prop to data grid. ([#1199](https://github.com/infor-design/enterprise-wc/issues/1199))
 - `[Button]` Renamed "type" attribute to "appearance", mapped a new "type" attribute that sets HTMLButtonElement's "type" attribute. ([#1062](https://github.com/infor-design/enterprise-wc/issues/1062))
 - `[ColorPicker]` Fix change event firing multiple times. ([#1181](https://github.com/infor-design/enterprise-wc/issues/1181))
 - `[DataGrid]` Fixed text overflow for editable cells with data grid. ([#1175](https://github.com/infor-design/enterprise-wc/issues/1175))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### 1.0.0-beta.10 Fixes
 
+- `[DataGrid]` Added rowStart prop to data grid. ([#1199](https://github.com/infor-design/enterprise-wc/issues/1199))
 - `[DateUtils]` Fix `weekNumber()` returning 0 value for all weeks. ([#1243](https://github.com/infor-design/enterprise-wc/issues/1243))
 
 ## 1.0.0-beta.9
 
 ### 1.0.0-beta.9 Fixes
 
-- `[DataGrid]` Added rowStart prop to data grid. ([#1199](https://github.com/infor-design/enterprise-wc/issues/1199))
 - `[Button]` Renamed "type" attribute to "appearance", mapped a new "type" attribute that sets HTMLButtonElement's "type" attribute. ([#1062](https://github.com/infor-design/enterprise-wc/issues/1062))
 - `[ColorPicker]` Fix change event firing multiple times. ([#1181](https://github.com/infor-design/enterprise-wc/issues/1181))
 - `[DataGrid]` Fixed text overflow for editable cells with data grid. ([#1175](https://github.com/infor-design/enterprise-wc/issues/1175))

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -176,6 +176,12 @@
   - link: virtual-scroll-infinite-scroll-m3.html
     type: Example
     description: Shows infinite-scrolling on a data grid with virtual scrolling
+  - link: virtual-scroll-row-start.html
+    type: Example
+    description: Shows a virtual-scroll enabled data grid with row-start attribute
+  - link: row-start.html
+    type: Example
+    description: Shows a data grid with row-start attribute
   - link: tooltip.html
     type: Example
     description: Shows a data grid with tooltip

--- a/src/components/ids-data-grid/demos/row-start.html
+++ b/src/components/ids-data-grid/demos/row-start.html
@@ -8,7 +8,7 @@
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
     <ids-layout-grid auto-fit="true" padding="md">
-      <ids-text font-size="12" type="h1">Data Grid (Virtual Scrolling)</ids-text>
+      <ids-text font-size="12" type="h1">Data Grid (row-start)</ids-text>
     </ids-layout-grid>
     <ids-layout-grid auto-fit="true" padding-x="md">
       <ids-layout-grid-cell>

--- a/src/components/ids-data-grid/demos/row-start.html
+++ b/src/components/ids-data-grid/demos/row-start.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid (Virtual Scrolling)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-data-grid id="data-grid-row-start" row-selection="multiple" auto-fit="bottom" row-height="md" row-start="777">
+        </ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/row-start.ts
+++ b/src/components/ids-data-grid/demos/row-start.ts
@@ -1,0 +1,101 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+import productsJSON from '../../../assets/data/products.json';
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-row-start')!;
+
+// Do an ajax request
+const url: any = productsJSON;
+const columns: IdsDataGridColumn[] = [];
+
+// Set up columns
+columns.push({
+  id: 'selectionCheckbox',
+  name: 'selection',
+  sortable: false,
+  resizable: false,
+  formatter: dataGrid.formatters.selectionCheckbox,
+  align: 'center'
+});
+columns.push({
+  id: 'rowNumber',
+  name: '#',
+  formatter: dataGrid.formatters.rowNumber,
+  sortable: false,
+  readonly: true,
+  width: 66
+});
+columns.push({
+  id: 'id',
+  name: 'ID',
+  field: 'id',
+  formatter: dataGrid.formatters.text,
+  width: 80,
+  sortable: true
+});
+columns.push({
+  id: 'color',
+  name: 'Color',
+  field: 'color',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'inStock',
+  name: 'In Stock',
+  field: 'inStock',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'productId',
+  name: 'Product Id',
+  field: 'productId',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'productName',
+  name: 'Product Name',
+  field: 'productName',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'unitPrice',
+  name: 'Unit Price',
+  field: 'unitPrice',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'units',
+  name: 'Units',
+  field: 'units',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+
+dataGrid.columns = columns;
+
+const setData = async () => {
+  const res = await fetch(url);
+  const data = await res.json();
+  dataGrid.data = data;
+};
+
+setData();
+
+dataGrid.addEventListener('selectionchanged', (e: Event) => {
+  console.info(`Selection Changed`, (<CustomEvent>e).detail);
+});
+
+dataGrid.addEventListener('scrollstart', async (e: Event) => {
+  console.info(`Virtual Scroll reached start`, (<CustomEvent>e).detail);
+});
+
+dataGrid.addEventListener('scrollend', async (e: Event) => {
+  console.info(`Virtual Scroll reached end`, (<CustomEvent>e).detail);
+});

--- a/src/components/ids-data-grid/demos/virtual-scroll-row-start.html
+++ b/src/components/ids-data-grid/demos/virtual-scroll-row-start.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid (Virtual Scrolling)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-data-grid id="data-grid-virtual-scroll-row-start" row-selection="multiple" auto-fit="bottom" virtual-scroll="true" row-height="md" row-start="777">
+        </ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/virtual-scroll-row-start.html
+++ b/src/components/ids-data-grid/demos/virtual-scroll-row-start.html
@@ -8,7 +8,7 @@
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
     <ids-layout-grid auto-fit="true" padding="md">
-      <ids-text font-size="12" type="h1">Data Grid (Virtual Scrolling)</ids-text>
+      <ids-text font-size="12" type="h1">Data Grid (Virtual Scroll row-start)</ids-text>
     </ids-layout-grid>
     <ids-layout-grid auto-fit="true" padding-x="md">
       <ids-layout-grid-cell>

--- a/src/components/ids-data-grid/demos/virtual-scroll-row-start.ts
+++ b/src/components/ids-data-grid/demos/virtual-scroll-row-start.ts
@@ -1,0 +1,101 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+import productsJSON from '../../../assets/data/products.json';
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-virtual-scroll-row-start')!;
+
+// Do an ajax request
+const url: any = productsJSON;
+const columns: IdsDataGridColumn[] = [];
+
+// Set up columns
+columns.push({
+  id: 'selectionCheckbox',
+  name: 'selection',
+  sortable: false,
+  resizable: false,
+  formatter: dataGrid.formatters.selectionCheckbox,
+  align: 'center'
+});
+columns.push({
+  id: 'rowNumber',
+  name: '#',
+  formatter: dataGrid.formatters.rowNumber,
+  sortable: false,
+  readonly: true,
+  width: 66
+});
+columns.push({
+  id: 'id',
+  name: 'ID',
+  field: 'id',
+  formatter: dataGrid.formatters.text,
+  width: 80,
+  sortable: true
+});
+columns.push({
+  id: 'color',
+  name: 'Color',
+  field: 'color',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'inStock',
+  name: 'In Stock',
+  field: 'inStock',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'productId',
+  name: 'Product Id',
+  field: 'productId',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'productName',
+  name: 'Product Name',
+  field: 'productName',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'unitPrice',
+  name: 'Unit Price',
+  field: 'unitPrice',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+columns.push({
+  id: 'units',
+  name: 'Units',
+  field: 'units',
+  formatter: dataGrid.formatters.text,
+  sortable: true
+});
+
+dataGrid.columns = columns;
+
+const setData = async () => {
+  const res = await fetch(url);
+  const data = await res.json();
+  dataGrid.data = data;
+};
+
+setData();
+
+dataGrid.addEventListener('selectionchanged', (e: Event) => {
+  console.info(`Selection Changed`, (<CustomEvent>e).detail);
+});
+
+dataGrid.addEventListener('scrollstart', async (e: Event) => {
+  console.info(`Virtual Scroll reached start`, (<CustomEvent>e).detail);
+});
+
+dataGrid.addEventListener('scrollend', async (e: Event) => {
+  console.info(`Virtual Scroll reached end`, (<CustomEvent>e).detail);
+});

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1381,7 +1381,7 @@ export default class IdsDataGrid extends Base {
     rowIndex = Math.min(rowIndex, maxRowIndex);
 
     if (!this.virtualScroll) {
-      this.rowByIndex(rowIndex)?.scrollIntoView();
+      this.rowByIndex(rowIndex)?.scrollIntoView?.();
       return;
     }
 
@@ -1404,7 +1404,7 @@ export default class IdsDataGrid extends Base {
 
     if (isInRange && doScroll) {
       this.offEvent('scroll.data-grid.virtual-scroll', this.container);
-      this.rowByIndex(rowIndex)?.scrollIntoView();
+      this.rowByIndex(rowIndex)?.scrollIntoView?.();
       this.#attachVirtualScrollEvent();
       return;
     }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -2,6 +2,7 @@
 import { customElement, scss } from '../../core/ids-decorators';
 import { attributes, IdsDirection } from '../../core/ids-attributes';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
+import { requestAnimationTimeout } from '../../utils/ids-timer-utils/ids-timer-utils';
 import { next, previous } from '../../utils/ids-dom-utils/ids-dom-utils';
 import { exportToCSV, exportToXLSX } from '../../utils/ids-excel-exporter/ids-excel-exporter';
 
@@ -316,7 +317,7 @@ export default class IdsDataGrid extends Base {
   afterRedraw() {
     const rowStart = this.rowStart || 0;
 
-    setTimeout(() => {
+    requestAnimationTimeout(() => {
       this.scrollRowIntoView(rowStart);
       requestAnimationFrame(() => {
         // Set Focus

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -324,7 +324,9 @@ export default class IdsDataGrid extends Base {
       });
     } else {
       requestAnimationTimeout(() => {
-        this.scrollRowIntoView(rowStart);
+        if (this.container) {
+          this.container.scrollTop = rowStart * this.virtualScrollSettings.ROW_HEIGHT;
+        }
       }, 100);
     }
   }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -184,6 +184,7 @@ export default class IdsDataGrid extends Base {
       attributes.ROW_HEIGHT,
       attributes.ROW_NAVIGATION,
       attributes.ROW_SELECTION,
+      attributes.ROW_START,
       attributes.SUPPRESS_CACHING,
       attributes.SUPPRESS_EMPTY_MESSAGE,
       attributes.SUPPRESS_ROW_CLICK_SELECTION,
@@ -313,12 +314,15 @@ export default class IdsDataGrid extends Base {
 
   /** Do some things after redraw */
   afterRedraw() {
-    requestAnimationFrame(() => {
+    const rowStart = this.rowStart || 0;
+
+    setTimeout(() => {
+      this.scrollRowIntoView(rowStart);
       requestAnimationFrame(() => {
         // Set Focus
-        this.setActiveCell(0, 0, true);
+        this.setActiveCell(0, rowStart || 0, true);
       });
-    });
+    }, 100);
   }
 
   /**
@@ -374,6 +378,30 @@ export default class IdsDataGrid extends Base {
     for (let index = 0; index < data.length; index++) {
       innerHTML += IdsDataGridRow.template(data[index], index, index + 1, this);
     }
+    return innerHTML;
+  }
+
+  /**
+   * Body inner template markup
+   * @private
+   * @returns {string} The template
+   */
+  bodyInnerTemplate2() {
+    this.resetCache();
+
+    const MAX_ROWS = this.virtualScrollSettings.MAX_ROWS;
+    const rowStart = this.rowStart;
+    // const rowEnd = Math.min(rowStart + MAX_ROWS, this.data.length);
+    const data = this.virtualScroll ? this.data.slice(rowStart).slice(0, MAX_ROWS) : this.data;
+    console.log('bodyInnertTemplate', data);
+
+    let innerHTML = '';
+    for (let index = 0; index < data.length; index++) {
+    // for (let index = rowStart; index < rowEnd; index++) {
+      const currentIndex = rowStart + index;
+      innerHTML += IdsDataGridRow.template(data[index], currentIndex, currentIndex + 1, this);
+    }
+    console.log('innerHTML', innerHTML);
     return innerHTML;
   }
 
@@ -1568,6 +1596,20 @@ export default class IdsDataGrid extends Base {
   }
 
   get rowHeight() { return this.getAttribute(attributes.ROW_HEIGHT) || 'lg'; }
+
+  /**
+   * Set the row index. If set, the datagrid's data set will initially load here.
+   * @param {number} rowIndex The row-index at which to start showing data.
+   */
+  set rowStart(rowIndex: number) {
+    this.setAttribute(attributes.ROW_START, String(rowIndex || 0));
+  }
+
+  /**
+   * Get the start-row index
+   * @returns {number} The start-row index
+   */
+  get rowStart(): number { return Number(this.getAttribute(attributes.ROW_START)) || 0; }
 
   /**
    * Sets keyboard navigation to rows

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -382,30 +382,6 @@ export default class IdsDataGrid extends Base {
   }
 
   /**
-   * Body inner template markup
-   * @private
-   * @returns {string} The template
-   */
-  bodyInnerTemplate2() {
-    this.resetCache();
-
-    const MAX_ROWS = this.virtualScrollSettings.MAX_ROWS;
-    const rowStart = this.rowStart;
-    // const rowEnd = Math.min(rowStart + MAX_ROWS, this.data.length);
-    const data = this.virtualScroll ? this.data.slice(rowStart).slice(0, MAX_ROWS) : this.data;
-    console.log('bodyInnertTemplate', data);
-
-    let innerHTML = '';
-    for (let index = 0; index < data.length; index++) {
-    // for (let index = rowStart; index < rowEnd; index++) {
-      const currentIndex = rowStart + index;
-      innerHTML += IdsDataGridRow.template(data[index], currentIndex, currentIndex + 1, this);
-    }
-    console.log('innerHTML', innerHTML);
-    return innerHTML;
-  }
-
-  /**
    * Check if row is selected.
    * @param {number} index The row index
    * @returns {boolean} True, if row is selected

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -325,11 +325,15 @@ export default class IdsDataGrid extends Base {
     } else {
       requestAnimationTimeout(() => {
         if (this.container) {
-          const containerTopPosition = this.container.getBoundingClientRect().top;
-          const headerHeight = this.header?.getBoundingClientRect?.().height ?? 0;
           let scrollTopPixels = rowStart * this.virtualScrollSettings.ROW_HEIGHT;
-          scrollTopPixels = this.rowByIndex(rowStart)?.getBoundingClientRect?.()?.y ?? scrollTopPixels;
-          this.container.scrollTop = scrollTopPixels - containerTopPosition - headerHeight;
+          if (!this.virtualScrollSettings.ENABLED) {
+            const containerTopPosition = this.container.getBoundingClientRect().top;
+            const headerHeight = this.header?.getBoundingClientRect?.().height ?? 0;
+            scrollTopPixels = this.rowByIndex(rowStart)?.getBoundingClientRect?.()?.y ?? scrollTopPixels;
+            scrollTopPixels = scrollTopPixels - containerTopPosition - headerHeight;
+          }
+
+          this.container.scrollTop = scrollTopPixels;
         }
       }, 150);
     }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1398,13 +1398,14 @@ export default class IdsDataGrid extends Base {
     bufferRowIndex = Math.max(bufferRowIndex, 0);
     bufferRowIndex = Math.min(bufferRowIndex, maxRowIndex);
 
+    if (isInRange && doScroll) {
+      this.offEvent('scroll.data-grid.virtual-scroll', this.container);
+      this.rowByIndex(rowIndex)?.scrollIntoView();
+      this.#attachVirtualScrollEvent();
+      return;
+    }
+
     if (isInRange) {
-      if (doScroll) {
-        this.offEvent('scroll.data-grid.virtual-scroll', this.container);
-        this.rowByIndex(rowIndex)?.scrollIntoView();
-        this.#attachVirtualScrollEvent();
-        return;
-      }
       // if rowIndex is in range of the currently visible rows:
       // then we should only move rows up or down according to how big the buffer should be.
       const moveRowsDown = bufferRowIndex - firstRowIndex;

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -328,12 +328,12 @@ export default class IdsDataGrid extends Base {
           let scrollTopPixels = rowStart * this.virtualScrollSettings.ROW_HEIGHT;
           if (!this.virtualScrollSettings.ENABLED) {
             const containerTopPosition = this.container.getBoundingClientRect().top;
-            const headerHeight = this.header?.getBoundingClientRect?.().height ?? 0;
             scrollTopPixels = this.rowByIndex(rowStart)?.getBoundingClientRect?.()?.y ?? scrollTopPixels;
-            scrollTopPixels = scrollTopPixels - containerTopPosition - headerHeight;
+            scrollTopPixels -= containerTopPosition;
           }
 
-          this.container.scrollTop = scrollTopPixels;
+          const headerHeight = this.header?.getBoundingClientRect?.().height ?? 0;
+          this.container.scrollTop = scrollTopPixels - headerHeight;
         }
       }, 150);
     }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -317,13 +317,16 @@ export default class IdsDataGrid extends Base {
   afterRedraw() {
     const rowStart = this.rowStart || 0;
 
-    requestAnimationTimeout(() => {
-      this.scrollRowIntoView(rowStart);
+    if (!rowStart) {
       requestAnimationFrame(() => {
         // Set Focus
-        this.setActiveCell(0, rowStart || 0, true);
+        this.setActiveCell(0, 0, true);
       });
-    }, 100);
+    } else {
+      requestAnimationTimeout(() => {
+        this.scrollRowIntoView(rowStart);
+      }, 100);
+    }
   }
 
   /**

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -325,9 +325,13 @@ export default class IdsDataGrid extends Base {
     } else {
       requestAnimationTimeout(() => {
         if (this.container) {
-          this.container.scrollTop = rowStart * this.virtualScrollSettings.ROW_HEIGHT;
+          const containerTopPosition = this.container.getBoundingClientRect().top;
+          const headerHeight = this.header?.getBoundingClientRect?.().height ?? 0;
+          let scrollTopPixels = rowStart * this.virtualScrollSettings.ROW_HEIGHT;
+          scrollTopPixels = this.rowByIndex(rowStart)?.getBoundingClientRect?.()?.y ?? scrollTopPixels;
+          this.container.scrollTop = scrollTopPixels - containerTopPosition - headerHeight;
         }
-      }, 100);
+      }, 150);
     }
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.

Our application needs to display a lot of rows and in some cases we need to show the starting from index 150 for example. Using ScrollRowIntoView(), it is visible that the data is loaded starting from index 0 and then scrolled to index 150. We do not need to show index 0 and the scrolling rows. We just need to display the rows that includes index 150.
-->
This PR adds `IdsDataGrid.rowStart` prop to the datagrid which controls the `row-start` attribute. If the `row-start` attribute is set, then the datagrid's result set will begin at the row specified by the `row-start` value:

`<ids-data-grid row-start="777"></ids-data-grid>`

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Fixes #1199 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. Check out branch run: `npm run start`
2. Open http://localhost:4300/ids-data-grid/row-start.html
3. The first record shown on the datagrid should be row # 777.
4. Open http://localhost:4300/ids-data-grid/virtual-scroll-row-start.html
5. The first record shown on the datagrid should be row # 777.
6. Ensure tests pass by running: `npm run test:ci`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
