### PR TITLE
1243 - DatePicker week number fix

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[ColorPicker]` Fix change event firing multiple times. ([#1181](https://github.com/infor-design/enterprise-wc/issues/1181))
 - `[DataGrid]` Fixed text overflow for editable cells with data grid. ([#1175](https://github.com/infor-design/enterprise-wc/issues/1175))
 - `[DataGrid]` Fix `IdsDataGrid.ScrollRowIntoView()` so that it finds correct row after infinite-scrolling. ([#1198](https://github.com/infor-design/enterprise-wc/issues/1198))
+- `[DateUtils]` Fix `weekNumber()` returning 0 value for all weeks. ([#1243](https://github.com/infor-design/enterprise-wc/issues/1243))
 - `[Docs]` Added some documentation on ways to customize a component. ([#970](https://github.com/infor-design/enterprise-wc/issues/970))
 - `[Dropdown]` Fixed unable to close the popup if selecting with the keyboard. ([#1236](https://github.com/infor-design/enterprise-wc/issues/1236))
 - `[Input/TriggerField]` Web component now displays as `inline`, similar to HTMLInputElement. ([#1157](https://github.com/infor-design/enterprise-wc/issues/1157))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.10
+
+### 1.0.0-beta.10 Fixes
+
+- `[DateUtils]` Fix `weekNumber()` returning 0 value for all weeks. ([#1243](https://github.com/infor-design/enterprise-wc/issues/1243))
+
 ## 1.0.0-beta.9
 
 ### 1.0.0-beta.9 Fixes
@@ -8,7 +14,6 @@
 - `[ColorPicker]` Fix change event firing multiple times. ([#1181](https://github.com/infor-design/enterprise-wc/issues/1181))
 - `[DataGrid]` Fixed text overflow for editable cells with data grid. ([#1175](https://github.com/infor-design/enterprise-wc/issues/1175))
 - `[DataGrid]` Fix `IdsDataGrid.ScrollRowIntoView()` so that it finds correct row after infinite-scrolling. ([#1198](https://github.com/infor-design/enterprise-wc/issues/1198))
-- `[DateUtils]` Fix `weekNumber()` returning 0 value for all weeks. ([#1243](https://github.com/infor-design/enterprise-wc/issues/1243))
 - `[Docs]` Added some documentation on ways to customize a component. ([#970](https://github.com/infor-design/enterprise-wc/issues/970))
 - `[Dropdown]` Fixed unable to close the popup if selecting with the keyboard. ([#1236](https://github.com/infor-design/enterprise-wc/issues/1236))
 - `[Input/TriggerField]` Web component now displays as `inline`, similar to HTMLInputElement. ([#1157](https://github.com/infor-design/enterprise-wc/issues/1157))

--- a/src/utils/ids-date-utils/ids-date-utils.ts
+++ b/src/utils/ids-date-utils/ids-date-utils.ts
@@ -336,20 +336,21 @@ export function weekNumberToDate(year: number, week: number, startsOn = 0): Date
  */
 export function weekNumber(date: Date, startsOn = 0) {
   // Set range end
-  const weekDayIndex: number = (date.getDay() + 7 - startsOn) % 7;
+  const rangeEndDate = new Date(date.getTime());
+  const weekDayIndex: number = (rangeEndDate.getDay() + 7 - startsOn) % 7;
 
-  date.setDate(date.getDate() - weekDayIndex + 3);
+  rangeEndDate.setDate(rangeEndDate.getDate() - weekDayIndex + 3);
 
-  const rangeEnd: number = date.getTime();
+  const rangeEnd: number = rangeEndDate.getTime();
 
   // Set range start
-  date.setMonth(0, 1);
+  const rangeStartDate = new Date(date.getFullYear(), 0, 1);
 
-  if (date.getDay() !== 4) {
-    date.setMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
+  if (rangeStartDate.getDay() !== 4) {
+    rangeStartDate.setMonth(0, 1 + ((4 - rangeStartDate.getDay() + 7) % 7));
   }
 
-  const rangeStart: number = date.getTime();
+  const rangeStart: number = rangeStartDate.getTime();
   const msInWeek = 604800000;
 
   // Number of weeks in range


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes the 0 values for week numbers in month year picklist dropdowns.

**Related github/jira issue (required)**:
Closes #1243 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, `npm install`, `npm run start`
2. Go to http://localhost:4300/ids-date-picker/sandbox.html
3. In the `With Week Numbers` example, open month year picklist dropdown
4. Check that the week selector is properly numbered.
5. Try selecting a week number value and check that datepicker navigates to the right month

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
