### PR TITLE
1396 - IdsDataGrid scrollend when zoomed

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Box]` Added new Box component. ([#1327](https://github.com/infor-design/enterprise/issues/1327))
 - `[Cards/Widget/Box]` Separated the card component into a box, widget and card component, features moved around in each. ([#1327](https://github.com/infor-design/enterprise/issues/1327))
+- `[DataGrid]` Fix scrollend event triggering in different zoom levels. ([#1396](https://github.com/infor-design/enterprise/issues/1396))
 - `[Stats]` Added new Stats component. ([#1326](https://github.com/infor-design/enterprise/issues/1326))
 - `[Widget]` Added new Widget component. ([#1327](https://github.com/infor-design/enterprise/issues/1327))
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1391,14 +1391,12 @@ export default class IdsDataGrid extends Base {
     this.offEvent('scroll.data-grid', this.container);
     this.onEvent('scroll.data-grid', this.container, () => {
       const scrollTop = this.container!.scrollTop;
-      const containerHeight = this.container!.clientHeight;
       const virtualRowHeight = virtualScrollSettings.ROW_HEIGHT + 1;
       const rowIndex = Math.floor(scrollTop / virtualRowHeight);
       const rows = this.rows;
-      const maxHeight = this.#containerMaxHeight;
 
       const reachedTheTop = rowIndex <= 0;
-      const reachedTheBottom = (scrollTop + containerHeight) >= maxHeight;
+      const reachedTheBottom = this.container!.offsetHeight + this.container!.scrollTop >= this.container!.scrollHeight;
 
       if (reachedTheTop) {
         const firstRow: any = rows[0];


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fix bug where scrollend event wasn't triggering when page is zoomed

**Related github/jira issue (required)**:
#1396 

**Steps necessary to review your pull request (required)**:
1) Go to http://localhost:4300/ids-data-grid/virtual-scroll-infinite-scroll-m3.html
2) Zoom page in to 110% and all the way down to trigger infinite scroll
3) Test different zoom levels

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
