### PR TITLE
1301 - Added a way to set theme via a link

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[DataGrid]` Fixed RTL order / typing in RTL in filter mode with text align right. ([#1302](https://github.com/infor-design/enterprise-wc/issues/1302))
 - `[DataGrid]` Added `xxs` row height for edge cases where you need a really crowded UI. ([#1199](https://github.com/infor-design/enterprise-wc/issues/1072))
 - `[SearchField]` Added categories to search-field. ([#700](https://github.com/infor-design/enterprise-wc/issues/700))
+- `[Themes]` Added the possibility to set the theme as a css file in link for more dynamic configuration. ([#1301](https://github.com/infor-design/enterprise-wc/issues/1301))
 
 ## 1.0.0-beta.11
 

--- a/doc/CUSTOMIZING.md
+++ b/doc/CUSTOMIZING.md
@@ -78,3 +78,17 @@ To set just a personalization color you just have to change the primary color va
 ```
 
 To create a full theme take all the variables in `src/themes/default/ids-theme-default-core.scss` and change the ones you need to create the theme. You only need to include the one you changed. For a non customer theme (Infor based) its recommended you always you the current palette colors as per `ids-color/demos/palette.html`. But note that you can change the entire palette if desired although this is current work in progress due to the need for further refinement.
+
+You can include the initial theme one of two ways.
+
+1. Let the components manage the styles in head manually
+2. If you need to serve the css files in a different way you can include the theme manually as a link. Then the theme switcher will replace the file name section when you use it. Or you could full manage this yourself (replacing the theme file changes theme). For example:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="/my-place/themes/ids-theme-default-light.css">
+</head>
+<body>
+```

--- a/src/components/ids-theme-switcher/README.md
+++ b/src/components/ids-theme-switcher/README.md
@@ -41,8 +41,8 @@ Add an ids-theme-switcher to the page near the top and set the version and mode 
 
 ## Settings and Attributes
 
-- `version` {string} Turns on the functionality to make the tag clickable like a link
 - `mode` {string} Turns on the functionality to add an (x) button to clear remove the tag
+- `selfManaged` {boolean} If added no links will attempt to be fetch via the fetch api. The expectation is you will manage the style sheet themes manually.
 
 ## Converting from Previous Versions
 

--- a/src/components/ids-theme-switcher/README.md
+++ b/src/components/ids-theme-switcher/README.md
@@ -4,6 +4,20 @@
 
 We include a theme switcher component that can be visual or non visual. If visual it comes with a menu button to allow you to pick theme. If non visible you can set its properties and all other components in the page will change theme to the set theme.
 
+You can include the initial theme one of two ways.
+
+1. Let the components manage the styles in head manually
+2. If you need to serve the css files in a different way you can include the theme manually as a link. Then the theme switcher will replace the file name section when you use it. Or you could full manage this yourself (replacing the theme file changes theme). For example:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="/my-place/themes/ids-theme-default-light.css">
+</head>
+<body>
+```
+
 ## Use Cases
 
 - When you want to use a common look across applications with a theme

--- a/src/components/ids-theme-switcher/demos/index.yaml
+++ b/src/components/ids-theme-switcher/demos/index.yaml
@@ -11,6 +11,9 @@
   - link: hidden.html
     type: Example
     description: Showing a switcher that is hidden but still functional
+  - link: use-link.html
+    type: Example
+    description: Showing using a link for the css files
   - link: theme-builder.html
     type: Example
     description: Showing a theme builder example

--- a/src/components/ids-theme-switcher/demos/index.yaml
+++ b/src/components/ids-theme-switcher/demos/index.yaml
@@ -11,6 +11,9 @@
   - link: hidden.html
     type: Example
     description: Showing a switcher that is hidden but still functional
+  - link: self-managed.html
+    type: Example
+    description: Showing ignoreing fetch attempts
   - link: use-link.html
     type: Example
     description: Showing using a link for the css files

--- a/src/components/ids-theme-switcher/demos/self-managed.html
+++ b/src/components/ids-theme-switcher/demos/self-managed.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+
+  <link rel="stylesheet" href="/themes/ids-theme-default-light.css">
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" self-managed></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Themes</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-tag>Normal Tag</ids-tag>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-theme-switcher/demos/self-manages.ts
+++ b/src/components/ids-theme-switcher/demos/self-manages.ts
@@ -1,0 +1,1 @@
+import '../../ids-tag/ids-tag';

--- a/src/components/ids-theme-switcher/demos/use-link.html
+++ b/src/components/ids-theme-switcher/demos/use-link.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+
+  <link rel="stylesheet" href="/themes/ids-theme-default-light.css">
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Themes</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-tag>Normal Tag</ids-tag>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-theme-switcher/demos/use-link.ts
+++ b/src/components/ids-theme-switcher/demos/use-link.ts
@@ -1,0 +1,1 @@
+import '../../ids-tag/ids-tag';

--- a/src/components/ids-theme-switcher/ids-theme-switcher.ts
+++ b/src/components/ids-theme-switcher/ids-theme-switcher.ts
@@ -10,6 +10,7 @@ import '../ids-menu-button/ids-menu-button';
 import styles from './ids-theme-switcher.scss';
 import type IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
 import type IdsMenuButton from '../ids-menu-button/ids-menu-button';
+import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 
 const Base = IdsLocaleMixin(
   IdsColorVariantMixin(
@@ -37,7 +38,7 @@ export default class IdsThemeSwitcher extends Base {
     super.connectedCallback();
     this.popup = this.shadowRoot?.querySelector('ids-popup-menu');
     this.menuButton = this.shadowRoot?.querySelector('ids-menu-button');
-    if (this.menuButton?.configureMenu) this.menuButton?.configureMenu();
+    this.menuButton?.configureMenu?.();
     this.#attachEventHandlers();
   }
 
@@ -166,6 +167,7 @@ export default class IdsThemeSwitcher extends Base {
       ...super.attributes,
       attributes.LANGUAGE,
       attributes.MODE,
+      attributes.SELF_MANAGED,
       attributes.THEME
     ];
   }
@@ -192,6 +194,21 @@ export default class IdsThemeSwitcher extends Base {
   }
 
   get mode(): string { return this.getAttribute(attributes.MODE) || 'light'; }
+
+  /**
+   * If true the themes are self managed by eh developer (no fetches will be attempted)
+   * @param {boolean} value Set to true to include the themes manually
+   */
+  set selfManaged(value: boolean) {
+    if (value) {
+      this.setAttribute(attributes.SELF_MANAGED, String(value));
+      return;
+    }
+
+    this.removeAttribute(attributes.SELF_MANAGED);
+  }
+
+  get selfManaged(): boolean { return stringToBool(this.getAttribute(attributes.SELF_MANAGED)) || false; }
 
   /**
    * Set the theme

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -409,6 +409,7 @@ export const attributes = {
   SORTABLE: 'sortable',
   SOURCE_FORMATTER: 'source-formatter',
   SQUARE: 'square',
+  SELF_MANAGED: 'self-managed',
   SRC: 'src',
   STACKED: 'stacked',
   STARS: 'stars',

--- a/src/core/ids-element.ts
+++ b/src/core/ids-element.ts
@@ -230,8 +230,20 @@ export default class IdsElement extends HTMLElement {
    * @param {string} theme name of the theme
    */
   async loadTheme(theme: string) {
+    // Reduce http requests
     if (this.lastTheme === theme) return;
     this.lastTheme = theme;
+
+    // Handle setting theme via links
+    const themeLink = document.querySelector('link[href*="ids-theme"]');
+    if (themeLink) {
+      const href = themeLink.getAttribute('href');
+      const filename = href?.replace(/^.*[\\/]/, '') || '';
+      themeLink.setAttribute('href', href?.replace(filename, `ids-theme-${theme}.css`) || '');
+      return;
+    }
+
+    // Handle auto themes
     const response = await fetch(`../themes/ids-theme-${theme}.css`, { cache: 'reload' });
     const themeStyles = await response.text();
     const head = (document.head as any);

--- a/src/core/ids-element.ts
+++ b/src/core/ids-element.ts
@@ -243,6 +243,9 @@ export default class IdsElement extends HTMLElement {
       return;
     }
 
+    const isSelfManaged = document.querySelector('ids-theme-switcher[self-managed]');
+    if (isSelfManaged) return;
+
     // Handle auto themes
     const response = await fetch(`../themes/ids-theme-${theme}.css`, { cache: 'reload' });
     const themeStyles = await response.text();


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Added a new way to set theme via a link as an option in order to allow for more flexibility.

**Related github/jira issue (required)**:
Fixes #1301 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-theme-switcher/example.html
- inspect the <head> and notice the item with `<style id="ids-theme"`
- change to dark or contrast mode -> notice the `<style>` gets updated
- go to http://localhost:4300/ids-theme-switcher/use-link.html
-  inspect the <head> and notice no item with `<style id="ids-theme"` instead a `<link rel="stylesheet" href="/themes/ids-theme-default-light.css">` is used
- change to dark or contrast mode -> notice the `<link>` gets updated

**Included in this Pull Request**:
- [x] A note to the change log.
