### PR TITLE
7841 - Change badge/tag and icon status size

### DIFF
--- a/src/components/ids-badge/README.md
+++ b/src/components/ids-badge/README.md
@@ -44,12 +44,6 @@ A shape badge is done by adding a `shape` attribute and one of the following: no
 <ids-badge color="alert" shape="round">10</ids-badge>
 ```
 
-A badge with an icon can be configure by adding the `<ids-icon></ids-icon>` component inside of the badge.
-
-```html
-<ids-badge color="alert" shape="round"><ids-icon icon="pending" size="normal"></ids-icon></ids-badge>
-```
-
 Audible span can de configure by adding `<ids-text audible="true"></ids-text>` inside of the badge.
 
 ```html

--- a/src/components/ids-badge/demos/example.html
+++ b/src/components/ids-badge/demos/example.html
@@ -17,7 +17,6 @@
         <ids-badge color="error">404 <ids-text audible="true">Items in Error</ids-text></ids-badge>
         <ids-badge color="warning" shape="round">10</ids-badge>
         <ids-badge color="warning" shape="normal">1000</ids-badge>
-        <ids-badge color="warning" shape="round"><ids-icon icon="pending" size="normal"></ids-icon></ids-badge>
         <ids-badge color="success">5</ids-badge>
         <ids-badge color="info">25k+</ids-badge>
      </ids-layout-grid-cell>

--- a/src/components/ids-badge/demos/side-by-side.html
+++ b/src/components/ids-badge/demos/side-by-side.html
@@ -23,7 +23,6 @@
         <ids-badge color="warning" shape="round">16</ids-badge>
         <ids-badge color="success">5</ids-badge>
         <ids-badge color="error">404 <ids-text audible="true">In Error Condition</ids-text></ids-badge>
-        <ids-badge color="alert" shape="round"><ids-icon icon="pending" size="normal"></ids-icon></ids-badge>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 

--- a/src/components/ids-tag/ids-tag.scss
+++ b/src/components/ids-tag/ids-tag.scss
@@ -15,10 +15,13 @@
   color: var(--ids-tag-color-text-default);
 
   // Layout
+  box-sizing: border-box;
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin-inline-end: var(--ids-space-30);
   padding-inline:  var(--ids-space-40);
-  padding-bottom:  var(--ids-space-20);
+  height: var(--ids-tag-height);
   contain: content;
 
   // Secondary has a darker border

--- a/src/components/ids-theme-switcher/demos/theme-builder.html
+++ b/src/components/ids-theme-switcher/demos/theme-builder.html
@@ -233,7 +233,6 @@
             <ids-badge shape="round">5</ids-badge>
             <ids-badge color="error">1500</ids-badge>
             <ids-badge color="warning" shape="round">10</ids-badge>
-            <ids-badge color="warning" shape="round"><ids-icon icon="pending" size="normal"></ids-icon></ids-badge>
             <ids-badge color="success" shape="round">5</ids-badge>
             <ids-badge color="info">25k+</ids-badge>
         </ids-layout-grid-cell>

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -710,7 +710,7 @@
   --ids-icon-color-default-disabled: var(--ids-color-text-disabled);
   --ids-icon-empty-color: var(--ids-color-primary);
   --ids-icon-empty-new-color: var(--ids-color-neutral-60);
-  --ids-icon-status-color-padding: 5px;
+  --ids-icon-status-color-padding: 3px;
   --ids-icon-status-color-border-radius: var(--ids-border-radius-circle);
   --ids-icon-status-color-ruby-color-text: var(--ids-color-ruby-60);
   --ids-icon-status-color-ruby-color-background: var(--ids-color-ruby-10);
@@ -1350,6 +1350,7 @@
   --ids-tab-module-color-text-disabled: var(--ids-color-neutral-50);
 
   // Tag
+  --ids-tag-height: 24px;
   --ids-tag-color-background-default: var(--ids-input-color-background-readonly);
   --ids-tag-color-border: var(--ids-input-color-background-readonly);
   --ids-tag-border-radius: var(--ids-border-radius-04);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

WC fix for issue on https://github.com/infor-design/enterprise/pull/7841

- tags made 24px height
- badges was already 24px height
- status icon made 24px x 24px

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/pull/7841

**Steps necessary to review your pull request (required)**:
- http://localhost:4300/ids-icon/status-color.html -> icon is 18x18 but border is 24x24
- http://localhost:4300/ids-badge/example.html -> is 24px height (on the inner shape)
- http://localhost:4300/ids-tag/example.html-> is 24px height (on the inner shape)
