### PR TITLE
1425 - tree-grid appendData was breaking rendering of existing rows

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[DataGrid]` Fixes scroll jumping in virtual/infinite scroll. ([#1390](https://github.com/infor-design/enterprise-wc/issues/1390))
 - `[DataGrid]` Fix scrollend event triggering in different zoom levels. ([#1396](https://github.com/infor-design/enterprise-wc/issues/1396))
 - `[DataGrid]` Added a `beforerowselected` and `beforeredeselected` event that can be vetoed to both lookup and datagrid. ([#1304](https://github.com/infor-design/enterprise-wc/issues/1304))
+- `[DataGrid]` Treegrid `appendData()` no longer breaks rendering of existing rows, and `scrollend` triggers properly. ([#1425](https://github.com/infor-design/enterprise-wc/issues/1425))
 - `[DropDown/DropDownList]` Add `showListItemIcon` setting for Module Nav component. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))
 - `[Input]` Adds `module-nav` color variant. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))
 - `[Popup]` Adds `module-nav` type. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.15 Features
 
+- `[DataGrid]` Treegrid `appendData()` no longer breaks rendering of existing rows, and `scrollend` triggers properly. ([#1425](https://github.com/infor-design/enterprise-wc/issues/1425))
 - `[Message]` Fix modal button separator. ([#1414](https://github.com/infor-design/enterprise-wc/issues/1414))
 - `[ModuleNav]` Added IdsModuleNav component with basic Role Switcher, Settings component. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))
 
@@ -19,7 +20,6 @@
 - `[DataGrid]` Fixes scroll jumping in virtual/infinite scroll. ([#1390](https://github.com/infor-design/enterprise-wc/issues/1390))
 - `[DataGrid]` Fix scrollend event triggering in different zoom levels. ([#1396](https://github.com/infor-design/enterprise-wc/issues/1396))
 - `[DataGrid]` Added a `beforerowselected` and `beforeredeselected` event that can be vetoed to both lookup and datagrid. ([#1304](https://github.com/infor-design/enterprise-wc/issues/1304))
-- `[DataGrid]` Treegrid `appendData()` no longer breaks rendering of existing rows, and `scrollend` triggers properly. ([#1425](https://github.com/infor-design/enterprise-wc/issues/1425))
 - `[DropDown/DropDownList]` Add `showListItemIcon` setting for Module Nav component. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))
 - `[Input]` Adds `module-nav` color variant. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))
 - `[Popup]` Adds `module-nav` type. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -179,6 +179,9 @@
   - link: tree-grid-virtual-scroll.html
     type: Example
     description: Shows a tree with virtual scrolling
+  - link: tree-grid-virtual-scroll-infinite-scroll.html
+    type: Example
+    description: Shows a tree with virtual and infinite scrolling
   - link: tree-grid-expand-collapse.html
     type: Example
     description: Shows a tree with expand and collapse rows

--- a/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.html
+++ b/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="16" hidden>
+    <ids-layout-flex direction="column" gap="8" full-height>
+      <ids-layout-flex-item>
+        <ids-theme-switcher mode="light"></ids-theme-switcher>
+      </ids-layout-flex-item>
+      <ids-layout-flex-item>
+        <ids-text font-size="12" type="h1">Tree Grid (Virtual Scrolling)</ids-text>
+      </ids-layout-flex-item>
+      <ids-layout-flex-item grow="1" overflow="hidden">
+        <ids-data-grid id="tree-grid-virtual-scroll" suppress-tooltips="true" row-selection="multiple" tree-grid="true" auto-fit="true" virtual-scroll="true" row-height="md">
+        </ids-data-grid>
+      </ids-layout-flex-item>
+    </ids-layout-flex>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.ts
+++ b/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.ts
@@ -1,0 +1,131 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+import treeLargeJSON from '../../../assets/data/tree-large.json';
+import '../../ids-layout-flex/ids-layout-flex';
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#tree-grid-virtual-scroll')!;
+
+// Do an ajax request
+const url: any = treeLargeJSON;
+const columns: IdsDataGridColumn[] = [];
+let currentId = 1000;
+// Set up columns
+columns.push({
+  id: 'selectionCheckbox',
+  name: 'selection',
+  sortable: false,
+  resizable: false,
+  formatter: dataGrid.formatters.selectionCheckbox,
+  align: 'center',
+  frozen: 'left'
+});
+columns.push({
+  id: 'name',
+  name: 'Name',
+  field: 'name',
+  sortable: true,
+  resizable: true,
+  formatter: dataGrid.formatters.tree,
+  click: (info: any) => {
+    console.info('Tree Expander Clicked', info);
+  },
+  width: 220,
+  frozen: 'left'
+});
+columns.push({
+  id: 'rowNumber',
+  name: '#',
+  formatter: dataGrid.formatters.rowNumber,
+  sortable: false,
+  readonly: true,
+  width: 66
+});
+
+columns.push({
+  id: 'id',
+  name: 'Id',
+  field: 'id',
+  sortable: true,
+  resizable: true,
+  formatter: dataGrid.formatters.text
+});
+columns.push({
+  id: 'location',
+  name: 'Location',
+  field: 'location',
+  sortable: true,
+  resizable: true,
+  formatter: dataGrid.formatters.text
+});
+columns.push({
+  id: 'capacity',
+  name: 'Capacity',
+  field: 'capacity',
+  sortable: true,
+  resizable: true,
+  formatter: dataGrid.formatters.integer
+});
+columns.push({
+  id: 'available',
+  name: 'Available',
+  field: 'available',
+  sortable: true,
+  resizable: true,
+  formatter: dataGrid.formatters.date
+});
+columns.push({
+  id: 'comments',
+  name: 'Comments',
+  field: 'comments',
+  sortable: true,
+  resizable: true,
+  formatter: dataGrid.formatters.text
+});
+
+dataGrid.columns = columns;
+
+const setData = async () => {
+  const res = await fetch(url);
+  const data = await res.json();
+  dataGrid.data = data.splice(0, 120);
+};
+
+setData();
+
+dataGrid.addEventListener('selectionchanged', (e: Event) => {
+  console.info(`Selection Changed`, (<CustomEvent>e).detail);
+});
+
+dataGrid.addEventListener('scrollend', (e: Event) => {
+  const newDataArray : any[] = [];
+  for (let counter = 0; counter < 10; counter++) {
+    currentId++;
+    const newData = {
+      id: currentId,
+      name: `Crawler-${currentId.toString()}`,
+      location: 'St. Louis',
+      capacity: 44,
+      available: '2022-05-08T01:57:17Z',
+      comments: 'integer pede justo lacinia eget tincidunt eget tempus vel pede morbi porttitor lorem id ligula suspendisse ornare consequat lectus',
+      time: '22:14:42',
+      rowExpanded: false,
+      children: [
+        {
+          id: currentId + 0.1,
+          name: 'Battery',
+          location: 'Lower',
+          capacity: 2,
+          available: '2022-01-14T02:43:11Z',
+          time: '7:20:19',
+          rowHidden: true
+        }
+      ]
+    };
+    newDataArray.push(newData);
+  }
+  console.info(`append`, newDataArray);
+  dataGrid.appendData(newDataArray);
+  console.info(`scrollend`, (<CustomEvent>e).detail);
+});

--- a/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.ts
+++ b/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.ts
@@ -104,7 +104,7 @@ dataGrid.addEventListener('scrollend', (e: Event) => {
     currentId++;
     const newData = {
       id: currentId,
-      name: `Crawler-${currentId.toString()}`,
+      name: `Crawler-${currentId}`,
       location: 'St. Louis',
       capacity: 44,
       available: '2022-05-08T01:57:17Z',

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -201,14 +201,14 @@ export default class IdsDataGridRow extends IdsElement {
       else childRow.setAttribute('hidden', '');
 
       this.setAttribute('aria-expanded', String(!isExpanded));
-      this.dataGrid?.updateDataset(Number(this.getAttribute('data-index')), { rowExpanded: !isExpanded });
+      this.dataGrid?.updateDataset(this.rowIndex, { rowExpanded: !isExpanded });
       this.querySelector('.ids-data-grid-tree-container ids-button ids-icon')?.setAttribute('icon', !isExpanded ? 'plusminus-folder-open' : 'plusminus-folder-closed');
     }
 
     // Handle Expand/Collapse for a tree
     if (this.dataGrid?.treeGrid) {
       this.setAttribute('aria-expanded', String(!isExpanded));
-      this.dataGrid?.updateDataset(Number(this.getAttribute('data-index')), { rowExpanded: !isExpanded });
+      this.dataGrid?.updateDataset(this.rowIndex, { rowExpanded: !isExpanded });
       this.querySelector('.ids-data-grid-tree-container ids-button ids-icon')!.setAttribute('icon', !isExpanded ? 'plusminus-folder-open' : 'plusminus-folder-closed');
       const level = this.getAttribute('aria-level');
       let isParentCollapsed = false;
@@ -218,7 +218,7 @@ export default class IdsDataGridRow extends IdsElement {
         if (nodeLevel > Number(level) && !isParentCollapsed) {
           if (isExpanded) childRow.setAttribute('hidden', '');
           else childRow.removeAttribute('hidden');
-          this.dataGrid?.updateDataset(Number(childRow.getAttribute('data-index')), { rowHidden: isExpanded });
+          this.dataGrid?.updateDataset(Number(childRow.getAttribute('row-index')), { rowHidden: isExpanded });
         }
         if (childRow.getAttribute('aria-expanded')) isParentCollapsed = childRow.getAttribute('aria-expanded') === 'false';
       });
@@ -226,7 +226,7 @@ export default class IdsDataGridRow extends IdsElement {
 
     // Emit an Event
     if (!noTrigger) {
-      const visibleRowIndex = Number(this.getAttribute('data-index'));
+      const visibleRowIndex = this.rowIndex;
       this.dataGrid?.triggerEvent(`row${isExpanded ? 'collapsed' : 'expanded'}`, this.dataGrid, {
         bubbles: true,
         detail: {

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -56,6 +56,10 @@ export default class IdsDataGridRow extends IdsElement {
     return this.getBoundingClientRect();
   }
 
+  get expandIcon() {
+    return this.querySelector('.ids-data-grid-tree-container ids-button ids-icon');
+  }
+
   /**
    * Set the row disabled state.
    * @param {number} value the value
@@ -124,45 +128,49 @@ export default class IdsDataGridRow extends IdsElement {
   /** Set row attributes and classes */
   #setAttributes() {
     const row = this.rowIndex;
+    const rowData = this.dataGrid.data[row];
     this.setAttribute('data-index', String(row));
     this.setAttribute('aria-rowindex', String(row + 1));
 
     // Handle Selection
-    if (this.dataGrid.data[row]?.rowSelected) {
-      this.selected = this.dataGrid.data[row].rowSelected;
+    if (rowData?.rowSelected) {
+      this.selected = rowData.rowSelected;
     }
-    if (!this.dataGrid.data[row]?.rowSelected && this.classList.contains('selected')) {
-      this.selected = this.dataGrid.data[row].rowSelected;
+    if (!rowData?.rowSelected && this.classList.contains('selected')) {
+      this.selected = rowData.rowSelected;
     }
 
     // Handle Tree
     if (this.dataGrid?.treeGrid) {
-      this.setAttribute('aria-setsize', this.dataGrid.data[row]?.ariaSetSize);
-      this.setAttribute('aria-level', this.dataGrid.data[row]?.ariaLevel);
-      this.setAttribute('aria-posinset', this.dataGrid.data[row]?.ariaPosinset);
+      this.setAttribute('aria-setsize', rowData?.ariaSetSize);
+      this.setAttribute('aria-level', rowData?.ariaLevel);
+      this.setAttribute('aria-posinset', rowData?.ariaPosinset);
 
-      if (this.dataGrid.data[row]?.children) {
-        this.setAttribute('aria-expanded', this.dataGrid.data[row]?.rowExpanded === false ? 'false' : 'true');
+      if (rowData?.children) {
+        this.setAttribute('aria-expanded', rowData?.rowExpanded === false ? 'false' : 'true');
       }
     }
 
     // Handle Expanded
-    if (this.dataGrid.data[row]?.rowExpanded) {
+    if (rowData?.rowExpanded) {
       this.setAttribute('aria-expanded', 'true');
+      this.expandIcon?.setAttribute?.('icon', 'plusminus-folder-open');
     }
-    if (!this.dataGrid.data[row]?.rowExpanded && this.getAttribute('aria-expanded') === 'false') {
+    if (!rowData?.rowExpanded && this.getAttribute('aria-expanded') === 'false') {
       this.setAttribute('aria-expanded', 'false');
+      this.expandIcon?.setAttribute?.('icon', 'plusminus-folder-closed');
     }
-    if (!this.dataGrid.data[row]?.rowExpanded && this.dataGrid.expandableRow) {
+    if (!rowData?.rowExpanded && this.dataGrid.expandableRow) {
       this.setAttribute('aria-expanded', 'false');
+      this.expandIcon?.setAttribute?.('icon', 'plusminus-folder-closed');
     }
 
     // Handle Hidden
-    if (this.dataGrid.data[row]?.rowHidden) {
+    if (rowData?.rowHidden) {
       this.hidden = true;
       this.classList.add('hidden');
     }
-    if (!this.dataGrid.data[row]?.rowHidden && this.classList.contains('hidden')) {
+    if (!rowData?.rowHidden && this.classList.contains('hidden')) {
       this.hidden = false;
       this.classList.remove('hidden');
     }
@@ -202,14 +210,14 @@ export default class IdsDataGridRow extends IdsElement {
 
       this.setAttribute('aria-expanded', String(!isExpanded));
       this.dataGrid?.updateDataset(this.rowIndex, { rowExpanded: !isExpanded });
-      this.querySelector('.ids-data-grid-tree-container ids-button ids-icon')?.setAttribute('icon', !isExpanded ? 'plusminus-folder-open' : 'plusminus-folder-closed');
+      this.expandIcon?.setAttribute('icon', !isExpanded ? 'plusminus-folder-open' : 'plusminus-folder-closed');
     }
 
     // Handle Expand/Collapse for a tree
     if (this.dataGrid?.treeGrid) {
       this.setAttribute('aria-expanded', String(!isExpanded));
       this.dataGrid?.updateDataset(this.rowIndex, { rowExpanded: !isExpanded });
-      this.querySelector('.ids-data-grid-tree-container ids-button ids-icon')!.setAttribute('icon', !isExpanded ? 'plusminus-folder-open' : 'plusminus-folder-closed');
+      this.expandIcon!.setAttribute('icon', !isExpanded ? 'plusminus-folder-open' : 'plusminus-folder-closed');
       const level = this.getAttribute('aria-level');
       let isParentCollapsed = false;
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1401,7 +1401,8 @@ export default class IdsDataGrid extends Base {
         this.#triggerCustomScrollEvent(firstRow.rowIndex, 'start');
       }
       if (reachedTheBottom) {
-        this.#triggerCustomScrollEvent(this.datasource.originalData.length, 'end');
+        const lastRowIndex = this.datasource.originalData.length - 1;
+        this.#triggerCustomScrollEvent(lastRowIndex, 'end');
       }
       if (!reachedTheTop && !reachedTheBottom) {
         this.#triggerCustomScrollEvent(0);

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1173,7 +1173,8 @@ export default class IdsDataGrid extends Base {
    */
   appendData(value: Array<Record<string, any>>) {
     if (this.virtualScroll) {
-      this.datasource.data = this.data.concat(value);
+      // NOTE: using currentData skips pagination-logic; it's ok in context of infinite-scroll
+      this.datasource.data = this.datasource.currentData.concat(value);
       this.#appendMissingRows();
     } else {
       this.data = this.data.concat(value);

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1173,8 +1173,8 @@ export default class IdsDataGrid extends Base {
    */
   appendData(value: Array<Record<string, any>>) {
     if (this.virtualScroll) {
-      // NOTE: using currentData skips pagination-logic; it's ok in context of infinite-scroll
-      this.datasource.data = this.datasource.currentData.concat(value);
+      // NOTE: using originalData skips pagination-logic; it's ok in context of infinite-scroll
+      this.datasource.data = this.datasource.originalData.concat(value);
       this.#appendMissingRows();
     } else {
       this.data = this.data.concat(value);
@@ -1401,8 +1401,7 @@ export default class IdsDataGrid extends Base {
         this.#triggerCustomScrollEvent(firstRow.rowIndex, 'start');
       }
       if (reachedTheBottom) {
-        const lastRow: any = rows[rows.length - 1];
-        this.#triggerCustomScrollEvent(lastRow.rowIndex, 'end');
+        this.#triggerCustomScrollEvent(this.datasource.originalData.length, 'end');
       }
       if (!reachedTheTop && !reachedTheBottom) {
         this.#triggerCustomScrollEvent(0);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Adding new rows in the treegrid using appendData() was breaking rendering of existing rows. Current rows were sometimes are in the wrong order, depth or parent row.

Also there was an issue with `scrollend` where it triggered prematurely when the rows are expanded. It looks like `scrollend` was calculating based on unexpanded rows only.

Added an example that shows infinite-scrolling on a virtual-scroll enabled tree-grid.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->

Closes #1425   

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. Check out branch and run: `nvm use && npm run start`
2. Go to: http://localhost:4300/ids-data-grid/tree-grid-virtual-scroll-infinite-scroll.html
3. Take note of the initial rows at the beginning.
4. Expand the first row, then scroll down to the end.
5. Scroll back up to compare the initial rows after scrolling.
6. The rows should not  have changed order/depth or parent.
7. Open dev console and run `$("#tree-grid-virtual-scroll").collapseAll() && $("#tree-grid-virtual-scroll").expandAll()`
8. No errors should be thrown.
9. Also the `scrollend` event should continue to fire at the right time. 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
