### PR TITLE
1242/1276 Allow dragging and dropping to work and fix drag errors

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### 1.0.0-beta.10 Fixes
 
-- `[DateUtils]` Fix `weekNumber()` returning 0 value for all weeks. ([#1243](https://github.com/infor-design/enterprise-wc/issues/1243))
+- `[DataGrid]` Fixed an error where dragging something onto the data grid header filter inputs would give an error. ([#1276](https://github.com/infor-design/enterprise-wc/issues/1276))
+- `[DataGrid]` Fixed an error where dragging something onto the data grid header filter would show the arrows as if a column was dragged and allow dropping text and arrow keys to work. ([#1242](https://github.com/infor-design/enterprise-wc/issues/1242))
+- `[DateUtils]` Fixed a `weekNumber()` bug that returned 0 value for all weeks. ([#1243](https://github.com/infor-design/enterprise-wc/issues/1243))
 - `[Themes]` Added theme support and css variables for all components. These can be used for customizing components and creating themes. See ([CUSTOMIZING.md](../doc/CUSTOMIZING.md)) for details. Note that with the `<ids-theme-switcher>` its now better to use the full theme name `<ids-theme-switcher theme="default-light">`. ([#1118](https://github.com/infor-design/enterprise-wc/issues/1118))
 
 ## 1.0.0-beta.9

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -4,6 +4,7 @@ import { attributes, IdsDirection } from '../../core/ids-attributes';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 import { next, previous } from '../../utils/ids-dom-utils/ids-dom-utils';
 import { exportToCSV, exportToXLSX } from '../../utils/ids-excel-exporter/ids-excel-exporter';
+import { eventPath, findInPath } from '../../utils/ids-event-path-utils/ids-event-path-utils';
 
 // Dependencies
 import IdsDataSource from '../../core/ids-data-source';
@@ -538,6 +539,7 @@ export default class IdsDataGrid extends Base {
    * @param {number} toIndex The new column index
    */
   moveColumn(fromIndex: number, toIndex: number) {
+    if (fromIndex === -1 || toIndex === -1) return;
     const correctFromIndex = this.columnIdxById(this.visibleColumns[fromIndex].id);
     const correctToIndex = this.columnIdxById(this.visibleColumns[toIndex].id);
 
@@ -582,8 +584,10 @@ export default class IdsDataGrid extends Base {
   #attachKeyboardListeners() {
     // Handle arrow navigation
     this.listen(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'], this, (e: KeyboardEvent) => {
-      if (!this.activeCell?.node) return;
+      const inFilter = findInPath(eventPath(e), '.ids-data-grid-header-cell-filter-wrapper');
       const key = e.key;
+      if (inFilter && (key === 'ArrowRight' || key === 'ArrowLeft')) return;
+      if (!this.activeCell?.node) return;
       const cellNode = this.activeCell.node;
       const cellNumber = Number(this.activeCell?.cell);
       const rowDiff = key === 'ArrowDown' ? 1 : (key === 'ArrowUp' ? -1 : 0); //eslint-disable-line

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -630,7 +630,7 @@ $input-size-full: 100%;
       color: var(--ids-data-grid-filter-input-text-color);
     }
 
-    &:hover .field-container {
+    &.ids-input:hover:not(.readonly):not(.disabled):not(.color-variant-borderless):hover .field-container {
       border-color: var(--ids-data-grid-filter-input-hover-color);
     }
 

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -466,6 +466,7 @@
   --ids-data-grid-filter-input-readonly-border-color: var(--ids-color-neutral-30);
   --ids-data-grid-filter-input-readonly-text-color: var(--ids-color-neutral-00);
   --ids-data-grid-filter-input-placeholder-text-color: var(--ids-color-neutral-40);
+  --ids-data-grid-filter-input-drop-background-color: var(--ids-body-background-color);
 
   // Data Grid (Rows)
   --ids-data-grid-xxs-row-height: 25px;

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -1299,6 +1299,7 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.wrapper.querySelector('.ids-data-grid-sort-arrows').style.display).toBe('none');
 
       const drop = new MouseEvent('drop', { bubbles: true });
+      dataGrid.dragInitiated = true;
       nodes[1].dispatchEvent(drop);
 
       // Overall success
@@ -1336,6 +1337,7 @@ describe('IdsDataGrid Component', () => {
       // Fake a Drag
       const dragstart = new MouseEvent('dragstart', { bubbles: true });
       nodes[2].dispatchEvent(dragstart);
+      dataGrid.dragInitiated = true;
 
       // simulate dragging
       const dragenter = new MouseEvent('dragenter', { bubbles: true });
@@ -1346,13 +1348,14 @@ describe('IdsDataGrid Component', () => {
       const dragend = new MouseEvent('dragend', { bubbles: true });
       nodes[0].dispatchEvent(dragend);
 
+      dataGrid.dragInitiated = true;
       const drop = new MouseEvent('drop', { bubbles: true });
       nodes[0].dispatchEvent(drop);
 
       // Overall success
-      expect(cols[0].id).toBe('other');
-      expect(cols[1].id).toBe('price');
-      expect(cols[2].id).toBe('bookCurrency');
+      expect(cols[0].id).toBe('price');
+      expect(cols[1].id).toBe('bookCurrency');
+      expect(cols[2].id).toBe('other');
     });
 
     it('supports dragging when right to left', async () => {
@@ -1403,9 +1406,9 @@ describe('IdsDataGrid Component', () => {
       nodes[0].dispatchEvent(drop);
 
       // Overall success
-      expect(cols[0].id).toBe('other');
-      expect(cols[1].id).toBe('price');
-      expect(cols[2].id).toBe('bookCurrency');
+      expect(cols[0].id).toBe('price');
+      expect(cols[1].id).toBe('bookCurrency');
+      expect(cols[2].id).toBe('other');
     });
 
     it('supports stopping reorder on non-reorderable', async () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Fixes bugs related to dragging items (text) onto the filter row. In addition fixes left and right arrow key and hover state on the filter row. And allow text to be dropped.

**Related github/jira issue (required)**:
Fixes #1276 
Fixes #1242 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-data-grid/disable-client-filter.html
- hover the filter row inputs and they should not disappear
- enter text in the field and move around with left and right arrow
- select the text ''DATA"' or any text on the label NOTE: this is done easiest by double clicking a word then click again and hold the left mouse down and start to drag it (took me a while to figure this out)
- drag it over the grid filter row -> should not error or show arrows as if you where dragging columns
- try dropping text on the filter input it should work (note that this example has filtering disabled so nothing more happens)
- also note: dragging text on an input always worked http://localhost:4300/ids-input/example.html by that method i just didnt realize how to do it before
- try column resize and drag to reorder and make sure it still works

**Included in this Pull Request**:
- [x] A note to the change log.
