### PR TITLE
1228 - Fix column click callback trigger with data grid

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.10 Fixes
 
 - `[DataGrid]` Added rowStart setting to data grid. ([#1199](https://github.com/infor-design/enterprise-wc/issues/1199))
+- `[DataGrid]` Fixed pressing enter on a column header filter input field was executing the column-s click callback for hyperlinks. ([#1228](https://github.com/infor-design/enterprise-wc/issues/1228))
 - `[DataGrid]` Fixed an error where dragging something onto the data grid header filter inputs would give an error. ([#1276](https://github.com/infor-design/enterprise-wc/issues/1276))
 - `[DataGrid]` Fixed an error where dragging something onto the data grid header filter would show the arrows as if a column was dragged and allow dropping text and arrow keys to work. ([#1242](https://github.com/infor-design/enterprise-wc/issues/1242))
 - `[DateUtils]` Fixed a `weekNumber()` bug that returned 0 value for all weeks. ([#1243](https://github.com/infor-design/enterprise-wc/issues/1243))

--- a/src/components/ids-data-grid/demos/columns-click-callback.html
+++ b/src/components/ids-data-grid/demos/columns-click-callback.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid (Columns Click Callback)</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-data-grid
+          id="data-grid-columns-click-callback"
+          label="Books"
+          pagination="client-side"
+          page-number="1"
+          page-size="10"
+          filter-when-typing="false"
+          disable-client-filter="true"
+        >
+        </ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/columns-click-callback.ts
+++ b/src/components/ids-data-grid/demos/columns-click-callback.ts
@@ -1,0 +1,95 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+import '../../ids-container/ids-container';
+import '../../ids-toast/ids-toast';
+import productsJSON from '../../../assets/data/products.json';
+
+const idsContainer = document.querySelector('ids-container');
+
+const showToast = (title = 'Toast Title', message = 'This is a Toast message.') => {
+  const toastId = 'test-demo-toast';
+  let toast: any = document.querySelector(`#${toastId}`);
+  if (!toast) {
+    toast = document.createElement('ids-toast');
+    toast.setAttribute('id', toastId);
+    idsContainer?.appendChild(toast);
+  }
+  toast.show({ title, message });
+};
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-columns-click-callback')!;
+
+(async function init() {
+  const columns: IdsDataGridColumn[] = [];
+
+  // Set up columns
+  columns.push({
+    id: 'id',
+    name: 'ID',
+    field: 'id',
+    width: 180,
+    resizable: true,
+    reorderable: true,
+    sortable: true,
+    filterType: dataGrid.filters.text,
+    formatter: (rowData, columnData, index) => {
+      const text = `Z ${index}`;
+      return `<ids-hyperlink title="${text}, Related Items" tabindex="-1">${text}</ids-hyperlink>`;
+    },
+    click: (rowData, columnData, event) => {
+      console.info('Click Event >>>', rowData, columnData, event);
+      showToast('Click Event', 'Running Hyperlink!');
+    }
+  });
+  columns.push({
+    id: 'color',
+    name: 'Color',
+    field: 'color',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    formatter: dataGrid.formatters.text,
+    filterType: dataGrid.filters.text
+  });
+  columns.push({
+    id: 'productId',
+    name: 'Product Id',
+    field: 'productId',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    formatOptions: { group: '' },
+    filterType: dataGrid.filters.integer,
+    formatter: dataGrid.formatters.integer
+  });
+  columns.push({
+    id: 'inStock',
+    name: 'In Stock',
+    field: 'inStock',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    align: 'center',
+    formatter: dataGrid.formatters.text,
+    filterType: dataGrid.filters.checkbox
+  });
+
+  // Do an ajax request
+  const url: any = productsJSON;
+
+  dataGrid.columns = columns;
+  const setData = async () => {
+    const res = await fetch(url);
+    const data = await res.json();
+    dataGrid.data = data;
+    dataGrid.pageTotal = data.length;
+  };
+  setData();
+
+  // Disable client filter
+  dataGrid.addEventListener('filtered', (e: any) => {
+    console.info('filtered:', e.detail);
+  });
+}());

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -53,6 +53,9 @@
   - link: columns-stretch.html
     type: Example
     description: Showing a stretch column
+  - link: columns-click-callback.html
+    type: Example
+    description: Shows a data grid with columns click callback
   - link: combo-sort.html
     type: Example
     description: Shows combined data type sorting

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -661,7 +661,7 @@ export default class IdsDataGrid extends Base {
 
     // Follow links with keyboard and start editing
     this.listen(['Enter'], this, (e: KeyboardEvent) => {
-      if (!this.activeCell?.node || !findInPath(eventPath(e), '.ids-data-grid-body')) return;
+      if (!this.activeCell?.node || findInPath(eventPath(e), '.ids-data-grid-header-cell-filter-wrapper')) return;
 
       const cellNode = this.activeCell.node;
       const hyperlink = cellNode.querySelector('ids-hyperlink');

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -661,7 +661,8 @@ export default class IdsDataGrid extends Base {
 
     // Follow links with keyboard and start editing
     this.listen(['Enter'], this, (e: KeyboardEvent) => {
-      if (!this.activeCell?.node) return;
+      if (!this.activeCell?.node || !findInPath(eventPath(e), '.ids-data-grid-body')) return;
+
       const cellNode = this.activeCell.node;
       const hyperlink = cellNode.querySelector('ids-hyperlink');
       const button = cellNode.querySelector('ids-button');

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -600,133 +600,130 @@ export default class IdsDataGrid extends Base {
    * @returns {object} This API object for chaining
    */
   #attachKeyboardListeners() {
-    this.offEvent('keydown.body', this.body);
-    this.onEvent('keydown.body', this.body, (e: KeyboardEvent): boolean | void => {
-      // Enter Edit by typing
-      const isPrintableKey = e.key.length === 1;
-      if (!this.activeCellEditor && isPrintableKey && e.key !== ' ') {
-        this.activeCell?.node?.startCellEdit?.();
+    // Handle arrow navigation
+    this.listen(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'], this, (e: KeyboardEvent) => {
+      const inFilter = findInPath(eventPath(e), '.ids-data-grid-header-cell-filter-wrapper');
+      const key = e.key;
+      if (inFilter && (key === 'ArrowRight' || key === 'ArrowLeft')) return;
+      if (!this.activeCell?.node) return;
+      const cellNode = this.activeCell.node;
+      const cellNumber = Number(this.activeCell?.cell);
+      const rowDiff = key === 'ArrowDown' ? 1 : (key === 'ArrowUp' ? -1 : 0); //eslint-disable-line
+      const cellDiff = key === 'ArrowRight' ? 1 : (key === 'ArrowLeft' ? -1 : 0); //eslint-disable-line
+      const nextRow = Number(next(cellNode.parentElement, `:not([hidden])`)?.getAttribute('row-index'));
+      const prevRow = Number(previous(cellNode.parentElement, `:not([hidden])`)?.getAttribute('row-index'));
+      const rowIndex = key === 'ArrowDown' ? nextRow : prevRow;
+
+      const movingHorizontal = key === 'ArrowLeft' || key === 'ArrowRight';
+      const reachedHorizontalBounds = cellNumber < 0 || cellNumber >= this.visibleColumns.length;
+      if (movingHorizontal && reachedHorizontalBounds) return;
+
+      const movingVertical = key === 'ArrowDown' || key === 'ArrowUp';
+      const reachedVerticalBounds = nextRow >= this.data.length || prevRow < 0;
+      if (movingVertical && reachedVerticalBounds) return;
+
+      if (this.activeCellEditor) cellNode.endCellEdit();
+
+      const activateCellNumber = cellNumber + cellDiff;
+      const activateRowIndex = rowDiff === 0 ? Number(this.activeCell?.row) : rowIndex;
+      this.setActiveCell(activateCellNumber, activateRowIndex);
+
+      if (this.rowSelection === 'mixed' && this.rowNavigation) {
+        (cellNode.parentElement as IdsDataGridRow).toggleRowActivation();
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    });
+
+    // Handle Selection and Expand
+    this.listen([' '], this, (e: Event) => {
+      if (this.activeCellEditor) return;
+      if (!this.activeCell?.node) return;
+      const button = this.activeCell.node.querySelector('ids-button');
+      if (button) {
+        button.click();
+        e.preventDefault();
         return;
       }
 
-      // Handle arrow navigation
-      if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-        const inFilter = findInPath(eventPath(e), '.ids-data-grid-header-cell-filter-wrapper');
-        const key = e.key;
-        if (inFilter && (key === 'ArrowRight' || key === 'ArrowLeft')) return;
-        if (!this.activeCell?.node) return;
-        const cellNode = this.activeCell.node;
-        const cellNumber = Number(this.activeCell?.cell);
-        const rowDiff = key === 'ArrowDown' ? 1 : (key === 'ArrowUp' ? -1 : 0); //eslint-disable-line
-        const cellDiff = key === 'ArrowRight' ? 1 : (key === 'ArrowLeft' ? -1 : 0); //eslint-disable-line
-        const nextRow = Number(next(cellNode.parentElement, `:not([hidden])`)?.getAttribute('row-index'));
-        const prevRow = Number(previous(cellNode.parentElement, `:not([hidden])`)?.getAttribute('row-index'));
-        const rowIndex = key === 'ArrowDown' ? nextRow : prevRow;
-
-        const movingHorizontal = key === 'ArrowLeft' || key === 'ArrowRight';
-        const reachedHorizontalBounds = cellNumber < 0 || cellNumber >= this.visibleColumns.length;
-        if (movingHorizontal && reachedHorizontalBounds) return;
-
-        const movingVertical = key === 'ArrowDown' || key === 'ArrowUp';
-        const reachedVerticalBounds = nextRow >= this.data.length || prevRow < 0;
-        if (movingVertical && reachedVerticalBounds) return;
-
-        if (this.activeCellEditor) cellNode.endCellEdit();
-
-        const activateCellNumber = cellNumber + cellDiff;
-        const activateRowIndex = rowDiff === 0 ? Number(this.activeCell?.row) : rowIndex;
-        this.setActiveCell(activateCellNumber, activateRowIndex);
-
-        if (this.rowSelection === 'mixed' && this.rowNavigation) {
-          (cellNode.parentElement as IdsDataGridRow).toggleRowActivation();
-        }
+      const child = this.activeCell.node.children[0];
+      const isCheckbox = child?.classList.contains('ids-data-grid-checkbox-container')
+        && !child?.classList.contains('is-selection-checkbox');
+      if (isCheckbox) {
+        this.activeCell.node.click();
         e.preventDefault();
-        e.stopPropagation();
+        return;
+      }
+      const row = this.rowByIndex(this.activeCell.row)!;
+      row.toggleSelection();
+      e.preventDefault();
+    });
+
+    // Follow links with keyboard and start editing
+    this.listen(['Enter'], this, (e: KeyboardEvent) => {
+      if (!this.activeCell?.node || findInPath(eventPath(e), '.ids-data-grid-header-cell')) return;
+      const cellNode = this.activeCell.node;
+      const hyperlink = cellNode.querySelector('ids-hyperlink');
+      const button = cellNode.querySelector('ids-button');
+      const customLink = cellNode.querySelector('a');
+
+      if (hyperlink && !hyperlink.container.matches(':focus') && !hyperlink.hasAttribute('disabled')) {
+        hyperlink.container.click();
+        hyperlink.container.focus();
       }
 
-      // Handle Selection and Expand
-      if (e.key === ' ') {
-        if (this.activeCellEditor) return;
-        if (!this.activeCell?.node) return;
-        const button = this.activeCell.node.querySelector('ids-button');
-        if (button) {
-          button.click();
-          e.preventDefault();
-          return;
-        }
-
-        const child = this.activeCell.node.children[0];
-        const isCheckbox = child?.classList.contains('ids-data-grid-checkbox-container')
-          && !child?.classList.contains('is-selection-checkbox');
-        if (isCheckbox) {
-          this.activeCell.node.click();
-          e.preventDefault();
-          return;
-        }
-        const row = this.rowByIndex(this.activeCell.row)!;
-        row.toggleSelection();
-        e.preventDefault();
+      if (button && !button.hasAttribute('disabled')) {
+        button.click();
       }
 
-      // Follow links with keyboard and start editing
-      if (e.key === 'Enter') {
-        if (!this.activeCell?.node) return;
+      customLink?.click();
 
-        const cellNode = this.activeCell.node;
-        const hyperlink = cellNode.querySelector('ids-hyperlink');
-        const button = cellNode.querySelector('ids-button');
-        const customLink = cellNode.querySelector('a');
-
-        if (hyperlink && !hyperlink.container.matches(':focus') && !hyperlink.hasAttribute('disabled')) {
-          hyperlink.container.click();
-          hyperlink.container.focus();
-        }
-
-        if (button && !button.hasAttribute('disabled')) {
-          button.click();
-        }
-
-        customLink?.click();
-
-        if (customLink) {
-          cellNode.focus();
-        }
-        this.#handleEditMode(e, cellNode);
+      if (customLink) {
+        cellNode.focus();
       }
+      this.#handleEditMode(e, cellNode);
+    });
 
-      // Commit Edit
-      if (e.key === 'F2') {
-        const cellNode = this.activeCell.node;
-        if (this.activeCellEditor) {
-          cellNode.endCellEdit();
-          cellNode.focus();
-        }
-      }
-
-      // Cancel Edit
-      if (e.key === 'Escape') {
-        const cellNode = this.activeCell.node;
-        if (this.activeCellEditor) {
-          cellNode.cancelCellEdit();
-          cellNode.focus();
-        }
-      }
-
-      // Edit Next
-      if (e.key === 'Tab') {
-        if (this.activeCellEditor) {
-          if (e.shiftKey) this.#editAdjacentCell(IdsDirection.Previous);
-          else this.#editAdjacentCell(IdsDirection.Next);
-
-          e.stopImmediatePropagation();
-          e.stopPropagation();
-          e.preventDefault();
-          return false;
-        }
-        return true;
+    // Commit Edit
+    this.listen(['F2'], this, () => {
+      const cellNode = this.activeCell.node;
+      if (this.activeCellEditor) {
+        cellNode.endCellEdit();
+        cellNode.focus();
       }
     });
 
+    // Cancel Edit
+    this.listen(['Escape'], this, () => {
+      const cellNode = this.activeCell.node;
+      if (this.activeCellEditor) {
+        cellNode.cancelCellEdit();
+        cellNode.focus();
+      }
+    });
+
+    // Edit Next
+    this.listen(['Tab'], this, (e: KeyboardEvent) => {
+      if (this.activeCellEditor) {
+        if (e.shiftKey) this.#editAdjacentCell(IdsDirection.Previous);
+        else this.#editAdjacentCell(IdsDirection.Next);
+
+        e.stopImmediatePropagation();
+        e.stopPropagation();
+        e.preventDefault();
+        return false;
+      }
+      return true;
+    });
+
+    // Enter Edit by typing
+    this.offEvent('keydown.body', this);
+    this.onEvent('keydown.body', this, (e: KeyboardEvent) => {
+      const isPrintableKey = e.key.length === 1;
+      if (!this.activeCellEditor && isPrintableKey && e.key !== ' ') {
+        this.activeCell?.node?.startCellEdit?.();
+      }
+    });
     return this;
   }
 

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -1567,43 +1567,43 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.row).toEqual(0);
       expect(dataGrid.activeCell.cell).toEqual(0);
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(0);
       expect(dataGrid.activeCell.cell).toEqual(1);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(2);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(3);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(4);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(5);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(6);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(7);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(8);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(9);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(10);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(11);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(12);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(13);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(14);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(15);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(16);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(17);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(17);
     });
 
@@ -1612,15 +1612,15 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.cell).toEqual(0);
 
       let event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(0);
       expect(dataGrid.activeCell.cell).toEqual(1);
 
       event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(0);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(0);
     });
 
@@ -1629,24 +1629,24 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.cell).toEqual(0);
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(1);
       expect(dataGrid.activeCell.cell).toEqual(0);
 
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(2);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(3);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(4);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(5);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(6);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(7);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(8);
     });
 
@@ -1673,7 +1673,7 @@ describe('IdsDataGrid Component', () => {
       // dipatch arrow down event
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
       dataGrid.rowNavigation = true;
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       // expect second row to be focused
       const rowElem = dataGrid.rowByIndex(dataGrid.activeCell.row);
@@ -1688,7 +1688,7 @@ describe('IdsDataGrid Component', () => {
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
       dataGrid.rowNavigation = true;
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       const rowElem = dataGrid.rowByIndex(dataGrid.activeCell.row);
       expect(rowElem.getAttribute('aria-rowindex')).toEqual('2');
@@ -1714,18 +1714,18 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.row).toEqual(0);
 
       let event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(1);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(2);
 
       event = new KeyboardEvent('keydown', { key: 'ArrowUp' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(1);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(0);
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(0);
     });
 
@@ -1747,7 +1747,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.redraw();
       dataGrid.setActiveCell(0, 0, false);
       dataGrid.container.querySelector('ids-data-grid-cell').focus();
-      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(hyperlinkClickListener).toHaveBeenCalled();
 
@@ -1764,7 +1764,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.redraw();
       dataGrid.setActiveCell(0, 0, false);
       dataGrid.container.querySelector('ids-data-grid-cell').focus();
-      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(buttonClickListener).toHaveBeenCalled();
 
@@ -1783,7 +1783,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.redraw();
       dataGrid.setActiveCell(0, 0, false);
       dataGrid.container.querySelector('ids-data-grid-cell').focus();
-      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(customLinkClickListener).toHaveBeenCalled();
     });
@@ -1800,7 +1800,7 @@ describe('IdsDataGrid Component', () => {
 
       dataGrid.addEventListener('activecellchanged', mockCallback);
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       expect(mockCallback.mock.calls.length).toBe(1);
     });
@@ -2022,7 +2022,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.activeCell.node.focus();
 
       const event = new KeyboardEvent('keydown', { key: ' ' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(dataGrid.selectedRows.length).toBe(1);
     });
 
@@ -2068,7 +2068,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.rowSelection = 'mixed';
       dataGrid.setActiveCell(0, 0);
       const event2 = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-      dataGrid.body.dispatchEvent(event2);
+      dataGrid.dispatchEvent(event2);
 
       dataGrid.deSelectRow(1);
       expect(dataGrid.activatedRow.index).toBe(0);
@@ -2584,10 +2584,10 @@ describe('IdsDataGrid Component', () => {
 
       dataGrid.setActiveCell(0, 0, true);
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
 
       const event2 = new KeyboardEvent('keydown', { key: ' ' });
-      dataGrid.body.dispatchEvent(event2);
+      dataGrid.dispatchEvent(event2);
       expect(firstRow.getAttribute('aria-expanded')).toEqual('false');
     });
 
@@ -3009,13 +3009,13 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       const event2 = new KeyboardEvent('keydown', { key: ' ' }); // Ignored
-      dataGrid.body.dispatchEvent(event2);
-      dataGrid.body.dispatchEvent(event2);
+      dataGrid.dispatchEvent(event2);
+      dataGrid.dispatchEvent(event2);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
       const event3 = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-      dataGrid.body.dispatchEvent(event3);
+      dataGrid.dispatchEvent(event3);
       expect(descCell.classList.contains('is-editing')).toBeFalsy();
     });
 
@@ -3049,7 +3049,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'a' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
     });
 
@@ -3060,44 +3060,44 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
       const event2 = new KeyboardEvent('keydown', { key: 'a' });
-      dataGrid.body.dispatchEvent(event2);
+      dataGrid.dispatchEvent(event2);
 
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeFalsy();
     });
 
     it('can continue to enter edit mode with tabbing', () => {
       dataGrid.editable = true;
       const tabKey = new KeyboardEvent('keydown', { key: 'Tab' });
-      dataGrid.body.dispatchEvent(tabKey); // Does nothing
+      dataGrid.dispatchEvent(tabKey); // Does nothing
 
       const descCell = dataGrid.container.querySelector('.ids-data-grid-row:nth-child(2) > .ids-data-grid-cell:nth-child(3)');
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'a' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
       for (let index = 0; index < 300; index++) {
-        dataGrid.body.dispatchEvent(tabKey);
+        dataGrid.dispatchEvent(tabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
 
       const shiftTabKey = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
       for (let index = 0; index < 300; index++) {
-        dataGrid.body.dispatchEvent(shiftTabKey);
+        dataGrid.dispatchEvent(shiftTabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
 
       for (let index = 0; index < 300; index++) {
-        dataGrid.body.dispatchEvent(tabKey);
+        dataGrid.dispatchEvent(tabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
 
       for (let index = 0; index < 300; index++) {
-        dataGrid.body.dispatchEvent(shiftTabKey);
+        dataGrid.dispatchEvent(shiftTabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
     });
@@ -3112,12 +3112,12 @@ describe('IdsDataGrid Component', () => {
       const rowsLen = dataGrid.rows.length;
       const cell = dataGrid.setActiveCell(2, 7);
       expect(cell.node.classList.contains('is-editable')).toBeTruthy();
-      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       expect(cell.node.classList.contains('is-editing')).toBeTruthy();
 
       const tabKey = new KeyboardEvent('keydown', { key: 'Tab' });
       for (let i = 0; i < 20; i++) {
-        dataGrid.body.dispatchEvent(tabKey);
+        dataGrid.dispatchEvent(tabKey);
       }
       expect(dataGrid.rows.length).toBeGreaterThan(rowsLen);
     });
@@ -3128,7 +3128,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(11, 1);
       expect(checkCell.querySelector('[aria-checked]').getAttribute('aria-checked')).toBe('false');
       const event = new KeyboardEvent('keydown', { key: ' ' });
-      dataGrid.body.dispatchEvent(event);
+      dataGrid.dispatchEvent(event);
       const checkCell2 = dataGrid.container.querySelector('.ids-data-grid-row:nth-child(2) > .ids-data-grid-cell:nth-child(12)');
       expect(checkCell2.querySelector('ids-checkbox').getAttribute('checked')).toBe('true');
     });
@@ -3139,7 +3139,7 @@ describe('IdsDataGrid Component', () => {
       const activeCell = dataGrid.setActiveCell(col, row);
       activeCell.node.focus();
       const enterKey = new KeyboardEvent('keydown', { key: 'Enter' });
-      dataGrid.body.dispatchEvent(enterKey);
+      dataGrid.dispatchEvent(enterKey);
     };
 
     it('supports a dropdown editor', () => {
@@ -3180,7 +3180,7 @@ describe('IdsDataGrid Component', () => {
       const gridCell = activeCell.node;
 
       // activate cell editing
-      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       const datePicker = gridCell.querySelector('ids-date-picker');
       expect(datePicker).toBeDefined();
 
@@ -3206,7 +3206,7 @@ describe('IdsDataGrid Component', () => {
       const gridCell = activeCell.node;
 
       // activate cell editing
-      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       const timePicker = gridCell.querySelector('ids-time-picker');
       expect(timePicker).toBeDefined();
       expect(timePicker.value).toEqual('2:25 PM');

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -1567,43 +1567,43 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.row).toEqual(0);
       expect(dataGrid.activeCell.cell).toEqual(0);
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(0);
       expect(dataGrid.activeCell.cell).toEqual(1);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(2);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(3);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(4);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(5);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(6);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(7);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(8);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(9);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(10);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(11);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(12);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(13);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(14);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(15);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(16);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(17);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(17);
     });
 
@@ -1612,15 +1612,15 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.cell).toEqual(0);
 
       let event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(0);
       expect(dataGrid.activeCell.cell).toEqual(1);
 
       event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(0);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.cell).toEqual(0);
     });
 
@@ -1629,24 +1629,24 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.cell).toEqual(0);
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(1);
       expect(dataGrid.activeCell.cell).toEqual(0);
 
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(2);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(3);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(4);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(5);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(6);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(7);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(8);
     });
 
@@ -1673,7 +1673,7 @@ describe('IdsDataGrid Component', () => {
       // dipatch arrow down event
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
       dataGrid.rowNavigation = true;
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       // expect second row to be focused
       const rowElem = dataGrid.rowByIndex(dataGrid.activeCell.row);
@@ -1688,7 +1688,7 @@ describe('IdsDataGrid Component', () => {
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
       dataGrid.rowNavigation = true;
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       const rowElem = dataGrid.rowByIndex(dataGrid.activeCell.row);
       expect(rowElem.getAttribute('aria-rowindex')).toEqual('2');
@@ -1714,18 +1714,18 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.activeCell.row).toEqual(0);
 
       let event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       expect(dataGrid.activeCell.row).toEqual(1);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(2);
 
       event = new KeyboardEvent('keydown', { key: 'ArrowUp' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(1);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(0);
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.activeCell.row).toEqual(0);
     });
 
@@ -1747,7 +1747,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.redraw();
       dataGrid.setActiveCell(0, 0, false);
       dataGrid.container.querySelector('ids-data-grid-cell').focus();
-      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(hyperlinkClickListener).toHaveBeenCalled();
 
@@ -1764,7 +1764,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.redraw();
       dataGrid.setActiveCell(0, 0, false);
       dataGrid.container.querySelector('ids-data-grid-cell').focus();
-      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(buttonClickListener).toHaveBeenCalled();
 
@@ -1783,7 +1783,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.redraw();
       dataGrid.setActiveCell(0, 0, false);
       dataGrid.container.querySelector('ids-data-grid-cell').focus();
-      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(customLinkClickListener).toHaveBeenCalled();
     });
@@ -1800,7 +1800,7 @@ describe('IdsDataGrid Component', () => {
 
       dataGrid.addEventListener('activecellchanged', mockCallback);
       const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       expect(mockCallback.mock.calls.length).toBe(1);
     });
@@ -2022,7 +2022,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.activeCell.node.focus();
 
       const event = new KeyboardEvent('keydown', { key: ' ' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(dataGrid.selectedRows.length).toBe(1);
     });
 
@@ -2068,7 +2068,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.rowSelection = 'mixed';
       dataGrid.setActiveCell(0, 0);
       const event2 = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-      dataGrid.dispatchEvent(event2);
+      dataGrid.body.dispatchEvent(event2);
 
       dataGrid.deSelectRow(1);
       expect(dataGrid.activatedRow.index).toBe(0);
@@ -2584,10 +2584,10 @@ describe('IdsDataGrid Component', () => {
 
       dataGrid.setActiveCell(0, 0, true);
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
 
       const event2 = new KeyboardEvent('keydown', { key: ' ' });
-      dataGrid.dispatchEvent(event2);
+      dataGrid.body.dispatchEvent(event2);
       expect(firstRow.getAttribute('aria-expanded')).toEqual('false');
     });
 
@@ -3009,13 +3009,13 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       const event2 = new KeyboardEvent('keydown', { key: ' ' }); // Ignored
-      dataGrid.dispatchEvent(event2);
-      dataGrid.dispatchEvent(event2);
+      dataGrid.body.dispatchEvent(event2);
+      dataGrid.body.dispatchEvent(event2);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
       const event3 = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-      dataGrid.dispatchEvent(event3);
+      dataGrid.body.dispatchEvent(event3);
       expect(descCell.classList.contains('is-editing')).toBeFalsy();
     });
 
@@ -3049,7 +3049,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'a' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
     });
 
@@ -3060,44 +3060,44 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
       const event2 = new KeyboardEvent('keydown', { key: 'a' });
-      dataGrid.dispatchEvent(event2);
+      dataGrid.body.dispatchEvent(event2);
 
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeFalsy();
     });
 
     it('can continue to enter edit mode with tabbing', () => {
       dataGrid.editable = true;
       const tabKey = new KeyboardEvent('keydown', { key: 'Tab' });
-      dataGrid.dispatchEvent(tabKey); // Does nothing
+      dataGrid.body.dispatchEvent(tabKey); // Does nothing
 
       const descCell = dataGrid.container.querySelector('.ids-data-grid-row:nth-child(2) > .ids-data-grid-cell:nth-child(3)');
       dataGrid.setActiveCell(2, 1);
       expect(descCell.classList.contains('is-editable')).toBeTruthy();
       const event = new KeyboardEvent('keydown', { key: 'a' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       expect(descCell.classList.contains('is-editing')).toBeTruthy();
       for (let index = 0; index < 300; index++) {
-        dataGrid.dispatchEvent(tabKey);
+        dataGrid.body.dispatchEvent(tabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
 
       const shiftTabKey = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
       for (let index = 0; index < 300; index++) {
-        dataGrid.dispatchEvent(shiftTabKey);
+        dataGrid.body.dispatchEvent(shiftTabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
 
       for (let index = 0; index < 300; index++) {
-        dataGrid.dispatchEvent(tabKey);
+        dataGrid.body.dispatchEvent(tabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
 
       for (let index = 0; index < 300; index++) {
-        dataGrid.dispatchEvent(shiftTabKey);
+        dataGrid.body.dispatchEvent(shiftTabKey);
         expect(dataGrid.container.querySelectorAll('.is-editing').length).toBe(1);
       }
     });
@@ -3112,12 +3112,12 @@ describe('IdsDataGrid Component', () => {
       const rowsLen = dataGrid.rows.length;
       const cell = dataGrid.setActiveCell(2, 7);
       expect(cell.node.classList.contains('is-editable')).toBeTruthy();
-      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       expect(cell.node.classList.contains('is-editing')).toBeTruthy();
 
       const tabKey = new KeyboardEvent('keydown', { key: 'Tab' });
       for (let i = 0; i < 20; i++) {
-        dataGrid.dispatchEvent(tabKey);
+        dataGrid.body.dispatchEvent(tabKey);
       }
       expect(dataGrid.rows.length).toBeGreaterThan(rowsLen);
     });
@@ -3128,7 +3128,7 @@ describe('IdsDataGrid Component', () => {
       dataGrid.setActiveCell(11, 1);
       expect(checkCell.querySelector('[aria-checked]').getAttribute('aria-checked')).toBe('false');
       const event = new KeyboardEvent('keydown', { key: ' ' });
-      dataGrid.dispatchEvent(event);
+      dataGrid.body.dispatchEvent(event);
       const checkCell2 = dataGrid.container.querySelector('.ids-data-grid-row:nth-child(2) > .ids-data-grid-cell:nth-child(12)');
       expect(checkCell2.querySelector('ids-checkbox').getAttribute('checked')).toBe('true');
     });
@@ -3139,7 +3139,7 @@ describe('IdsDataGrid Component', () => {
       const activeCell = dataGrid.setActiveCell(col, row);
       activeCell.node.focus();
       const enterKey = new KeyboardEvent('keydown', { key: 'Enter' });
-      dataGrid.dispatchEvent(enterKey);
+      dataGrid.body.dispatchEvent(enterKey);
     };
 
     it('supports a dropdown editor', () => {
@@ -3180,7 +3180,7 @@ describe('IdsDataGrid Component', () => {
       const gridCell = activeCell.node;
 
       // activate cell editing
-      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       const datePicker = gridCell.querySelector('ids-date-picker');
       expect(datePicker).toBeDefined();
 
@@ -3206,7 +3206,7 @@ describe('IdsDataGrid Component', () => {
       const gridCell = activeCell.node;
 
       // activate cell editing
-      dataGrid.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      dataGrid.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       const timePicker = gridCell.querySelector('ids-time-picker');
       expect(timePicker).toBeDefined();
       expect(timePicker.value).toEqual('2:25 PM');


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed pressing enter on a column header filter input field was executing the `column's click` callback for hyperlinks.

**Related github/jira issue (required)**:
Closes #1228

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4300/ids-data-grid/columns-click-callback.html
- Add some text on the first column header filter
- Press `Enter` key
- Column's click callback should not executed
- Press `Enter` key in first column's cell (any row)
- Should trigger column's click callback
- See console and should popup toast message

Note: Would like to fix a bug but needs help (Tim)
- https://main.wc.design.infor.com/ids-data-grid/filter.html
- open menu
- use arrow keys (should work on menu not grid)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
