### PR TITLE
1309 - Added maxlength and uppercase settings

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.14
+
+### 1.0.0-beta.14 Fixes
+
+- `[DataGrid]` Added `uppercase` and `maxlength` settings to editors and filters (text only). ([#1309](https://github.com/infor-design/enterprise-wc/issues/1309))
+
 ## 1.0.0-beta.13
 
 ### 1.0.0-beta.13 Fixes

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -274,6 +274,8 @@ The following settings are available on editors.
 `editorSettings.mask` Will pass mask settings to the input (if supported).
 `editorSettings.maskOptions` Will pass maskOptions settings to the input (if supported).
 `editorSettings.options` Dataset used for dropdown editor's list box options.
+`editorSettings.maxlength` Sets the input editor's `maxlength` property to the max characters you can type
+`editorSettings.uppercase` Sets the input editor's to all uppercase
 
 When the use clicks in the cell or activates editing with the keyboard with the Enter key and types. The following events will fire.
 
@@ -378,7 +380,7 @@ When used as an attribute in the DOM the settings are kebab case, when used in J
 |`href` | {string|Function} | Used to create the href for hyperlink formatters. This can be a string or a function that can work dynamically. It can also replace `{{value}}` with the current value. |
 |`text` | {string} | Used to create the txt value for hyperlink formatters if a hard coded link text is needed. |
 |`disabled` | {boolean|Function} | Sets the cell contents to disabled, can also use a callback to determine this dynamically. Only checkboxes, radios, buttons and link columns can be disabled at this time. Selection columns require disabled rows in order to not be clickable/selectable. |
-|`uppercase` | {boolean} | Allows you to set the text as uppercase. |
+|`uppercase` | {boolean} | Transforms all the text in the cell contents to uppercase. See also filterOptions and editorOptions |
 
 ## Formatters
 
@@ -538,7 +540,7 @@ All the filter settings can be passed thru columns data.
 |`filterType` | Function | Data grid built-in filter method, see the dedicated section below. |
 |`filterConditions` | Array | List of items to be use as operators in menu-button or options in dropdown. |
 |`filterFunction` | Function | User defined filter method, it must return a boolean. |
-|`filterOptions` | Object | Setting for components are in use, for example: `label, placeholder, disabled`. |
+|`filterOptions` | Object | Passes settings in for the filter component example: `label, placeholder, disabled, uppercase, maxlength`. |
 |`isChecked` | Function | User defined filter method, it must return a boolean. This method use along built-in `checkbox` only, when filter data value is not boolean type. |
 
 ### Built-in Filter Methods

--- a/src/components/ids-data-grid/demos/editable.ts
+++ b/src/components/ids-data-grid/demos/editable.ts
@@ -41,7 +41,7 @@ rowHeightMenu?.addEventListener('selected', (e: Event) => {
       editorSettings: {
         autoselect: true,
         dirtyTracker: true,
-        validate: 'required'
+        validate: 'required',
       }
     },
     readonly(row: number) {
@@ -58,12 +58,20 @@ rowHeightMenu?.addEventListener('selected', (e: Event) => {
     resizable: true,
     reorderable: true,
     formatter: dataGrid.formatters.text,
+    filterType: dataGrid.filters.text,
+    filterOptions: {
+      maxlength: 2,
+      uppercase: true
+    },
+    uppercase: true,
     editor: {
       type: 'input',
       editorSettings: {
         autoselect: true,
         dirtyTracker: true,
-        mask: [/[a-zA-Z]/, /[a-zA-Z]/, /[a-zA-Z]/, /[a-zA-Z]/]
+        // mask: [/[a-zA-Z]/, /[a-zA-Z]/, /[a-zA-Z]/, /[a-zA-Z]/],
+        maxlength: 2,
+        uppercase: true
       }
     },
   });

--- a/src/components/ids-data-grid/ids-data-grid-column.ts
+++ b/src/components/ids-data-grid/ids-data-grid-column.ts
@@ -168,6 +168,10 @@ export interface IdsDataGridColumn {
     autoupdate?: boolean;
     /** If the filter type is "contents" lets you set a blank string to a text value (matched by ID) */
     notFilteredItem?: { value: string, label: string }
+    /** For filter type input, sets the text to all upper case when typed */
+    uppercase?: boolean;
+    /** For filter type input, sets the text max lenght when typed */
+    maxlength?: number;
   };
   /** Lets you make a dynamic filter function */
   filterFunction?: any;

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -1069,6 +1069,8 @@ export default class IdsDataGridFilters {
     const placeholder = opt.placeholder ? ` placeholder="${opt.placeholder}"` : '';
     const disabled = opt.disabled ? ' disabled' : '';
     const readonly = opt.readonly ? ' readonly' : '';
+    const maxlength = opt.maxlength ? ` maxlength="${opt.maxlength}"` : '';
+    const uppercase = opt.uppercase ? ` uppercase` : '';
 
     let value = this.#conditions.filter((c: any) => c.columnId === column.id)[0]?.value ?? null;
     this.#initial[column.id] = this.#initial[column.id] || {};
@@ -1087,7 +1089,7 @@ export default class IdsDataGridFilters {
       text-align="${column.align === 'right' ? 'end' : 'start'}"
       no-margins
       compact
-      ${placeholder}${disabled}${readonly}${value}>
+      ${placeholder}${disabled}${readonly}${maxlength}${uppercase}${value}>
     </ids-input>`;
   }
 

--- a/src/components/ids-input/README.md
+++ b/src/components/ids-input/README.md
@@ -143,13 +143,15 @@ setData();
 - `size` {string} set the input size, it will set `md` as defaults.
 - `search-field` when autocomplete is enabled can be set to a string of the field to be searched in the dataset.
 - `revealable-text` {boolean} sets whether the show/hide button is available for password fields must be paired with type='password'
-- `readonly` {boolean} set readonly state.
-- `text-align` {string} set text-align to input, it will set `left` as defaults.
-- `type` {string} set the input type, it will set `text` as defaults.
-- `validate` {string} set the input validation rules, use `space` to add multiple validation rules.
+- `readonly` {boolean} sets the input's readonly state.
+- `text-align` {string} sets the text alignment (default is `left`).
+- `type` {string} set the input type, (default is `text`)
+- `validate` {string} sets the input validation rules, use `space` to add multiple validation rules.
 - `format` {string} if the validation rules include date/time, use the setting to set custom date/time format
 - `validationEvents` {string} set the input validation events, use `space` to add multiple validation rules, it will set `blur` as defaults.
-- `value` {string} set the input value.
+- `value` {string} sets the input value.
+- `maxlength` {number}  sets the input's `maxlength` property to the max characters you can type
+- `uppercase` {boolean} sets the input editor's to all uppercase
 
 ## Keyboard Guidelines
 

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -709,6 +709,10 @@ $input-size-full: 100%;
   }
 }
 
+.is-uppercase {
+  text-transform: uppercase;
+}
+
 .highlight {
   font-weight: var(--ids-font-weight-bold);
 }

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -149,6 +149,7 @@ export default class IdsInput extends Base {
       attributes.FORMAT,
       attributes.ID,
       attributes.LABEL_WRAP,
+      attributes.MAXLENGTH,
       attributes.NO_MARGINS,
       attributes.PADDING,
       attributes.PASSWORD_VISIBLE,
@@ -161,6 +162,7 @@ export default class IdsInput extends Base {
       attributes.TEXT_ALIGN,
       attributes.TEXT_ELLIPSIS,
       attributes.TYPE,
+      attributes.UPPERCASE,
       attributes.VALUE,
     ];
   }
@@ -939,6 +941,42 @@ export default class IdsInput extends Base {
   }
 
   /**
+   * Sets the max width when typing
+   * @param {number | string} n The max length to use
+   */
+  set maxlength(n: number | string) {
+    if (n) {
+      this.setAttribute(attributes.MAXLENGTH, '');
+      this.input?.setAttribute(attributes.MAXLENGTH, n.toString());
+      return;
+    }
+    this.removeAttribute(attributes.MAXLENGTH);
+    this.input?.removeAttribute(attributes.MAXLENGTH);
+  }
+
+  get maxlength(): number {
+    return Number(this.getAttribute(attributes.MAXLENGTH));
+  }
+
+  /**
+   * Sets the text to all upper case
+   * @param {number | string} n If true use upper case
+   */
+  set uppercase(n: boolean | string) {
+    if (stringToBool(n)) {
+      this.setAttribute(attributes.UPPERCASE, '');
+      this.input?.classList.add('is-uppercase');
+      return;
+    }
+    this.removeAttribute(attributes.UPPERCASE);
+    this.input?.classList.remove('is-uppercase');
+  }
+
+  get uppercase(): boolean {
+    return stringToBool(this.getAttribute(attributes.UPPERCASE));
+  }
+
+  /**
    * Sets the no margins attribute
    * @param {boolean | string} n true or false or as a string
    */
@@ -977,6 +1015,14 @@ export default class IdsInput extends Base {
   }
 
   /**
+   * format attribute
+   * @returns {string|null} return date format
+   */
+  get format(): string | null {
+    return this.getAttribute(attributes.FORMAT);
+  }
+
+  /**
    * Overrides the standard "blur" behavior to instead tell the inner HTMLInput element to blur.
    */
   blur(): void {
@@ -988,25 +1034,5 @@ export default class IdsInput extends Base {
    */
   focus(): void {
     this.input?.focus();
-  }
-
-  /**
-   * Set a format to be used in the validation
-   * @param {string|null} val date, time format
-   */
-  set format(val: string | null) {
-    if (val) {
-      this.setAttribute(attributes.FORMAT, val);
-    } else {
-      this.removeAttribute(attributes.FORMAT);
-    }
-  }
-
-  /**
-   * format attribute
-   * @returns {string|null} return date format
-   */
-  get format(): string | null {
-    return this.getAttribute(attributes.FORMAT);
   }
 }

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -473,6 +473,7 @@ export const attributes = {
   TYPE: 'type',
   TYPEAHEAD: 'typeahead',
   UNIQUE_ID: 'unique-id',
+  UPPERCASE: 'uppercase',
   URL: 'url',
   USE_CURRENT_TIME: 'use-current-time',
   USE_DEFAULT_COPYRIGHT: 'use-default-copyright',


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds a setting to filter and editors in datagrid. So that you can use `maxlength` and `uppercase` to limit the text and force it to be uppercase.

**Related github/jira issue (required)**:
Fixes #1309 

**Steps necessary to review your pull request (required)**:

- check docs
- check API in editor.ts example
- go to http://localhost:4300/ids-data-grid/editable.html
- check you can only type 2 chars in the filter
- check you can type lower case chars and it converts to upper in the filter
- check you can only type 2 chars in the editable cell
- check you can type lower case chars and it converts to upper in the editable cell


**Included in this Pull Request**:
- [x] A note to the change log.