### PR TITLE
1321 - Fixed where text selection caused dragging

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[DataGrid]` Fix tree collapse/expand state while sorting. ([#1284](https://github.com/infor-design/enterprise-wc/issues/1284))
 - `[Tooltip]` Changed the tooltip heights to match. ([#7509](https://github.com/infor-design/enterprise/issues/7509))
 - `[Themes]` Added theme switcher to side-by-side examples and ability to switch 4.x themes in the `ids-theme-switcher `component. ([#939](https://github.com/infor-design/enterprise-wc/issues/939))
+- `[DataGrid]` Fixed a bug in the filter header where text selection in the inputs would cause accidental dragging. ([#1321](https://github.com/infor-design/enterprise-wc/issues/1321))
 
 ## 1.0.0-beta.12
 

--- a/src/components/ids-data-grid/ids-data-grid-header.ts
+++ b/src/components/ids-data-grid/ids-data-grid-header.ts
@@ -170,12 +170,29 @@ export default class IdsDataGridHeader extends IdsEventsMixin(IdsElement) {
     let dragger: HTMLElement;
     let startIndex = 0;
     let dragInitiated = false;
+    let dragParent: HTMLElement | null;
+
+    this.offEvent('mousedown.reorder', this);
+    this.onEvent('mousedown.reorder', this, (e: MouseEvent) => {
+      const nodeName = (e.target as HTMLElement).nodeName;
+
+      if (nodeName === 'IDS-INPUT') {
+        dragParent = (e.target as HTMLElement).closest('.ids-data-grid-header-cell');
+        dragParent?.setAttribute('draggable', 'false');
+      }
+    });
+
+    this.offEvent('mouseup.reorder', this);
+    this.onEvent('mouseup.reorder', this, () => {
+      dragParent?.setAttribute('draggable', 'true');
+    });
 
     // Style the Dragger
     this.offEvent('dragstart.reorder', this);
     this.onEvent('dragstart.reorder', this, (e: DragEvent) => {
-      if (this.dataGrid.isResizing) return;
       const target = (e.target as any);
+      const nodeName = (e.target as HTMLElement).nodeName;
+      if (this.dataGrid.isResizing || !target || nodeName === 'IDS-INPUT') return;
       dragInitiated = true;
       target.classList.add('active-drag-column');
       dragger = target.cloneNode(true);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Fixed a bug in the filter header where text selection in the inputs would cause accidental dragging.

**Related github/jira issue (required)**:
Fixes #1321 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-data-grid/disable-client-filter.html
- click in the draggable (and not draggable) filter inputs and then type anything
- then try and use the mouse to select the text and parts of the text in said input
- should not longer trigger the column to drag
- before and after doing this make sure you can drag the column by clicking other parts than the input

**Included in this Pull Request**:
- [x] A note to the change log.