### PR TITLE
1294 - Fix release assets to include themes

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,4 +1,9 @@
 # What's New with Enterprise Web Components
+## 1.0.0-beta.11
+
+### 1.0.0-beta.10 Fixes
+
+- `[Build]` Fixed missing theme css files in the build and improved build logic. ([#294](https://github.com/infor-design/enterprise-wc/issues/294))
 
 ## 1.0.0-beta.10
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,7 +1,8 @@
 # What's New with Enterprise Web Components
+
 ## 1.0.0-beta.11
 
-### 1.0.0-beta.10 Fixes
+### 1.0.0-beta.11 Fixes
 
 - `[Build]` Fixed missing theme css files in the build and improved build logic. ([#294](https://github.com/infor-design/enterprise-wc/issues/294))
 

--- a/doc/PUBLISH.md
+++ b/doc/PUBLISH.md
@@ -2,14 +2,14 @@
 
 ## Publishing a package to NPM
 
-- Search for `1.0.0-beta.n` (current version) and replace with next version `1.0.0-beta.10`
+- Search for `1.0.0-beta.n` (current version) and replace with next version `1.0.0-beta.11`
 - It will be in`package.json`, `package-dist.json`, about tests, and `src/core/ids-attributes.js` and this file.
 - Commit and push
-- Make and push a tag with `git tag 1.0.0-beta.10 && git push origin --tags`
+- Make and push a tag with `git tag 1.0.0-beta.11 && git push origin --tags`
 - Run command `npm run publish:dry-run` to test first if you wish
 - Run command `npm run publish:npm` or `publish:debug` (we may want to publish debuggable code for a period of time of stability)
 - Install GitHub cli so you get the [`gh`](https://cli.github.com/manual/gh_release_create) command with `brew install gh`
-- Run command `gh release create 1.0.0-beta.10 --title "1.0.0-beta.10" --notes-file "doc/CHANGELOG.md"`
+- Run command `gh release create 1.0.0-beta.11 --title "1.0.0-beta.11" --notes-file "doc/CHANGELOG.md"`
 - Go to [`the releases page`](https://github.com/infor-design/enterprise-wc/releases) and edit the changelog contents if needed and make a pre-release if needed
 - Update the change log and add a new section
 - Commit and push (direct to repo or PR)

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-enterprise-wc",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "The Web Component version of the IDS Enterprise component library",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ids-enterprise-wc",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ids-enterprise-wc",
-      "version": "1.0.0-beta.10",
+      "version": "1.0.0-beta.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/puppeteer": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-enterprise-wc",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "The Web Component version of the IDS Enterprise component library",
   "author": "Infor Design",
   "license": "Apache-2.0",

--- a/scripts/esbuild-prod.mjs
+++ b/scripts/esbuild-prod.mjs
@@ -22,6 +22,7 @@ fs.rmSync(outDir, { recursive: true, force: true });
 
 let components = fsFiles('./src/', 'ts');
 components = components.filter((item) => (!item.includes('demo') && !item.includes('-base') && !item.includes('ids-locale/data')));
+const themes = fsFiles('./src/', 'scss').filter((item) => (item.includes('themes/default')));
 
 const cssFiles = [];
 
@@ -30,7 +31,7 @@ const cssFiles = [];
 // npx esbuild src/components/ids-tag/ids-tag.ts src/components/ids-alert/ids-alert.ts --bundle --splitting --outdir=out --format=esm
 const result = await esbuild
   .build({
-    entryPoints: components,
+    entryPoints: [...components, ...themes],
     outdir: outDir,
     bundle: true,
     splitting: true,
@@ -45,13 +46,21 @@ const result = await esbuild
         transform(source, dir, filePath) {
           // Make the css file for standalone css
           const rootDir = path.basename(path.dirname(dir));
-          if (rootDir === 'components') {
+          if (rootDir === 'componentsXXXXXX') {
             const noHost = source.replace(':host {', ':root {');
             const comp = path.basename(path.dirname(filePath));
             const file = `${outDir}${path.sep}components${path.sep}${comp}${path.sep}${comp}.css`;
             cssFiles.push({ file, source: noHost });
             fs.mkdirSync(path.dirname(file), { recursive: true }, () => {});
             fs.writeFileSync(file, noHost, () => {});
+          }
+
+          if (rootDir === 'themes') {
+            const comp = path.basename(filePath);
+            const folder = `${outDir}${path.sep}themes${path.sep}`;
+            const file = `${folder}${comp.replace('.scss', '.css')}`;
+            fs.mkdirSync(folder, { recursive: true }, () => { });
+            fs.writeFileSync(file, source.split('/*# sourceMappingURL')[0], () => { });
           }
           return source;
         }
@@ -76,7 +85,8 @@ types = types.filter((item) => (!item.includes('demo')
     && !item.includes('ids-locale/data/')
     && !item.includes('ids-locale/info/')
     && !item.includes('ids-locale-global')
-    && !item.includes('cultures')));
+    && !item.includes('cultures')
+    && !item.includes('themes/ids-theme')));
 
 types.forEach((type) => {
   fs.copyFileSync(type, type.replace('build/types/src', outDir));
@@ -99,6 +109,8 @@ if (mode === 'production') {
     })
     .catch(() => process.exit(1));
 }
+
+fs.rmSync(`${outDir}/themes/default`, { recursive: true, force: true });
 
 // Create Stats File
 // Can view this file at https://esbuild.github.io/analyze/

--- a/src/components/ids-about/demos/standalone-css.html
+++ b/src/components/ids-about/demos/standalone-css.html
@@ -26,7 +26,7 @@
                 <span>Language : en</span><br/>
                 <span>Browser :   Chrome (92.0.4515.159)</span><br/>
                 <span>Browser Language : en-US</span><br/>
-                <span>IDS Version : 1.0.0-beta.10</span></p>
+                <span>IDS Version : 1.0.0-beta.11</span></p>
             </div>
           </div>
         </div>

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -528,7 +528,7 @@ export const prefix = {
   PREFIX: 'ids'
 };
 
-export const version = '1.0.0-beta.10';
+export const version = '1.0.0-beta.11';
 
 export enum IdsDirection {
   Up = 'up',

--- a/src/core/ids-element.ts
+++ b/src/core/ids-element.ts
@@ -228,21 +228,18 @@ export default class IdsElement extends HTMLElement {
    * @param {string} theme name of the theme
    */
   async loadTheme(theme: string) {
-    await fetch(`../themes/ids-theme-${theme}.css`)
-      .then(async (data) => {
-        const themeStyles = await data.text();
-
-        const head = (document.head as any);
-        const styleElem = document.querySelector('#ids-theme');
-        const style = styleElem || document.createElement('style');
-        style.textContent = themeStyles;
-        style.id = 'ids-theme';
-        if (this.nonce) style.setAttribute('nonce', this.nonce);
-        if (!styleElem) {
-          const titleElem = (head.querySelector('title') as HTMLElement);
-          if (titleElem) head.insertBefore(style, titleElem.nextElementSibling);
-          else head.insertAdjacentHTML('beforeend', style);
-        }
-      });
+    const response = await fetch(`../themes/ids-theme-${theme}.css`);
+    const themeStyles = await response.text();
+    const head = (document.head as any);
+    const styleElem = document.querySelector('#ids-theme');
+    const style = styleElem || document.createElement('style');
+    style.textContent = themeStyles;
+    style.id = 'ids-theme';
+    if (this.nonce) style.setAttribute('nonce', this.nonce);
+    if (!styleElem) {
+      const titleElem = (head.querySelector('title') as HTMLElement);
+      if (titleElem) head.insertBefore(style, titleElem.nextElementSibling);
+      else head.insertAdjacentHTML('beforeend', style);
+    }
   }
 }

--- a/src/themes/default/ids-theme-default-contrast.scss
+++ b/src/themes/default/ids-theme-default-contrast.scss
@@ -6,7 +6,7 @@
   --ids-color-text-on-primary: var(--ids-color-neutral-00);
 
   // Body Colors
-  --ids-body-background-color: var(--ids-color-neutral-10);
+  --ids-body-background-color: rgba(239 239 240 / 0.5);
   --ids-body-text-on-background-color: var(--ids-color-neutral-100);
 
   // Text Colors

--- a/test/ids-about/ids-about-func-test.ts.snap
+++ b/test/ids-about/ids-about-func-test.ts.snap
@@ -11,7 +11,7 @@ exports[`IdsAbout Component (using properties) should render 1`] = `
         <span>Locale : en-US</span><br>
         <span>Language : en</span><br>
         <span>Browser Language : en-US</span><br>
-        <span>IDS Version : 1.0.0-beta.10</span>
+        <span>IDS Version : 1.0.0-beta.11</span>
       </ids-text><ids-text slot="copyright" type="p">Copyright © 2022 Infor. All rights reserved. The word and design marks set forth herein are trademarks and/or registered trademarks of Infor and/or its affiliates and subsidiaries. All other trademarks listed herein are the property of their respective owners <ids-hyperlink target="_blank" href="https://www.infor.com" role="link">www.infor.com</ids-hyperlink>.</ids-text></ids-about>"
 `;
 
@@ -26,7 +26,7 @@ exports[`IdsAbout Component (using properties) should render 2`] = `
         <span>Locale : en-US</span><br>
         <span>Language : en</span><br>
         <span>Browser Language : en-US</span><br>
-        <span>IDS Version : 1.0.0-beta.10</span>
+        <span>IDS Version : 1.0.0-beta.11</span>
       </ids-text><ids-text slot="copyright" type="p">Copyright © 2022 Infor. All rights reserved. The word and design marks set forth herein are trademarks and/or registered trademarks of Infor and/or its affiliates and subsidiaries. All other trademarks listed herein are the property of their respective owners <ids-hyperlink target="_blank" href="https://www.infor.com" role="link">www.infor.com</ids-hyperlink>.</ids-text></ids-about>"
 `;
 
@@ -41,6 +41,6 @@ exports[`IdsAbout Component (using properties) should render 3`] = `
         <span>Locale : en-US</span><br>
         <span>Language : en</span><br>
         <span>Browser Language : en-US</span><br>
-        <span>IDS Version : 1.0.0-beta.10</span>
+        <span>IDS Version : 1.0.0-beta.11</span>
       </ids-text><ids-text slot="copyright" type="p">Copyright © 2022 Infor. All rights reserved. The word and design marks set forth herein are trademarks and/or registered trademarks of Infor and/or its affiliates and subsidiaries. All other trademarks listed herein are the property of their respective owners <ids-hyperlink target="_blank" href="https://www.infor.com" role="link">www.infor.com</ids-hyperlink>.</ids-text></ids-about>"
 `;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

The release was missing the new theme files. In order to fix this modified the build script and fetching logic.
Included a background color change for contrast theme and made a release.

**Related github/jira issue (required)**:

Fixes #1294 

**Steps necessary to review your pull request (required)**:
- `npm run build:dist`
- notice new themes folder in build/dist
- can also run https://github.com/infor-design/enterprise-wc-examples/tree/main/angular-ids-wc after doing `npm i` and it will get the new release and should run well now (no 404 and missing styles)

**Included in this Pull Request**:
- [x] A note to the change log.
