### PR TITLE
1291 - DataGrid: Filter menu usability improvements

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### 1.0.0-beta.15 Fixes
 
+- `[DataGrid]` Fixed duplicate filter menus ([#1258](https://github.com/infor-design/enterprise-wc/issues/1258))
+- `[DataGrid]` Fixed missing/incorrect event handling in some cases with built-in filter menus/pickers. ([#1291](https://github.com/infor-design/enterprise-wc/issues/1291))
+- `[DataGrid]` Fixed incorrect placement of slotted filter menus/pickers. ([#1297](https://github.com/infor-design/enterprise-wc/issues/1297))
 - `[DataGrid]` Added example that shows context-menu with option to activate cell edit-mode on right-click. ([#1319](https://github.com/infor-design/enterprise-wc/issues/1319))
 
 ## 1.0.0-beta.14

--- a/src/components/ids-data-grid/ids-data-grid-filters.scss
+++ b/src/components/ids-data-grid/ids-data-grid-filters.scss
@@ -3,6 +3,7 @@
   ::slotted([slot^='filter-']) {
     align-items: center;
     display: flex;
+    position: relative;
   }
 
   .ids-data-grid-header-cell-content.vertical-align-center {

--- a/src/components/ids-data-grid/ids-data-grid-filters.scss
+++ b/src/components/ids-data-grid/ids-data-grid-filters.scss
@@ -1,5 +1,9 @@
 /* Ids Data Grid Component - Filter */
 .ids-data-grid {
+  --ids-button-formatter-color-text-default: var(--ids-data-grid-filter-icon-color);
+  --ids-button-formatter-color-background-hover: var(--ids-data-grid-filter-icon-background-hover);
+  --ids-button-formatter-color-text-hover: var(--ids-data-grid-filter-icon-color-hover);
+
   ::slotted([slot^='filter-']) {
     align-items: center;
     display: flex;

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -888,6 +888,25 @@ export default class IdsDataGridFilters {
    * @returns {void}
    */
   attachFilterEventHandlers() {
+    this.root.onEvent(`keydown.${this.#id()}`, this.root.wrapper, (e: any) => {
+      const elem = e.target;
+      if (!elem) return;
+
+      // Only apply this event to handlers that exist on internal (not slotted) filter menus
+      const containerNode = getClosestContainerNode(elem);
+      if (containerNode === document) return;
+
+      const key = e.key;
+      if (key === 'ArrowDown') {
+        if (/ids-trigger-field/gi.test(elem.nodeName)) {
+          elem.querySelector('ids-trigger-button').click();
+        }
+        if (/ids-dropdown/gi.test(elem.nodeName)) {
+          elem.click();
+        }
+      }
+    });
+
     this.root.offEvent(`show.${this.#id()}`, this.root.wrapper);
     this.root.onEvent(`show.${this.#id()}`, this.root.wrapper, (e: any) => {
       const elem = e.target;
@@ -918,6 +937,29 @@ export default class IdsDataGridFilters {
           }
         });
       }
+
+      // Dropdown Lists
+      if (/ids-dropdown-list/gi.test(elem.nodeName)) {
+        this.root.onEvent(`keydown.${this.#id()}`, elem, (f: any) => {
+          const key = f.key;
+          if (key === 'ArrowUp') {
+            console.info('dropdown arrow up');
+            elem.navigate(-1);
+          }
+          if (key === 'ArrowDown') {
+            console.info('dropdown arrow down');
+            elem.navigate(1);
+          }
+          if (['Enter', 'SpaceBar', ' '].includes(key)) {
+            console.info(`dropdown select with "${key}"`);
+            elem.select();
+          }
+          if (key === 'Escape') {
+            console.info('dropdown cancel with escape');
+            elem.triggerCloseEvent(true);
+          }
+        });
+      }
     });
 
     this.root.offEvent(`hide.${this.#id()}`, this.root.wrapper);
@@ -931,8 +973,14 @@ export default class IdsDataGridFilters {
 
       if (this.root.openMenu) this.root.openMenu = null;
 
-      if (/ids-popup-menu/gi.test(elem.nodeName)) {
+      // Popup Menus/Dropdown Lists
+      if (/ids-popup-menu|ids-dropdown-list/gi.test(elem.nodeName)) {
         this.root.offEvent(`keydown.${this.#id()}`, elem);
+      }
+
+      // Anything extending IdsPickerPopup
+      if (/ids-time-picker-popup|ids-date-picker-popup/gi.test(elem.nodeName)) {
+        elem.target?.focus();
       }
     });
 

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -745,8 +745,8 @@ export default class IdsDataGridFilters {
       const timePicker = node?.querySelector('ids-time-picker');
       const btn = node?.querySelector('ids-menu-button');
       const menu = node?.querySelector('ids-popup-menu');
-      const triggerBtn = node?.querySelector('ids-trigger-button');
-      const triggerField = node?.querySelector('ids-trigger-field');
+      let triggerBtn = node?.querySelector('ids-trigger-button');
+      let triggerField = node?.querySelector('ids-trigger-field');
       const datePickerPopup = node?.querySelector('ids-date-picker-popup');
       const timePickerPopup = node?.querySelector('ids-time-picker-popup');
       let menuAttachment = '.ids-data-grid-wrapper';
@@ -783,9 +783,19 @@ export default class IdsDataGridFilters {
 
       // Connect Popup Menus
       if (menu) {
+        if (slot) {
+          triggerField = slot.assignedElements()[0].querySelector('ids-input');
+          triggerBtn = slot.assignedElements()[0].querySelector('ids-menu-button');
+          menu.setAttribute(attributes.TARGET, `#${triggerBtn.getAttribute('id')}`);
+          menu.setAttribute(attributes.TRIGGER_ELEM, `#${triggerBtn.getAttribute('id')}`);
+        } else {
+          menu.setAttribute(attributes.ATTACHMENT, menuAttachment);
+        }
         menu.setAttribute(attributes.TRIGGER_TYPE, 'click');
-        menu.setAttribute(attributes.ATTACHMENT, menuAttachment);
-        menu.onOutsideClick = () => { menu.hide(); };
+        menu.onOutsideClick = () => {
+          menu.hide();
+        };
+        menu.removeTriggerEvents();
 
         // Move/Rebind menu (order of these statements matters)
         menu.appendToTargetParent();

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -328,6 +328,8 @@ export default class IdsDataGrid extends Base {
       return;
     }
 
+    this.#removeAttachedMenus();
+
     const header = IdsDataGridHeader.template(this);
     const body = this.bodyTemplate();
     if (this.container) this.container.innerHTML = header + body;
@@ -2685,5 +2687,16 @@ export default class IdsDataGrid extends Base {
    */
   cellByIndex(rowIndex: number, columnIndex: number): IdsDataGridCell | null {
     return this.rowByIndex(rowIndex)?.cellByIndex?.(columnIndex) ?? null;
+  }
+
+  /**
+   * Removes filter row menus that have been moved from filter row headers into the data grid wrapper
+   * @private
+   */
+  #removeAttachedMenus() {
+    const attachedMenus = this.wrapper?.querySelectorAll<IdsPopupMenu>('ids-popup-menu');
+    if (attachedMenus?.length) {
+      [...attachedMenus].forEach((el: IdsPopupMenu) => el.remove());
+    }
   }
 }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -94,6 +94,8 @@ export default class IdsDataGrid extends Base {
 
   cacheHash = Math.random().toString(32).substring(2, 10);
 
+  openMenu: null | IdsPopupMenu = null;
+
   /**
    * Types for contextmenu.
    */
@@ -137,6 +139,11 @@ export default class IdsDataGrid extends Base {
     this.redrawBody();
     setContextmenu.apply(this);
     this.#attachScrollEvents();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.openMenu = null;
   }
 
   /** Reference to datasource API */
@@ -684,8 +691,9 @@ export default class IdsDataGrid extends Base {
       const key = e.key;
 
       if (!e.shiftKey) this.#resetLastShiftedRow();
-      if (inFilter && (key === 'ArrowRight' || key === 'ArrowLeft')) return;
+      if (inFilter) return;
       if (!this.activeCell?.node) return;
+      if (this.openMenu) return;
 
       const cellNode = this.activeCell.node;
       const cellNumber = Number(this.activeCell?.cell);
@@ -736,6 +744,7 @@ export default class IdsDataGrid extends Base {
 
     // Handle Selection and Expand
     this.listen([' '], this, (e: Event) => {
+      if (this.openMenu) return;
       if (this.activeCellEditor) return;
       if (!this.activeCell?.node) return;
 
@@ -763,6 +772,7 @@ export default class IdsDataGrid extends Base {
 
     // Follow links with keyboard and start editing
     this.listen(['Enter'], this, (e: KeyboardEvent) => {
+      if (this.openMenu) return;
       if (!this.activeCell?.node || findInPath(eventPath(e), '.ids-data-grid-header-cell')) return;
 
       const row = this.rowByIndex(this.activeCell.row)!;
@@ -801,6 +811,7 @@ export default class IdsDataGrid extends Base {
 
     // Cancel Edit
     this.listen(['Escape'], this, () => {
+      if (this.openMenu) return;
       const cellNode = this.activeCell.node;
       if (this.activeCellEditor) {
         cellNode.cancelCellEdit();
@@ -810,6 +821,7 @@ export default class IdsDataGrid extends Base {
 
     // Edit Next
     this.listen(['Tab'], this, (e: KeyboardEvent) => {
+      if (this.openMenu) return;
       if (this.activeCellEditor) {
         if (e.shiftKey) this.#editAdjacentCell(IdsDirection.Previous);
         else this.#editAdjacentCell(IdsDirection.Next);

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -749,7 +749,7 @@ export default class IdsDataGrid extends Base {
       if (!this.activeCell?.node) return;
 
       const row = this.rowByIndex(this.activeCell.row)!;
-      if (row.disabled) return;
+      if (!row || row.disabled) return;
 
       const button = this.activeCell.node.querySelector('ids-button');
       if (button) {
@@ -776,7 +776,7 @@ export default class IdsDataGrid extends Base {
       if (!this.activeCell?.node || findInPath(eventPath(e), '.ids-data-grid-header-cell')) return;
 
       const row = this.rowByIndex(this.activeCell.row)!;
-      if (row.disabled) return;
+      if (!row || row.disabled) return;
 
       const cellNode = this.activeCell.node;
       const hyperlink = cellNode.querySelector('ids-hyperlink');

--- a/src/components/ids-dropdown/ids-dropdown-list.ts
+++ b/src/components/ids-dropdown/ids-dropdown-list.ts
@@ -172,10 +172,7 @@ export default class IdsDropdownList extends Base {
           this.triggerOpenEvent();
           return;
         }
-
-        const value = this.selected?.getAttribute(attributes.VALUE) || '';
-        this.value = value;
-        this.triggerSelectedEvent();
+        this.select();
       });
     }
   }
@@ -497,5 +494,44 @@ export default class IdsDropdownList extends Base {
   onSizeChange(value: string) {
     if (value) this.listBox?.setAttribute(attributes.SIZE, value);
     else this.listBox?.removeAttribute(attributes.SIZE);
+  }
+
+  /**
+   * Uses a currently-highlighted list item to "navigate" a specified number
+   * of steps to another list item, highlighting it.
+   * @param {number} [amt] positive/negative/0 value
+   * @returns {Element | null} the item that will be highlighted
+   */
+  navigate(amt = 0) {
+    const selected = this.selected;
+    const next = selected?.nextElementSibling;
+    const prev = selected?.previousElementSibling;
+    let currentItem: Element | null = null;
+
+    if (amt > 0 && next) {
+      if (next.hasAttribute(attributes.GROUP_LABEL) && !next.nextElementSibling) return currentItem;
+      currentItem = next.hasAttribute(attributes.GROUP_LABEL) ? next.nextElementSibling : next;
+    }
+
+    if (amt < 0 && prev) {
+      if (prev.hasAttribute(attributes.GROUP_LABEL) && !prev.previousElementSibling) return currentItem;
+      currentItem = prev.hasAttribute(attributes.GROUP_LABEL) ? prev.previousElementSibling : prev;
+    }
+
+    if (currentItem) {
+      this.deselectOption(selected);
+      this.selectOption(currentItem as IdsListBoxOption);
+    }
+
+    return currentItem;
+  }
+
+  /**
+   * Performs a "selection" on the list and notifies the Dropdown component
+   */
+  select() {
+    const value = this.selected?.getAttribute(attributes.VALUE) || '';
+    this.value = value;
+    this.triggerSelectedEvent();
   }
 }

--- a/src/components/ids-menu/ids-menu.ts
+++ b/src/components/ids-menu/ids-menu.ts
@@ -44,6 +44,8 @@ const Base = IdsKeyboardMixin(
 export default class IdsMenu extends Base {
   datasource = new IdsDataSource();
 
+  keyboardEventTarget: HTMLElement | null = null;
+
   lastHovered?: any;
 
   lastNavigated?: any;
@@ -138,9 +140,11 @@ export default class IdsMenu extends Base {
    * @returns {void}
    */
   attachKeyboardListeners() {
+    const target = this.keyboardEventTarget || this;
+
     // Arrow Up navigates focus backward
     this.unlisten('ArrowUp');
-    this.listen(['ArrowUp'], this, (e: any) => {
+    this.listen(['ArrowUp'], target, (e: any) => {
       e.preventDefault();
       e.stopPropagation();
       this.navigate(-1, true);
@@ -148,7 +152,7 @@ export default class IdsMenu extends Base {
 
     // Arrow Down navigates focus forward
     this.unlisten('ArrowDown');
-    this.listen(['ArrowDown'], this, (e: any) => {
+    this.listen(['ArrowDown'], target, (e: any) => {
       e.preventDefault();
       e.stopPropagation();
       this.navigate(1, true);
@@ -158,7 +162,7 @@ export default class IdsMenu extends Base {
     this.unlisten('Enter');
     this.unlisten('Spacebar');
     this.unlisten(' ');
-    this.listen(['Enter', 'Spacebar', ' '], this, (e: any) => {
+    this.listen(['Enter', 'Spacebar', ' '], target, (e: any) => {
       const thisItem = e.target.closest('ids-menu-item');
       this.selectItem(thisItem);
       this.lastNavigated = thisItem;
@@ -758,5 +762,12 @@ export default class IdsMenu extends Base {
     [...this.items, ...this.headers].forEach((item: IdsMenuItem | IdsMenuHeader) => {
       if (typeof item.decorateForIcon === 'function') item.decorateForIcon(this.hasIcons);
     });
+  }
+
+  /**
+   * Focuses the correct element
+   */
+  focus() {
+    this.focusTarget?.focus();
   }
 }

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -507,6 +507,9 @@
   --ids-data-grid-header-expander-active-color:  var(--ids-color-neutral-00);
 
   // Data Grid (Filter)
+  --ids-data-grid-filter-icon-color: var(--ids-color-neutral-30);
+  --ids-data-grid-filter-icon-background-hover: transparent;
+  --ids-data-grid-filter-icon-color-hover: var(--ids-color-neutral-10);
   --ids-data-grid-filter-input-color-background: transparent;
   --ids-data-grid-filter-input-color-border-default: var(--ids-color-neutral-30);
   --ids-data-grid-filter-input-color-text-default: var(--ids-color-neutral-00);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes a few improvements to the keyboard usability of the Data Grid's filter row menus.  This PR also fixes some bugs surrounding these menus' events, especially when the grid is redrawn due to column re-ordering or data issues.

**Related github/jira issue (required)**:
- Fixes #1291
- Fixes #1297
- Fixes #1258

**Steps necessary to review your pull request (required)**:
Pull/Build/Run, then test the following:

_Duplicate/Incorrectly-placed Menus (#1258/#1297):_
- Open  http://localhost:4300/ids-data-grid/filter.html
- Re-order the columns by dragging their handles
- Try opening any filter menu button.  The popups should be in the correct place
- Open http://localhost:4300/ids-data-grid/filter-custom.html
- Try opening the "Color" or "Product ID" menus.  They should be in the correct place.

_Reparenting issues (#1291):_
- Open http://localhost:4300/ids-data-grid/filter.html
- Focus any filter menu button and use the "Enter" key to open.  The menu should open and focus should be inside the menu.  It should be navigable with the arrow keys, and selections should be possible with "Enter" or "SpaceBar".  "Escape" should close the menu and cancel selection.
- When the menu closes, focus should return to the menu button.
- Open http://localhost:4300/ids-data-grid/filter-custom.html -- Test the "Color" and "Product Id" columns which are slotted, and should not be affected by the new events, but should behave the same.
- Open http://localhost:4300/ids-data-grid/filter-trigger-fields.html
- On Date, Time, and Dropdown columns, test keyboard interactions by using Tab/Shift+Tab to focus the trigger fields.  Pressing the down arrow while focused should activate each picker.
- When selections are made and pickers close, focus should be returned to the corresponding trigger field.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
