### PR TITLE
1304 - Added before row selected events

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## 1.0.0-beta.14
 
+### 1.0.0-beta.14 Features
+
+- `[DataGrid]` Added a `beforerowselected` and `beforeredeselected` event that can be vetoed to both lookup and datagrid. ([#1304](https://github.com/infor-design/enterprise-wc/issues/1304))
+
 ### 1.0.0-beta.14 Fixes
 
 - `[Button]` Fixed mismatch on secondary and primary button (internal) height. ([#1376](https://github.com/infor-design/enterprise/issues/1376))
 - `[Datagrid]` Removed the internal second parameter from the scrollRowIntoView so it cant be used. ([#1367](https://github.com/infor-design/enterprise-wc/issues/1367))
 - `[DataGrid]` Added `uppercase` and `maxlength` settings to editors and filters (text only). ([#1309](https://github.com/infor-design/enterprise-wc/issues/1309))
 - `[DataGrid]` Adds guards to Datagrid's `this.header` value because it is being referenced in some places before it is loaded in DOM. ([#1250](https://github.com/infor-design/enterprise-wc/issues/1250))
-- `[DataGrid]` Adjusted header cell height for xxs row size. ([#1369](https://github.com/infor-design/enterprise-wc/issues/1369))
 - `[DataGrid]` Adjusted header cell height for `xxs` row size. ([#1369](https://github.com/infor-design/enterprise-wc/issues/1369))
 - `[DataGrid]` Fixed an issue with the newer `maxlength` setting as it was not working in safari. ([#1403](https://github.com/infor-design/enterprise-wc/issues/1403))
 - `[LayoutGrid]` Added breakpoint sizes for the flow attribute in the grid-layout. ([#1405](https://github.com/infor-design/enterprise-wc/issues/1405))

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -102,6 +102,14 @@ Here is a code example for multi select
 ```
 
 ```js
+  dataGrid.addEventListener('beforerowselected', (e: Event) => {
+    console.info(`Before Row Selected`, (<CustomEvent>e).detail);
+    if (Number((e as any).detail.data.book) === 104) {
+      console.error('Row 104 randomly cant be selected');
+      (<CustomEvent>e).detail.response(false);
+    }
+  });
+
   dataGrid.addEventListener('rowselected', (e) => {
     console.info(`Row Selected`, e.detail);
   });
@@ -470,7 +478,9 @@ The formatter is then linked via the column on the formatter setting. When the g
 - `sorted` Fires when the sort column is changed.
 - `selectionchanged` Fires any time the selection changes.
 - `activationchanged` Fires any time the active row changes.
+- `beforerowselected` Fires before each row is selected. You can veto the selection by returning false in the event response for example `e.detail.response(false);`
 - `rowselected` Fires for each row that is selected.
+- `beforerowdeselected` Fires before each row is deselected. You can veto the deselection by returning false in the event response for example `e.detail.response(false);`
 - `rowdeselected` Fires for each row that is deselected.
 - `rowactivated` Fires for each row that is activated.
 - `rowdeactivated` Fires for each row that is deactivated.

--- a/src/components/ids-data-grid/demos/single-selection.ts
+++ b/src/components/ids-data-grid/demos/single-selection.ts
@@ -133,6 +133,14 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-single-select')
   setData();
 
   // Event Handlers
+  dataGrid.addEventListener('beforerowselected', (e: Event) => {
+    console.info(`Before Row Selected`, (<CustomEvent>e).detail);
+    if (Number((e as any).detail.data.book) === 104) {
+      console.error('Row 104 randomly cant be selected');
+      (<CustomEvent>e).detail.response(false);
+    }
+  });
+
   dataGrid.addEventListener('rowselected', (e: Event) => {
     console.info(`Row Selected`, (<CustomEvent>e).detail);
   });

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -2042,6 +2042,21 @@ export default class IdsDataGrid extends Base {
 
     if (!row || row.selected) return;
 
+    let canSelect = true;
+    const response = (veto: any) => {
+      canSelect = !!veto;
+    };
+
+    this.triggerEvent('beforerowselected', this, {
+      detail: {
+        elem: this, row, data: this.data[index], response
+      }
+    });
+
+    if (!canSelect) {
+      return;
+    }
+
     if (this.rowSelection === 'multiple' || this.rowSelection === 'mixed') {
       const checkbox = row?.querySelector('.is-selection-checkbox .ids-data-grid-checkbox');
       checkbox?.classList.add('checked');
@@ -2089,6 +2104,21 @@ export default class IdsDataGrid extends Base {
     }
 
     if (!row) return;
+
+    let canDeselect = true;
+    const response = (veto: any) => {
+      canDeselect = !!veto;
+    };
+
+    this.triggerEvent('rowdeselected', this, {
+      detail: {
+        elem: this, row, data: this.data[index], response
+      }
+    });
+
+    if (!canDeselect) {
+      return;
+    }
 
     if (this.rowSelection === 'mixed') {
       row.classList.remove('mixed');

--- a/src/components/ids-lookup/ids-lookup.ts
+++ b/src/components/ids-lookup/ids-lookup.ts
@@ -616,8 +616,16 @@ export default class IdsLookup extends Base {
     }) as EventListener);
 
     // Propagate a few events to the parent
+    this.dataGrid?.addEventListener('beforerowselected', ((e: CustomEvent) => {
+      this.triggerEvent('beforerowselected', this, { detail: e.detail });
+    }) as EventListener);
+
     this.dataGrid?.addEventListener('rowselected', ((e: CustomEvent) => {
       this.triggerEvent('rowselected', this, { detail: e.detail });
+    }) as EventListener);
+
+    this.dataGrid?.addEventListener('beforerowdeselected', ((e: CustomEvent) => {
+      this.triggerEvent('beforerowdeselected', this, { detail: e.detail });
     }) as EventListener);
 
     this.dataGrid?.addEventListener('rowdeselected', ((e: CustomEvent) => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds a vetoable `beforerowselected` and matching `beforerowdeselected` event to datagrid. Also put this in lookup as it uses datagrid.

Note: Will add tests when #1225 is done

**Related github/jira issue (required)**:
Fixes #1304 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-data-grid/single-selection.html
- click on row 104 -> note message in console and the row selection is vetoed
- click other rows -> note that it fires the event but the row is allowed to select

**Included in this Pull Request**:
- [x] A note to the change log.