### PR TITLE
1320 - Datagrid header filter-field activates editable cells

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[DataGrid]` Fixed scrollend event firing. ([#1305](https://github.com/infor-design/enterprise-wc/issues/1305))
 - `[DataGrid]` Fixed keeping virtual scroll selected/deselected states. ([#1329](https://github.com/infor-design/enterprise-wc/issues/1329))
 - `[DataGrid]` Fixed `scrollend` event firing. ([#1305](https://github.com/infor-design/enterprise-wc/issues/1305))
+- `[DataGrid]` Prevent header filter activating editor cell. ([#1320](https://github.com/infor-design/enterprise-wc/issues/1320))
 - `[Tooltip]` Changed the tooltip heights to match. ([#7509](https://github.com/infor-design/enterprise/issues/7509))
 - `[Themes]` Added theme switcher to side-by-side examples and ability to switch 4.x themes in the `ids-theme-switcher `component. ([#939](https://github.com/infor-design/enterprise-wc/issues/939))
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -783,6 +783,11 @@ export default class IdsDataGrid extends Base {
       return true;
     });
 
+    this.offEvent('keydown.body', this.header);
+    this.onEvent('keydown.body', this.header, () => {
+      this.activeCell = {};
+    });
+
     // Enter Edit by typing
     this.offEvent('keydown.body', this);
     this.onEvent('keydown.body', this, (e: KeyboardEvent) => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Datagrid header-filters were broken when editable cells were visible.  Typing into a header-filter would cause an editable cell to be focused, and the filter would fail.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1320 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out this branch
2. Update `src/components/ids-data-grid/demos/editable-inline.ts`
3. Remove the first 2 columns: `selectionCheckbox` and `rowNumber`
4. On the `description` column, add this: `filterType: dataGrid.filters.text` 
5. The run: `npm run start`
6. Open http://localhost:4300/ids-data-grid/editable-inline.html
7. Type something into the `description` column's header filter
8. Verify that the filter works properly and that no editable cells are activated

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
