### PR TITLE
1367 - Change scrollRowIntoView api

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.14
+
+### 1.0.0-beta.14 Fixes
+
+- `[Datagrid]` Fixed a bug where the parent may scroll into view when using scrollRowIntoView. ([#1371](https://github.com/infor-design/enterprise-wc/issues/1371))
+- `[Datagrid]` Removed the internal second parameter from the scrollRowIntoView so it cant be used. ([#1367](https://github.com/infor-design/enterprise-wc/issues/1367))
+
 ## 1.0.0-beta.13
 
 ### 1.0.0-beta.13 Fixes

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### 1.0.0-beta.14 Fixes
 
-- `[Datagrid]` Fixed a bug where the parent may scroll into view when using scrollRowIntoView. ([#1371](https://github.com/infor-design/enterprise-wc/issues/1371))
 - `[Datagrid]` Removed the internal second parameter from the scrollRowIntoView so it cant be used. ([#1367](https://github.com/infor-design/enterprise-wc/issues/1367))
 
 ## 1.0.0-beta.13

--- a/src/components/ids-data-grid/demos/virtual-scroll-infinite-scroll.html
+++ b/src/components/ids-data-grid/demos/virtual-scroll-infinite-scroll.html
@@ -14,7 +14,6 @@
         <ids-text font-size="12" type="h1">Data Grid (Virtual Scrolling)</ids-text>
       </ids-layout-flex-item>
       <ids-layout-flex-item grow="1" overflow="hidden">
-        <ids-text>Test Text</ids-text>
         <ids-data-grid id="data-grid-1" row-selection="multiple" auto-fit="true" virtual-scroll="true" row-height="xs">
       </ids-layout-flex-item>
     </ids-layout-flex>

--- a/src/components/ids-data-grid/demos/virtual-scroll-infinite-scroll.html
+++ b/src/components/ids-data-grid/demos/virtual-scroll-infinite-scroll.html
@@ -14,6 +14,7 @@
         <ids-text font-size="12" type="h1">Data Grid (Virtual Scrolling)</ids-text>
       </ids-layout-flex-item>
       <ids-layout-flex-item grow="1" overflow="hidden">
+        <ids-text>Test Text</ids-text>
         <ids-data-grid id="data-grid-1" row-selection="multiple" auto-fit="true" virtual-scroll="true" row-height="xs">
       </ids-layout-flex-item>
     </ids-layout-flex>

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1495,7 +1495,6 @@ export default class IdsDataGrid extends Base {
    * @param {number} rowIndex row index
    */
   #scrollTo(rowIndex: number): void {
-    const oldScrollTop = (this.parentElement) ? this.parentElement.scrollTop : 0;
     this.rowByIndex(rowIndex)?.scrollIntoView?.();
     const headerHeight = this.header.clientHeight;
     const scrollHeight = this.container!.scrollHeight;
@@ -1505,7 +1504,6 @@ export default class IdsDataGrid extends Base {
 
     // offset for sticky header height
     if (!isScrollBottom) this.container!.scrollTop -= headerHeight;
-    if (this.parentElement) this.parentElement.scrollTop = oldScrollTop;
   }
 
   /**

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -379,10 +379,10 @@ export default class IdsDataGrid extends Base {
 
           const headerHeight = this.header?.getBoundingClientRect?.().height ?? 0;
           this.container.scrollTop = scrollTopPixels - headerHeight;
-          this.scrollRowIntoView(rowStart);
+          this.#scrollRowIntoView(rowStart);
           requestAnimationTimeout(() => {
             this.#attachVirtualScrollEvent();
-            this.scrollRowIntoView(this.rowStart);
+            this.#scrollRowIntoView(this.rowStart);
           }, 150);
           handleReady();
         }
@@ -1447,7 +1447,7 @@ export default class IdsDataGrid extends Base {
       if (rowIndex === debounceRowIndex) return;
       debounceRowIndex = rowIndex;
 
-      this.scrollRowIntoView(rowIndex, false);
+      this.#scrollRowIntoView(rowIndex, false);
     }, { capture: true, passive: true }); // @see https://javascript.info/bubbling-and-capturing#capturing
   }
 
@@ -1495,39 +1495,24 @@ export default class IdsDataGrid extends Base {
    * @param {number} rowIndex row index
    */
   #scrollTo(rowIndex: number): void {
-    this.rowByIndex(rowIndex)?.scrollIntoView?.();
     const headerHeight = this.header.clientHeight;
-    const scrollHeight = this.container!.scrollHeight;
-    const containerHeight = this.container!.clientHeight;
-    const scrollTop = this.container!.scrollTop;
-    const isScrollBottom = (scrollTop + containerHeight) >= scrollHeight;
-
-    // offset for sticky header height
-    if (!isScrollBottom) this.container!.scrollTop -= headerHeight;
+    this.container!.scrollTop = (this.rowByIndex(rowIndex)?.offsetTop || 0) - headerHeight;
   }
 
   /**
-   * We always want to set doScroll=true when scrollRowIntoView() is called manually in code...
-   * ...so when the "public" uses it they would simply do scrollRowIntoView(x).
-   *
-   * However, this method is also used in the "onscroll" event-handler...
-   * ...within that "onscroll" event-handler, we want doScroll=false,
-   * ...and let the browser handle moving/panning the window without interference.
-   * @param {number} rowIndex - which row to scroll into view.
-   * @param {boolean} doScroll - set to "true" to have the browser perform the scroll action
-   * @see IdsDataGrid.#attachVirtualScrollEvent()
-   * @see https://medium.com/@moshe_31114/building-our-recycle-list-solution-in-react-17a21a9605a0
-   * @see https://dev.to/adamklein/build-your-own-virtual-scroll-part-i-11ib
-   * @see https://dev.to/adamklein/build-your-own-virtual-scroll-part-ii-3j86
-   * @see https://fluffy.es/solve-duplicated-cells
-   * @see https://vaadin.com/docs/latest/components/grid#columns
-   * @see https://www.htmlelements.com/demos/grid/datagrid-bind-to-json
-   * @see https://dev.to/gopal1996/understanding-reflow-and-repaint-in-the-browser-1jbg
-   * @see https://medium.com/teads-engineering/the-most-accurate-way-to-schedule-a-function-in-a-web-browser-eadcd164da12
-   * @see https://javascript.info/bubbling-and-capturing#capturing
-   * @see https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
+   * Scroll a given row into view
+   * @param {number} rowIndex which row to scroll into view.
    */
-  scrollRowIntoView(rowIndex: number, doScroll = true) {
+  scrollRowIntoView(rowIndex: number) {
+    this.#scrollRowIntoView(rowIndex);
+  }
+
+  /**
+   * Scroll a given row into view
+   * @param {number} rowIndex which row to scroll into view.
+   * @param {boolean} doScroll set to "true" to have the browser perform the scroll action
+   */
+  #scrollRowIntoView(rowIndex: number, doScroll = true) {
     if (this.#rafReference) cancelAnimationFrame(this.#rafReference);
 
     const data = this.data;
@@ -2313,7 +2298,7 @@ export default class IdsDataGrid extends Base {
 
     let rowNode = this.rowByIndex(rowIndex);
     if (!rowNode && this.virtualScroll) {
-      this.scrollRowIntoView(rowIndex);
+      this.#scrollRowIntoView(rowIndex);
       rowNode = this.rowByIndex(rowIndex);
     }
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1495,8 +1495,17 @@ export default class IdsDataGrid extends Base {
    * @param {number} rowIndex row index
    */
   #scrollTo(rowIndex: number): void {
+    const oldScrollTop = (this.parentElement) ? this.parentElement.scrollTop : 0;
+    this.rowByIndex(rowIndex)?.scrollIntoView?.();
     const headerHeight = this.header.clientHeight;
-    this.container!.scrollTop = (this.rowByIndex(rowIndex)?.offsetTop || 0) - headerHeight;
+    const scrollHeight = this.container!.scrollHeight;
+    const containerHeight = this.container!.clientHeight;
+    const scrollTop = this.container!.scrollTop;
+    const isScrollBottom = (scrollTop + containerHeight) >= scrollHeight;
+
+    // offset for sticky header height
+    if (!isScrollBottom) this.container!.scrollTop -= headerHeight;
+    if (this.parentElement) this.parentElement.scrollTop = oldScrollTop;
   }
 
   /**

--- a/src/themes/default/ids-theme-default-dark.scss
+++ b/src/themes/default/ids-theme-default-dark.scss
@@ -175,12 +175,13 @@
   // Data Grid (Header)
   --ids-data-grid-header-color-border: var(--ids-color-neutral-80);
   --ids-data-grid-header-color-background-default: var(--ids-color-neutral-20);
+  --ids-data-grid-header-hover-background-color: var(--ids-color-neutral-30);
   --ids-data-grid-header-checkbox-color-border: var(--ids-color-neutral-100);
   --ids-data-grid-header-checkbox-color-background: transparent;
   --ids-data-grid-header-color-icon: var(--ids-color-neutral-100);
   --ids-data-grid-header-color-background-placeholder-dragging: var(--ids-color-neutral-10);
   --ids-data-grid-header-color-text: var(--ids-color-neutral-100);
-  --ids-data-grid-header-color-icon-unsorted: var(--ids-color-neutral-40);
+  --ids-data-grid-header-color-icon-unsorted: var(--ids-color-neutral-50);
   --ids-data-grid-header-color-icon-sorted: var(--ids-color-neutral-100);
   --ids-data-grid-header-expander-color: var(--ids-color-neutral-70);
   --ids-data-grid-header-expander-active-color:  var(--ids-color-neutral-100);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Removes the "internal" second parameter of the `scrollRowIntoView` function. Also spotted an issue in dark mode.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-wc/issues/1367
Fixes https://github.com/infor-design/enterprise-wc/issues/1382

**Steps necessary to review your pull request (required)**:
- review inline code
- notice that `scrollRowIntoView` no longer has in internal second parameter
- test a few examples regarding row start, virtual scroll, infiinite scroll and see it is unaffected
- also go to http://localhost:4300/ids-data-grid/editable.html and change to dark mode, hover the header and it shouldnt be all black as per https://github.com/infor-design/enterprise-wc/issues/1382

**Included in this Pull Request**:
- [x] A note to the change log.
