### PR TITLE
1372 - IdsScrollView control nav buttons missing

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[DataGrid]` Add ability to multi select with shift key. ([#1330](https://github.com/infor-design/enterprise-wc/issues/1330))
 - `[DataGrid]` Fix tree not selecting or collapsing all children in AngularJS. ([#1284](https://github.com/infor-design/enterprise-wc/issues/1284))
 - `[DataGrid]` Fix tree collapse/expand state while sorting. ([#1284](https://github.com/infor-design/enterprise-wc/issues/1284))
+- `[ScrollView]` Fix scroll view to observe slot changes. ([#1372](https://github.com/infor-design/enterprise/issues/1372))
 - `[Tooltip]` Changed the tooltip heights to match. ([#7509](https://github.com/infor-design/enterprise/issues/7509))
 - `[Themes]` Added theme switcher to side-by-side examples and ability to switch 4.x themes in the `ids-theme-switcher `component. ([#939](https://github.com/infor-design/enterprise-wc/issues/939))
 - `[DataGrid]` Fixed a bug in the filter header where text selection in the inputs would cause accidental dragging. ([#1321](https://github.com/infor-design/enterprise-wc/issues/1321))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Datagrid]` Removed the internal second parameter from the scrollRowIntoView so it cant be used. ([#1367](https://github.com/infor-design/enterprise-wc/issues/1367))
 - `[DataGrid]` Added `uppercase` and `maxlength` settings to editors and filters (text only). ([#1309](https://github.com/infor-design/enterprise-wc/issues/1309))
 - `[DataGrid]` Adds guards to Datagrid's `this.header` value because it is being referenced in some places before it is loaded in DOM. ([#1250](https://github.com/infor-design/enterprise-wc/issues/1250))
+- `[ScrollView]` Fix scroll view to observe slot changes. ([#1372](https://github.com/infor-design/enterprise/issues/1372))
 
 ## 1.0.0-beta.13
 
@@ -26,7 +27,6 @@
 - `[DataGrid]` Add ability to multi select with shift key. ([#1330](https://github.com/infor-design/enterprise-wc/issues/1330))
 - `[DataGrid]` Fix tree not selecting or collapsing all children in AngularJS. ([#1284](https://github.com/infor-design/enterprise-wc/issues/1284))
 - `[DataGrid]` Fix tree collapse/expand state while sorting. ([#1284](https://github.com/infor-design/enterprise-wc/issues/1284))
-- `[ScrollView]` Fix scroll view to observe slot changes. ([#1372](https://github.com/infor-design/enterprise/issues/1372))
 - `[Tooltip]` Changed the tooltip heights to match. ([#7509](https://github.com/infor-design/enterprise/issues/7509))
 - `[Themes]` Added theme switcher to side-by-side examples and ability to switch 4.x themes in the `ids-theme-switcher `component. ([#939](https://github.com/infor-design/enterprise-wc/issues/939))
 - `[DataGrid]` Fixed a bug in the filter header where text selection in the inputs would cause accidental dragging. ([#1321](https://github.com/infor-design/enterprise-wc/issues/1321))

--- a/src/components/ids-scroll-view/ids-scroll-view.ts
+++ b/src/components/ids-scroll-view/ids-scroll-view.ts
@@ -295,18 +295,20 @@ export default class IdsScrollView extends Base {
    * @returns {void}
    */
   #renderCircleButtons(): void {
+    let controlButtons = '';
     this.querySelectorAll('[slot]').forEach((item, i) => {
       const cssClass = ` class="circle-button${i === 0 ? ' selected' : ''}"`;
       const ariaSelected = i === 0 ? ' aria-selected="true"' : '';
       const label = item.getAttribute('label') || item.getAttribute('alt') || '';
       const tooltip = this.showTooltip ? `tooltip="${label}"` : '';
 
-      this.controls?.insertAdjacentHTML('beforeend', `
-        <ids-button data-slide-number="${i}" part="button" exportparts="button: scroll-view-button" role="tab"${cssClass}${ariaSelected}${tooltip}>
-          <ids-icon icon="filter-not-selected"></ids-icon>
-          <span class="audible">${label}</span>
-        </ids-button>`);
+      controlButtons += `<ids-button data-slide-number="${i}" part="button" exportparts="button: scroll-view-button" role="tab"${cssClass}${ariaSelected}${tooltip}>
+        <ids-icon icon="filter-not-selected"></ids-icon>
+        <span class="audible">${label}</span>
+      </ids-button>`;
     });
+
+    if (this.controls) this.controls.innerHTML = controlButtons;
   }
 
   /**
@@ -365,6 +367,10 @@ export default class IdsScrollView extends Base {
         e.stopPropagation();
       }
     });
+
+    const itemSlot = this.container?.querySelector(`slot[name="scroll-view-item"]`);
+    this.offEvent('click.scrollview', itemSlot);
+    this.onEvent('slotchange', itemSlot, () => this.#renderCircleButtons());
 
     // Handle scroll-end, after snap scrolling event is complete
     // https://stackoverflow.com/a/66029649

--- a/src/components/ids-scroll-view/ids-scroll-view.ts
+++ b/src/components/ids-scroll-view/ids-scroll-view.ts
@@ -73,8 +73,7 @@ export default class IdsScrollView extends Base {
       <div class="ids-scroll-view" part="scroll-view" role="complementary" tabindex="-1">
         <slot name="scroll-view-item"></slot>
       </div>
-      <div class="${controlsClass}" part="controls" role="tablist">
-      </div>
+      <div class="${controlsClass}" part="controls" role="tablist"></div>
     </div>`;
   }
 
@@ -295,20 +294,20 @@ export default class IdsScrollView extends Base {
    * @returns {void}
    */
   #renderCircleButtons(): void {
-    let controlButtons = '';
+    if (this.controls) this.controls.innerHTML = '';
+
     this.querySelectorAll('[slot]').forEach((item, i) => {
       const cssClass = ` class="circle-button${i === 0 ? ' selected' : ''}"`;
       const ariaSelected = i === 0 ? ' aria-selected="true"' : '';
       const label = item.getAttribute('label') || item.getAttribute('alt') || '';
       const tooltip = this.showTooltip ? `tooltip="${label}"` : '';
 
-      controlButtons += `<ids-button data-slide-number="${i}" part="button" exportparts="button: scroll-view-button" role="tab"${cssClass}${ariaSelected}${tooltip}>
-        <ids-icon icon="filter-not-selected"></ids-icon>
-        <span class="audible">${label}</span>
-      </ids-button>`;
+      this.controls?.insertAdjacentHTML('beforeend', `
+        <ids-button data-slide-number="${i}" part="button" exportparts="button: scroll-view-button" role="tab"${cssClass}${ariaSelected}${tooltip}>
+          <ids-icon icon="filter-not-selected"></ids-icon>
+          <span class="audible">${label}</span>
+        </ids-button>`);
     });
-
-    if (this.controls) this.controls.innerHTML = controlButtons;
   }
 
   /**

--- a/test/ids-scroll-view/ids-scroll-view-func-test.ts
+++ b/test/ids-scroll-view/ids-scroll-view-func-test.ts
@@ -4,6 +4,7 @@
 import { attributes } from '../../src/core/ids-attributes';
 import IdsScrollView from '../../src/components/ids-scroll-view/ids-scroll-view';
 import IntersectionObserver from '../helpers/intersection-observer-mock';
+import wait from '../helpers/wait';
 
 describe('IdsScrollView Component', () => {
   let scrollView: any;
@@ -118,6 +119,15 @@ describe('IdsScrollView Component', () => {
     const link = scrollView.controls.querySelector('[data-slide-number="0"]');
     expect(link.classList.contains('selected')).toBeTruthy();
     expect(link.getAttribute('aria-selected')).toEqual('true');
+  });
+
+  it('should rerender controls based on slotchange events', async () => {
+    document.body.innerHTML = '';
+    const elem = new IdsScrollView();
+    document.body.appendChild(elem);
+    elem.innerHTML = html;
+    await wait(1000);
+    expect(elem.controls?.querySelectorAll('ids-button.circle-button').length).toEqual(6);
   });
 
   it('moved on ArrowLeft/ArrowRight', () => {

--- a/test/ids-scroll-view/ids-scroll-view-func-test.ts.snap
+++ b/test/ids-scroll-view/ids-scroll-view-func-test.ts.snap
@@ -6,7 +6,6 @@ exports[`IdsScrollView Component renders correctly 1`] = `
         <slot name="scroll-view-item"></slot>
       </div>
       <div class="ids-scroll-view-controls" part="controls" role="tablist">
-      
         <ids-button data-slide-number="0" part="button" exportparts="button: scroll-view-button" role="tab" class="circle-button selected" aria-selected="true">
           <ids-icon icon="filter-not-selected"></ids-icon>
           <span class="audible">Slide 1, Sony Camera, Front</span>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
IdsScrollView wasn't showing control nav buttons when image elements are inserted using ngFor.
Fix was to make IdsScrollView listen for slotchanges to update control nav buttons accordingly.

**Related github/jira issue (required)**:
Fixes #1372 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, `npm rinstall`, `npm run start`
2. Go to http://localhost:4300/ids-scroll-view/example.html
3. Try removing some image elements from the DOM through dev tools
4. Navigation Buttons (circle icons) should update and reflect correct number of slotted elements left
5. Run `$('ids-scroll-view').insertAdjacentHTML('afterbegin', '<img class="camera-2" slot="scroll-view-item" alt="Slide 2, Sony Camera, Back Display" src="/src/assets/images/camera-2.png">');`
6. Scroll View should add 1 new image and 1 extra nav button

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

