### PR TITLE
7597 - Fix tooltip size

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 1.0.0-beta.13 Fixes
 
+- `[Tooltip]` Changed the tooltip heights to match. ([#7509](https://github.com/infor-design/enterprise/issues/7509))
+
 ## 1.0.0-beta.12
 
 ### 1.0.0-beta.12 Fixes

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -1239,7 +1239,7 @@
 
   // Tooltip
   --ids-tooltip-background-color: var(--ids-color-neutral-80);
-  --ids-tooltip-padding: 4px 8px;
+  --ids-tooltip-padding: 8px 16px;
   --ids-tooltip-border-radius: var(--ids-border-radius-xs);
   --ids-tooltip-text-color: var(--ids-color-neutral-00);
   --ids-tooltip-font-size: var(--ids-font-size-md);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Syncing up with https://github.com/infor-design/enterprise/pull/7597 ~ made tooltip 36px in height

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/pull/7597

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-tooltip/sandbox.html
- do `$('ids-tooltip').visible = true` in the console so you can inspect it
- check the height is 36px (8px x 16px padding)

**Included in this Pull Request**:
- [x] A note to the change log.
