### PR TITLE
1341 - IdsDataGrid virtual scroll fast scrolling

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Colors]` Added new slate color palette with lower range colors. Some elements are updated. ([#7624](https://github.com/infor-design/enterprise/issues/7624))
 - `[DataGrid]` Fixed scrollend event firing. ([#1305](https://github.com/infor-design/enterprise-wc/issues/1305))
 - `[DataGrid]` Fixed keeping virtual scroll selected/deselected states. ([#1329](https://github.com/infor-design/enterprise-wc/issues/1329))
+- `[DataGrid]` Fixed virtual scroll showing blank when scrolling fast. ([#1341](https://github.com/infor-design/enterprise-wc/issues/1341))
 - `[DataGrid]` Fixed `scrollend` event firing. ([#1305](https://github.com/infor-design/enterprise-wc/issues/1305))
 - `[Tooltip]` Changed the tooltip heights to match. ([#7509](https://github.com/infor-design/enterprise/issues/7509))
 - `[Themes]` Added theme switcher to side-by-side examples and ability to switch 4.x themes in the `ids-theme-switcher `component. ([#939](https://github.com/infor-design/enterprise-wc/issues/939))

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1560,6 +1560,7 @@ export default class IdsDataGrid extends Base {
     const bodyTranslateY = bufferRowIndex * virtualRowHeight;
     const bodyPaddingBottom = maxPaddingBottom - bodyTranslateY;
 
+    // refetch rows because lastRowIndex could have been updated after row recycling
     lastRowIndex = this.rows.at(-1)?.rowIndex;
     reachedTheBottom = lastRowIndex >= maxRowIndex;
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -119,10 +119,10 @@ export default class IdsDataGrid extends Base {
   }
 
   /* Returns all the row elements in an array */
-  get rows() {
+  get rows(): IdsDataGridRow[] {
     // NOTE: Array.from() seems slower than dotdotdot array-destructuring.
     if (!this.container) return [];
-    return [...this.container.querySelectorAll<HTMLElement>('.ids-data-grid-body ids-data-grid-row')];
+    return [...this.container.querySelectorAll<IdsDataGridRow>('.ids-data-grid-body ids-data-grid-row')];
   }
 
   /* Returns the outside wrapper element */
@@ -1510,12 +1510,12 @@ export default class IdsDataGrid extends Base {
     const firstRow: any = rows[0];
     const lastRow: any = rows[rows.length - 1];
     const firstRowIndex = firstRow.rowIndex;
-    const lastRowIndex = lastRow.rowIndex;
+    let lastRowIndex = lastRow.rowIndex;
 
     const isAboveFirstRow = rowIndex < firstRowIndex;
     const isBelowLastRow = rowIndex > lastRowIndex;
     const isInRange = !isAboveFirstRow && !isBelowLastRow;
-    const reachedTheBottom = lastRowIndex >= maxRowIndex;
+    let reachedTheBottom = lastRowIndex >= maxRowIndex;
 
     let bufferRowIndex = rowIndex - virtualScrollSettings.BUFFER_ROWS;
     bufferRowIndex = Math.max(bufferRowIndex, 0);
@@ -1560,11 +1560,14 @@ export default class IdsDataGrid extends Base {
     const bodyTranslateY = bufferRowIndex * virtualRowHeight;
     const bodyPaddingBottom = maxPaddingBottom - bodyTranslateY;
 
+    lastRowIndex = this.rows.at(-1)?.rowIndex;
+    reachedTheBottom = lastRowIndex >= maxRowIndex;
+
     if (!reachedTheBottom) {
-      body?.style.setProperty('transform', `translateY(${bodyTranslateY}px)`);
+      body.style.setProperty('transform', `translateY(${bodyTranslateY}px)`);
     }
 
-    body?.style.setProperty('padding-bottom', `${Math.max(bodyPaddingBottom, 0)}px`);
+    body.style.setProperty('padding-bottom', `${Math.max(bodyPaddingBottom, 0)}px`);
 
     if (doScroll) {
       container!.scrollTop = rowIndex * virtualRowHeight;
@@ -1602,13 +1605,13 @@ export default class IdsDataGrid extends Base {
     if (!rowCount || !rows.length) return;
     const data = this.data;
 
-    const bottomRow: any = rows[rows.length - 1];
+    const bottomRow = rows[rows.length - 1];
     const bottomRowIndex = bottomRow.rowIndex;
     const staleRows = rows.slice(0, rowCount);
-    const rowsToMove: any[] = [];
+    const rowsToMove: IdsDataGridRow[] = [];
 
     // NOTE: Using Array.every as an alternaive to using a for-loop with a break
-    staleRows.every((row: any, idx) => {
+    staleRows.every((row: IdsDataGridRow, idx) => {
       const nextIndex = bottomRowIndex + (idx + 1);
       if (nextIndex >= data.length) return false;
       row.rowIndex = nextIndex;
@@ -1632,10 +1635,10 @@ export default class IdsDataGrid extends Base {
     const rows = this.rows;
     if (!rowCount || !rows.length) return;
 
-    const topRow: any = rows[0];
+    const topRow = rows[0];
     const topRowIndex = topRow.rowIndex;
     const staleRows = rows.slice((-1 * rowCount));
-    const rowsToMove: any[] = [];
+    const rowsToMove: IdsDataGridRow[] = [];
 
     // NOTE: Using Array.every as an alternaive to using a for-loop with a break
     staleRows.every((row: any, idx) => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes problem where scrolling fast with virtual scroll sometimes leaves the data grid looking empty.
Problem was as suggested, `translateY` css wasn't being reapplied because `const reachedTheBottom` was off.
`lastRowIndex` needed to be updated after row recycling inside `scrollRowIntoView()`

**Related github/jira issue (required)**:
Closes #1341 

**Steps necessary to review your pull request (required)**:

**Setup (Copied from #1341 issue)** 
1. update virtual-scroll-infinite-scroll-m3.ts
2. set max count to 1000, `87:  const MAX_RESULTS_COUNT = 1000;`
3. load a lot of data `99:  const dataSet = data.splice(0, Math.min(numRowsNeeded, 900));`
4. remove .rowStart `104:  // dataGrid.rowStart = 120;`
5. remove .selectRow `109: // dataGrid.selectRow(120);`
6. npm start
7. move scrollbar to the bottom, (up to record 1000)
8. move scrollbar to the top/beginning as fast as possible

Test to make sure datagrid consistently isn't shown as empty after scrolling fast.
Please test other data grid virtual/infinite scroll examples to see that they all still work as expected.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

