### PR TITLE
1330 - IdsDataGrid shift key multiselect

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[DataGrid]` Fixed keeping virtual scroll selected/deselected states. ([#1329](https://github.com/infor-design/enterprise-wc/issues/1329))
 - `[DataGrid]` Fixed `scrollend` event firing. ([#1305](https://github.com/infor-design/enterprise-wc/issues/1305))
 - `[DataGrid]` Prevent header filter activating editor cell. ([#1320](https://github.com/infor-design/enterprise-wc/issues/1320))
+- `[DataGrid]` Add ability to multi select with shift key. ([#1330](https://github.com/infor-design/enterprise-wc/issues/1330))
 - `[Tooltip]` Changed the tooltip heights to match. ([#7509](https://github.com/infor-design/enterprise/issues/7509))
 - `[Themes]` Added theme switcher to side-by-side examples and ability to switch 4.x themes in the `ids-theme-switcher `component. ([#939](https://github.com/infor-design/enterprise-wc/issues/939))
 

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -295,6 +295,10 @@ export default class IdsDataGridRow extends IdsElement {
     }
   }
 
+  get selected(): boolean {
+    return this.classList.contains('selected');
+  }
+
   /**
    * Updates some attributes/classes on a single row's cells
    * @private

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -462,12 +462,26 @@ export default class IdsDataGrid extends Base {
   #lastSelectedRow: number | null = null;
 
   /**
+   * Keep reference to last shifted row
+   * @private
+   */
+  #lastShiftedRow: number | null = null;
+
+  /**
    * Reset flag for last selected row
    * @private
    * @returns {void}
    */
   #resetLastSelectedRow(): void {
     this.#lastSelectedRow = null;
+  }
+
+  /**
+   * Reset reference to last shifted row
+   * @private
+   */
+  #resetLastShiftedRow(): void {
+    this.#lastShiftedRow = null;
   }
 
   /**
@@ -525,6 +539,8 @@ export default class IdsDataGrid extends Base {
       if (row.disabled) return;
 
       const rowNum = row.rowIndex;
+
+      if (!e.shiftKey) this.#resetLastShiftedRow();
 
       const isHyperlink = e.target?.nodeName === 'IDS-HYPERLINK' || e.target?.nodeName === 'A';
       const isButton = e.target?.nodeName === 'IDS-BUTTON';
@@ -664,8 +680,10 @@ export default class IdsDataGrid extends Base {
       const inFilter = findInPath(eventPath(e), '.ids-data-grid-header-cell-filter-wrapper');
       const key = e.key;
 
+      if (!e.shiftKey) this.#resetLastShiftedRow();
       if (inFilter && (key === 'ArrowRight' || key === 'ArrowLeft')) return;
       if (!this.activeCell?.node) return;
+
       const cellNode = this.activeCell.node;
       const cellNumber = Number(this.activeCell?.cell);
       const rowDiff = key === 'ArrowDown' ? 1 : (key === 'ArrowUp' ? -1 : 0); //eslint-disable-line
@@ -687,6 +705,24 @@ export default class IdsDataGrid extends Base {
       const activateCellNumber = cellNumber + cellDiff;
       const activateRowIndex = rowDiff === 0 ? Number(this.activeCell?.row) : rowIndex;
       this.setActiveCell(activateCellNumber, activateRowIndex);
+
+      // Handle row selection
+      if ((this.rowSelection === 'mixed' || this.rowSelection === 'multiple') && movingVertical && e.shiftKey) {
+        const previousActiveRow = Number(cellNode.parentElement.getAttribute('row-index'));
+        this.#lastShiftedRow ??= previousActiveRow;
+        const shiftSelectFrom = Math.min(activateRowIndex, this.#lastShiftedRow);
+        const shiftSelectTo = Math.max(activateRowIndex, this.#lastShiftedRow);
+
+        if (Number.isNaN(shiftSelectFrom) || Number.isNaN(shiftSelectTo)) return;
+
+        if (previousActiveRow < shiftSelectFrom || previousActiveRow > shiftSelectTo) {
+          this.deSelectRow(previousActiveRow);
+        }
+
+        for (let i = shiftSelectFrom; i <= shiftSelectTo; i++) {
+          this.selectRow(i);
+        }
+      }
 
       if (this.rowSelection === 'mixed' && this.rowNavigation) {
         (cellNode.parentElement as IdsDataGridRow).toggleRowActivation();
@@ -2004,7 +2040,7 @@ export default class IdsDataGrid extends Base {
       return;
     }
 
-    if (!row) return;
+    if (!row || row.selected) return;
 
     if (this.rowSelection === 'multiple' || this.rowSelection === 'mixed') {
       const checkbox = row?.querySelector('.is-selection-checkbox .ids-data-grid-checkbox');

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -1719,6 +1719,22 @@ describe('IdsDataGrid Component', () => {
       expect(rowElem.getAttribute('aria-rowindex')).toEqual('2');
     });
 
+    it('can handle keyboard mixed row selection with shift key', () => {
+      dataGrid.rowSelection = 'mixed';
+      expect(dataGrid.activeCell.row).toEqual(0);
+      expect(dataGrid.activeCell.cell).toEqual(0);
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown', shiftKey: true });
+      dataGrid.rowNavigation = true;
+      dataGrid.dispatchEvent(event);
+
+      const previousRow = dataGrid.rowByIndex(0);
+      const nextRow = dataGrid.rowByIndex(1);
+
+      expect(previousRow.selected).toBeTruthy();
+      expect(nextRow.selected).toBeTruthy();
+    });
+
     it('can set the rowNavigation setting', () => {
       dataGrid.rowNavigation = true;
       expect(dataGrid.getAttribute('row-navigation')).toEqual('');


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Add ability to multi select with keyboard navigation and shift key.

**Related github/jira issue (required)**:
Fixes #1330 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, `npm install`, `npm run start`
2. Go to http://localhost:4300/ids-data-grid/example.html
3. Try multiselecting with keyboard arrows and shift key, should work as expected

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
