### PR TITLE
1308 - IdsLayoutGrid content max width

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -57,6 +57,7 @@
 - `[Draggable]` Removed the `ids-` from the event names. ([#1328](https://github.com/infor-design/enterprise-wc/issues/1328))
 - `[Icons]` Added new icons. ([#7510](https://github.com/infor-design/enterprise/issues/7510)
 - `[Locale]` Added new translations. ([#7512](https://github.com/infor-design/enterprise/issues/7512)
+- `[LayoutGrid]` Added support for max-width and centering. ([1308](https://github.com/infor-design/enterprise-wc/issues/1308))
 - `[Themes]` Added theme support and css variables for all components. These can be used for customizing components and creating themes. See ([CUSTOMIZING.md](../doc/CUSTOMIZING.md)) for details. Note that with the `<ids-theme-switcher>` its now better to use the full theme name `<ids-theme-switcher theme="default-light">`. ([#1118](https://github.com/infor-design/enterprise-wc/issues/1118))
 - `[Splitter]` Added new designs and minor fixes. ([#1328](https://github.com/infor-design/enterprise-wc/issues/1328))
 - `[SwapList]` Refactored to use new icons. ([#7511](https://github.com/infor-design/enterprise/issues/7511)

--- a/src/components/ids-layout-grid/README.md
+++ b/src/components/ids-layout-grid/README.md
@@ -37,6 +37,7 @@ The Ids Layout Grid is comprised of 2 web components, IdsLayoutGrid and IdsLayou
 - **Gap**: Specifies the size of the gap between cells in a grid. If not assigned defaults to `md`.
 - **Margin**: Specifies the amount of space between a grid and its outer border.
 - **MarginY**: Specifies the amount of vertical space between a grid and its outer border.
+- **MaxWidth**: Specifies the maximum width of a grid and its outer border. Allows for setting the max-width attribute with predefined values (see Breakpoints) or custom values that end with 'px', providing flexibility for styling and dynamic updates.
 - **Padding**: Specifies the amount of space between a grid content and its inner border.
 - **PaddingX**: Specifies the amount of horizontal space between a grid content and its inner border.
 - **PaddingY**: Specifies the amount of vertical space between a grid and its inner border.
@@ -149,7 +150,35 @@ For AutoFit layout the grid cells in this example have a min/max value of 100px 
 </ids-layout-grid>
 ```
 
-An Ids Layout Grid with a custom number of columns or rows. The example below shows a 4 column grid where the first cell spans 3 columns and the 3rd cell spans 2 rows.
+An Ids Layout Grid with a custom number of columns or rows. The example above shows a 4 column grid where the first cell spans 3 columns and the 3rd cell spans 2 rows.
+
+---
+
+```html
+<ids-layout-grid
+    id="eight-column-grid"
+    cols="8"
+    padding-x="md"
+    justify-content="center"
+    max-width="lg"
+    margin="auto"
+>
+    <ids-layout-grid-cell col-span="1" fill height="176px">
+        <ids-text font-size="12">1 Col</ids-text>
+    </ids-layout-grid-cell>
+    <ids-layout-grid-cell col-span="1" fill height="176px">
+        <ids-text font-size="12">1 Col</ids-text>
+    </ids-layout-grid-cell>
+    <ids-layout-grid-cell col-span="1" fill height="176px">
+        <ids-text font-size="12">1 Col</ids-text>
+    </ids-layout-grid-cell>
+    <ids-layout-grid-cell col-span="1" fill height="176px">
+        <ids-text font-size="12">1 Col</ids-text>
+    </ids-layout-grid-cell>
+</ids-layout-grid>
+```
+
+Above is an example of a contained and centered grid. The max-width attribute is set to "lg", which represents a predefined breakpoint value for the maximum width of the grid. This controls how wide the grid can become. The margin attribute is set to "auto" to horizontally center the entire grid on the page by applying equal left and right margins.
 
 ---
 

--- a/src/components/ids-layout-grid/README.md
+++ b/src/components/ids-layout-grid/README.md
@@ -180,6 +180,9 @@ An Ids Layout Grid with a custom number of columns or rows. The example above sh
 
 Above is an example of a contained and centered grid. The max-width attribute is set to "lg", which represents a predefined breakpoint value for the maximum width of the grid. This controls how wide the grid can become. The margin attribute is set to "auto" to horizontally center the entire grid on the page by applying equal left and right margins.
 
+*Note*:
+The available sizes for maxWidth are based on the current predefined breakpoint sizes. These breakpoint sizes provide convenient options for setting the maximum width of the grid, ensuring responsiveness and compatibility with different screen sizes. However, the maxWidth attribute also allows users to specify a custom width if needed, giving them flexibility in defining the maximum width according to their specific requirements. While custom widths can be used, it is generally recommended to utilize the predefined breakpoint sizes whenever possible for consistency and responsiveness across different devices and viewports.
+
 ---
 
 Examples of grid with responsive col-spans

--- a/src/components/ids-layout-grid/demos/example.html
+++ b/src/components/ids-layout-grid/demos/example.html
@@ -410,6 +410,88 @@
           <ids-text font-size="12">16 Col</ids-text>
         </ids-layout-grid-cell>
       </ids-layout-grid>
+
+      <ids-layout-grid
+        auto-fit="true"
+        padding="md"
+      >
+        <ids-layout-grid-cell>
+          <ids-text font-size="12" type="h1">Contained Grid (margin auto)</ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+
+      <ids-layout-grid
+        id="eight-column-grid"
+        cols="8"
+        padding-x="md"
+        justify-content="center"
+        max-width="lg"
+        margin="auto"
+      >
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="4" fill height="176px">
+          <ids-text font-size="12">4 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="4" fill height="176px">
+          <ids-text font-size="12">4 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="5" fill height="176px">
+          <ids-text font-size="12">5 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="3" fill height="176px">
+          <ids-text font-size="12">3 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="6" fill height="176px">
+          <ids-text font-size="12">6 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="7" fill height="176px">
+          <ids-text font-size="12">7 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="8" fill height="176px">
+          <ids-text font-size="12">8 Col</ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
     </ids-container>
   </body>
 </html>

--- a/src/components/ids-layout-grid/ids-layout-grid-common.ts
+++ b/src/components/ids-layout-grid/ids-layout-grid-common.ts
@@ -23,6 +23,7 @@ export const GRID_ATTRIBUTES: string[] = [
   attributes.MIN_COL_WIDTH,
   attributes.MAX_ROW_HEIGHT,
   attributes.MIN_ROW_HEIGHT,
+  attributes.MAX_WIDTH,
   attributes.PADDING,
   attributes.PADDING_X,
   attributes.PADDING_Y,
@@ -87,8 +88,9 @@ export type IdsGapType = undefined | 'none' | 'sm' | 'md' | 'lg' | 'xl';
 export type IdsJustifyType = undefined | 'space-around' | 'space-between' | 'center' | 'end' | 'space-evenly' | 'start';
 export type IdsFlowType = undefined | 'row' | 'column' | 'dense' | 'row-dense' | 'column-dense';
 export type IdsGridAlignItems = 'start' | 'end' | 'center' | 'stretch';
-export type IdsGridMargins = undefined | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type IdsGridMargins = undefined | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'auto';
 export type IdsGridPadding = undefined | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type IdsMaxWidth = undefined | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | string;
 
 export const GAP_TYPES: Array<IdsGapType> = [
   undefined,
@@ -131,7 +133,8 @@ export const MARGIN_SIZES: Array<IdsGridMargins> = [
   'sm',
   'md',
   'lg',
-  'xl'
+  'xl',
+  'auto'
 ];
 
 export const PADDING_SIZES: Array<IdsGridPadding | any> = [
@@ -142,4 +145,14 @@ export const PADDING_SIZES: Array<IdsGridPadding | any> = [
   'md',
   'lg',
   'xl'
+];
+
+export const MAX_WIDTH_SIZES: Array<IdsMaxWidth | any> = [
+  undefined,
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  'xxl'
 ];

--- a/src/components/ids-layout-grid/ids-layout-grid.scss
+++ b/src/components/ids-layout-grid/ids-layout-grid.scss
@@ -36,6 +36,7 @@ $min-col-width: var(--min-col-width);
 $max-col-width: var(--max-col-width);
 $min-row-height: var(--min-row-height);
 $max-row-height: var(--max-row-height);
+$max-width: var(--max-width);
 
 :host(.#{$prefix}),
 .#{$prefix} {
@@ -95,6 +96,11 @@ $max-row-height: var(--max-row-height);
   margin: $grid-margin-xl;
 }
 
+:host([margin='auto']),
+.#{$prefix}.#{$prefix}-margin-auto {
+  margin: auto;
+}
+
 :host([margin-y='xs']),
 .#{$prefix}.#{$prefix}-margin-y-xs {
   margin-block: $grid-margin-xs;
@@ -118,6 +124,40 @@ $max-row-height: var(--max-row-height);
 :host([margin-y='xl']),
 .#{$prefix}.#{$prefix}-margin-y-xl {
   margin-block: $grid-margin-xl;
+}
+
+:host([max-width='xs']),
+.#{$prefix}.#{$prefix}-max-width-xs {
+  max-width: $breakpoint-xs;
+}
+
+:host([max-width='sm']),
+.#{$prefix}.#{$prefix}-max-width-sm {
+  max-width: $breakpoint-sm;
+}
+
+:host([max-width='md']),
+.#{$prefix}.#{$prefix}-max-width-md {
+  max-width: $breakpoint-md;
+}
+
+:host([max-width='lg']),
+.#{$prefix}.#{$prefix}-max-width-lg {
+  max-width: $breakpoint-lg;
+}
+
+:host([max-width='xl']),
+.#{$prefix}.#{$prefix}-max-width-xl {
+  max-width: $breakpoint-xl;
+}
+
+:host([max-width='xxl']),
+.#{$prefix}.#{$prefix}-max-width-xxl {
+  max-width: $breakpoint-xxl;
+}
+
+:host([max-width$='px']) {
+  max-width: var(--max-width);
 }
 
 :host([padding='xs']),

--- a/src/components/ids-layout-grid/ids-layout-grid.ts
+++ b/src/components/ids-layout-grid/ids-layout-grid.ts
@@ -11,6 +11,7 @@ import {
   GAP_TYPES,
   FLOW_TYPES,
   MARGIN_SIZES,
+  MAX_WIDTH_SIZES,
   PADDING_SIZES,
   prefix
 } from './ids-layout-grid-common';
@@ -347,7 +348,7 @@ export default class IdsLayoutGrid extends IdsElement {
 
   /**
    * Set the margin attribute
-   * @param {string | null} value The value of the margin [null, 'sm', 'md', 'lg', 'xl']
+   * @param {string | null} value The value of the margin [null, 'sm', 'md', 'lg', 'xl', 'auto']
    */
   set margin(value: string | null) {
     if (!value || MARGIN_SIZES.indexOf(value as any) <= 0) {
@@ -380,6 +381,23 @@ export default class IdsLayoutGrid extends IdsElement {
    * @returns {string | null} The number value that represents the margin of the grid
    */
   get marginY(): string | null { return this.getAttribute(attributes.MARGIN_Y); }
+
+  set maxWidth(value: string | null) {
+    if (!value || MAX_WIDTH_SIZES.indexOf(value as any) <= 0) {
+      this.removeAttribute(attributes.MAX_WIDTH);
+
+      // If custom value is set use custom property
+      if (value?.endsWith('px')) {
+        this.style.setProperty('--max-width', value);
+        this.setAttribute(attributes.MAX_WIDTH, value);
+      }
+    } else {
+      this.setAttribute(attributes.MAX_WIDTH, value);
+      this.style.removeProperty('--max-width');
+    }
+  }
+
+  get maxWidth(): string | null { return this.getAttribute(attributes.MAX_WIDTH); }
 
   /**
    * Set the padding attribute

--- a/src/components/ids-layout-grid/ids-layout-grid.ts
+++ b/src/components/ids-layout-grid/ids-layout-grid.ts
@@ -382,6 +382,10 @@ export default class IdsLayoutGrid extends IdsElement {
    */
   get marginY(): string | null { return this.getAttribute(attributes.MARGIN_Y); }
 
+  /**
+   * Set the maxWidth attribute
+   * @param {string | null} value The value of the max-width [null, 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '###px']
+   */
   set maxWidth(value: string | null) {
     if (!value || MAX_WIDTH_SIZES.indexOf(value as any) <= 0) {
       this.removeAttribute(attributes.MAX_WIDTH);
@@ -397,6 +401,10 @@ export default class IdsLayoutGrid extends IdsElement {
     }
   }
 
+  /**
+   * Get the maxWidth attribute
+   * @returns {string | null} The value that represents the maxWidth of the grid
+   */
   get maxWidth(): string | null { return this.getAttribute(attributes.MAX_WIDTH); }
 
   /**

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -260,6 +260,7 @@ export const attributes = {
   MAX_ROW_HEIGHT: 'max-row-height',
   MAX_TRANSFORM_X: 'max-transform-x',
   MAX_TRANSFORM_Y: 'max-transform-y',
+  MAX_WIDTH: 'max-width',
   MENU: 'menu',
   MENU_ID: 'menu-id',
   MESSAGE: 'message',


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds the ability to set a maximum width on the `ids-layout-grid`.  The available sizes for `maxWidth` are based on the current predefined breakpoint sizes. However, the `maxWidth` attribute also allows users to specify a custom width if needed, giving them flexibility in defining the maximum width according to their specific requirements. While custom widths can be used, it is generally recommended to utilize the predefined breakpoint sizes whenever possible for consistency and responsiveness across different devices and viewports.

**Related github/jira issue (required)**:
closes #1308 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- go to http://localhost:4300/ids-layout-grid/example.html
- Scroll to bottom and see contained grid example

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
