### PR TITLE
1266 - datagrid expandable-row-template child-level data props

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[DataGrid]` Adds guards to Datagrid's `this.header` value because it is being referenced in some places before it is loaded in DOM. ([#1250](https://github.com/infor-design/enterprise-wc/issues/1250))
 - `[DataGrid]` Adjusted header cell height for xxs row size. ([#1369](https://github.com/infor-design/enterprise-wc/issues/1369))
 - `[DataGrid]` Adjusted header cell height for `xxs` row size. ([#1369](https://github.com/infor-design/enterprise-wc/issues/1369))
+- `[DataGrid]` Fixed child-level data props when using `expandable-row-template` option. ([#1266](https://github.com/infor-design/enterprise-wc/issues/1266))
 - `[DataGrid]` Fixed an issue with the newer `maxlength` setting as it was not working in safari. ([#1403](https://github.com/infor-design/enterprise-wc/issues/1403))
 - `[LayoutGrid]` Added breakpoint sizes for the flow attribute in the grid-layout. ([#1405](https://github.com/infor-design/enterprise-wc/issues/1405))
 - `[ListView]` Added support for `ids-list-view-item` child component. ([#1042](https://github.com/infor-design/enterprise-wc/issues/1042))

--- a/src/assets/data/books.json
+++ b/src/assets/data/books.json
@@ -20,7 +20,14 @@
     "publishDate": "2021-04-23T18:25:43.511Z",
     "price": "12.99",
     "location": "United States",
-    "color": "#165eab"
+    "color": "#165eab",
+    "children":{
+      "prop1": "row1_childprop1",
+      "prop2": "row1_childprop2",
+      "prop3": {
+        "info": "row1_childprop3_info"
+      }
+    }
   },
   {
     "book": 102,

--- a/src/components/ids-data-grid/demos/expandable-row.html
+++ b/src/components/ids-data-grid/demos/expandable-row.html
@@ -26,6 +26,8 @@
               </ids-layout-grid>
               <ids-layout-grid auto-fit="true" padding-x="md">
                 <ids-text font-size="14" type="span">Lorem Ipsum is simply sample text of the printing and typesetting industry. Lorem Ipsum has been the industry standard sample text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only...</ids-text>
+                <ids-text font-size="14" type="span">${children.prop1}</ids-text>
+                <ids-text font-size="14" type="span">${children.prop3.info}</ids-text>
               </ids-layout-grid>
             </template>
         </ids-data-grid>

--- a/src/utils/ids-string-utils/ids-string-utils.ts
+++ b/src/utils/ids-string-utils/ids-string-utils.ts
@@ -68,7 +68,18 @@ export function stringToNumber(val?: string | number | any): number {
  */
 export function injectTemplate(str: string, obj: any): string {
   // Replace all other keys with data
-  return str.replace(/\${(.*?)}/g, (_x, g) => (obj[g] === undefined ? '&nbsp;' : obj[g]));
+  return str.replace(/\${(.*?)}/g, (_x, g) => {
+    let value = obj[g];
+    if (value !== undefined) return value;
+
+    if (g.includes('.')) {
+      const path = g.split('.');
+      path.forEach((key: string) => {
+        value = value?.[key] ?? obj[key];
+      });
+    }
+    return value ?? '&nbsp;';
+  });
 }
 
 /**

--- a/test/core/ids-string-utils-func-test.ts
+++ b/test/core/ids-string-utils-func-test.ts
@@ -45,6 +45,16 @@ describe('IdsStringUtils Tests', () => {
     const template = 'Test String <b>${field}</b>'; //eslint-disable-line
 
     expect(injectTemplate(template, obj)).toEqual('Test String <b>test-value</b>');
+
+    const obj2: any = { field: { depth1: 'test-value-depth-1' } };
+    const template2 = 'Test String <b>${field.depth1}</b>'; //eslint-disable-line
+
+    expect(injectTemplate(template2, obj2)).toEqual('Test String <b>test-value-depth-1</b>');
+
+    const obj3: any = { field: { depth1: { depth2: 'test-value-depth-2' } } };
+    const template3 = 'Test String <b>${field.depth1.depth2}</b>'; //eslint-disable-line
+
+    expect(injectTemplate(template3, obj3)).toEqual('Test String <b>test-value-depth-2</b>');
   });
 
   it('can test if a character is printable', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

When using the `expandable-row-template` option on `ids-data-grid`, child-level properties were not getting populated in the expandable row, and instead were showing as `undefined`. 

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1266  

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. Check out branch and run: `nvm use && npm run start`
2. Go to: http://localhost:4300/ids-data-grid/expandable-row.html
3. Expand first row and ensure it shows `row1_childprop1` (for `${children.prop1}`)
4. Expand first row and ensure it shows `row1_childprop3_info` for `${children.prop3.info}`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
