### PR TITLE
1166 - Fix Angular ReactiveForm values

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[DataGrid]` Prevent scroll when resize columns. ([#1209](https://github.com/infor-design/enterprise-wc/issues/1209))
 - `[Editor]` Added new toolbar styles in all themes. ([#7606](https://github.com/infor-design/enterprise-wc/issues/7606))
 - `[Editor]` Fixed issue where buttons are disabled in source view. ([#1195](https://github.com/infor-design/enterprise-wc/issues/1195))
+- `[Input]` Fixed input elements so values are properly reflected in Angular Reactive Forms. ([#1455](https://github.com/infor-design/enterprise-wc/issues/1455))
 - `[Locale]` Made Locale a global instance and moved it off ids-container and related fixes. ([#663](https://github.com/infor-design/enterprise-wc/issues/663))
 - `[Message]` Fix modal button separator. ([#1414](https://github.com/infor-design/enterprise-wc/issues/1414))
 - `[ModuleNav]` Added IdsModuleNav component with basic Role Switcher, Settings component. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))

--- a/src/components/ids-color-picker/ids-color-picker.ts
+++ b/src/components/ids-color-picker/ids-color-picker.ts
@@ -791,7 +791,8 @@ export default class IdsColorPicker extends Base {
    * @param {boolean} label label
    */
   onLabelChange(label: string) {
-    this.textInput?.setAttribute(attributes.LABEL, label);
+    // this.textInput?.setAttribute(attributes.LABEL, label);
+    if (this.textInput) this.textInput.label = label ?? '';
   }
 
   /**

--- a/src/components/ids-color-picker/ids-color-picker.ts
+++ b/src/components/ids-color-picker/ids-color-picker.ts
@@ -791,7 +791,6 @@ export default class IdsColorPicker extends Base {
    * @param {boolean} label label
    */
   onLabelChange(label: string) {
-    // this.textInput?.setAttribute(attributes.LABEL, label);
     if (this.textInput) this.textInput.label = label ?? '';
   }
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1412,7 +1412,7 @@ export default class IdsDataGrid extends Base {
 
       if (reachedTheTop) {
         const firstRow: any = rows[0];
-        this.#triggerCustomScrollEvent(firstRow.rowIndex, 'start');
+        this.#triggerCustomScrollEvent(firstRow?.rowIndex ?? 0, 'start');
       }
       if (reachedTheBottom) {
         const lastRowIndex = this.datasource.originalData.length - 1;

--- a/src/components/ids-dropdown/ids-dropdown-attributes-mixin.ts
+++ b/src/components/ids-dropdown/ids-dropdown-attributes-mixin.ts
@@ -142,7 +142,7 @@ const IdsDropdownAttributeMixin = <T extends Constraints>(superclass: T) => clas
     if (typeof this.onSizeChange === 'function') this.onSizeChange(value);
   }
 
-  get size(): string { return this.getAttribute(attributes.SIZE) ?? 'md'; }
+  get size(): string { return this.getAttribute(attributes.SIZE) || 'md'; }
 
   /**
    * Set the element's ability to display an optional icon in front of the text

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -305,7 +305,7 @@ export default class IdsDropdown extends Base {
     const labels = this.labels;
     const label = String(value);
     if (labels.includes(label)) {
-      value = this.values[labels.indexOf(label)];
+      value = this.optionValues[labels.indexOf(label)];
     }
 
     let selector = `ids-list-box-option[value="${value}"]`;
@@ -333,10 +333,10 @@ export default class IdsDropdown extends Base {
   }
 
   /**
-   * Get all available values of the dropdown
+   * Get all available option-values for the dropdown
    * @returns {string[]} value
    */
-  get values(): string[] {
+  get optionValues(): string[] {
     return this.options.map((item) => item.value ?? '');
   }
 

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -302,6 +302,12 @@ export default class IdsDropdown extends Base {
    * @param {string} value The value/id to use
    */
   set value(value: string | null) {
+    const labels = this.labels;
+    const label = String(value);
+    if (labels.includes(label)) {
+      value = this.values[labels.indexOf(label)];
+    }
+
     let selector = `ids-list-box-option[value="${value}"]`;
     if (value === ' ' || !value) selector = `ids-list-box-option:not([value])`;
     const elem = this.dropdownList?.listBox?.querySelector<IdsListBoxOption>(selector);
@@ -314,6 +320,8 @@ export default class IdsDropdown extends Base {
     if (this.input) this.input.value = elem.textContent?.trim();
     this.state.selectedIndex = [...((elem?.parentElement as any)?.children || [])].indexOf(elem);
 
+    this.setAttribute(attributes.VALUE, String(value));
+
     // Send the change event
     if (this.value === value) {
       this.triggerEvent('change', this, {
@@ -324,11 +332,18 @@ export default class IdsDropdown extends Base {
         }
       });
     }
-    this.setAttribute(attributes.VALUE, String(value));
   }
 
   get value(): string | null {
     return this.getAttribute(attributes.VALUE);
+  }
+
+  get values(): string[] {
+    return this.options.map((item) => item.value ?? '');
+  }
+
+  get labels(): string[] {
+    return this.options.map((item) => item.textContent ?? '');
   }
 
   /**

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -313,14 +313,15 @@ export default class IdsDropdown extends Base {
     const elem = this.dropdownList?.listBox?.querySelector<IdsListBoxOption>(selector);
     if (!elem) return;
 
+    // NOTE: setAttribute() must be called here, before the internal input.value is set below
+    this.setAttribute(attributes.VALUE, String(value));
+
     this.clearSelected();
     this.selectOption(elem);
     this.selectIcon(elem);
     this.selectTooltip(elem);
     if (this.input) this.input.value = elem.textContent?.trim();
     this.state.selectedIndex = [...((elem?.parentElement as any)?.children || [])].indexOf(elem);
-
-    this.setAttribute(attributes.VALUE, String(value));
 
     // Send the change event
     if (this.value === value) {

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -334,14 +334,26 @@ export default class IdsDropdown extends Base {
     }
   }
 
+  /**
+   * Get the current value of the dropdown
+   * @returns {string | null} value
+   */
   get value(): string | null {
     return this.getAttribute(attributes.VALUE);
   }
 
+  /**
+   * Get all available values of the dropdown
+   * @returns {string[]} value
+   */
   get values(): string[] {
     return this.options.map((item) => item.value ?? '');
   }
 
+  /**
+   * Get all availabe labels of the dropdown
+   * @returns {string[]} value
+   */
   get labels(): string[] {
     return this.options.map((item) => item.textContent ?? '');
   }

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -322,17 +322,6 @@ export default class IdsDropdown extends Base {
     this.selectTooltip(elem);
     if (this.input) this.input.value = elem.textContent?.trim();
     this.state.selectedIndex = [...((elem?.parentElement as any)?.children || [])].indexOf(elem);
-
-    // Send the change event
-    if (this.value === value) {
-      this.triggerEvent('change', this, {
-        bubbles: true,
-        detail: {
-          elem: this,
-          value: this.value
-        }
-      });
-    }
   }
 
   /**
@@ -356,7 +345,7 @@ export default class IdsDropdown extends Base {
    * @returns {string[]} value
    */
   get labels(): string[] {
-    return this.options.map((item) => item.textContent ?? '');
+    return this.options.map((item) => item.innerText ?? item.textContent ?? '');
   }
 
   /**
@@ -1277,7 +1266,7 @@ export default class IdsDropdown extends Base {
   onSizeChange(value: string) {
     if (value) this.dropdownList?.setAttribute(attributes.SIZE, value);
     else this.dropdownList?.removeAttribute(attributes.SIZE);
-    this.input?.setAttribute(attributes.SIZE, value);
+    this.input?.setAttribute(attributes.SIZE, value || 'md');
   }
 
   /**

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -96,6 +96,7 @@ type IdsInputTemplateVariables = {
  * @inherits IdsElement
  * @mixes IdsLocaleMixin
  * @mixes IdsEventsMixin
+ * @mixes IdsFormInputMixin
  * @mixes IdsKeyboardMixin
  * @mixes IdsClearableMixin
  * @mixes IdsColorVariantMixin
@@ -895,8 +896,6 @@ export default class IdsInput extends Base {
   set value(val: string | undefined) {
     let v = ['string', 'number'].includes(typeof val) ? String(val) : String(val || '');
     const currentValue = this.value;
-    // console.log({ currentValue, val });
-    // const currentValue = this.getAttribute(attributes.VALUE) || '';
 
     // If a mask is enabled, use the conformed value.
     // If no masking occurs, simply use the provided value.

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -8,6 +8,7 @@ import IdsDirtyTrackerMixin from '../../mixins/ids-dirty-tracker-mixin/ids-dirty
 import IdsClearableMixin from '../../mixins/ids-clearable-mixin/ids-clearable-mixin';
 import IdsColorVariantMixin from '../../mixins/ids-color-variant-mixin/ids-color-variant-mixin';
 import IdsFieldHeightMixin from '../../mixins/ids-field-height-mixin/ids-field-height-mixin';
+import IdsFormInputMixin from '../../mixins/ids-form-input-mixin/ids-form-input-mixin';
 import IdsLabelStateMixin from '../../mixins/ids-label-state-mixin/ids-label-state-mixin';
 import IdsMaskMixin from '../../mixins/ids-mask-mixin/ids-mask-mixin';
 import IdsValidationMixin from '../../mixins/ids-validation-mixin/ids-validation-mixin';
@@ -48,8 +49,10 @@ const Base = IdsTooltipMixin(
                   IdsValidationMixin(
                     IdsLocaleMixin(
                       IdsKeyboardMixin(
-                        IdsEventsMixin(
-                          IdsElement
+                        IdsFormInputMixin(
+                          IdsEventsMixin(
+                            IdsElement
+                          )
                         )
                       )
                     )
@@ -353,8 +356,17 @@ export default class IdsInput extends Base {
    * @readonly
    * @returns {HTMLInputElement} the inner `input` element
    */
-  get input(): HTMLInputElement | undefined | null {
-    return this.container?.querySelector<HTMLInputElement>(`input[part="input"]`);
+  get input(): HTMLInputElement | null {
+    return this.container?.querySelector<HTMLInputElement>(`input[part="input"]`) ?? null;
+  }
+
+  /**
+   * @readonly
+   * @returns {HTMLInputElement} the inner `input` element
+   * @see IdsFormInputMixin.formInput
+   */
+  get formInput(): HTMLInputElement | null {
+    return this.input;
   }
 
   /**
@@ -618,52 +630,6 @@ export default class IdsInput extends Base {
           value: this.value
         }
       });
-    });
-
-    this.onEvent('input.native', this.input, (e: any) => {
-      this.triggeredByChange = true;
-      this.value = this.input?.value ?? '';
-      this.triggerInputEvent(e);
-    });
-
-    this.onEvent('change.native', this.input, (e: any) => {
-      this.triggeredByChange = true;
-      this.value = this.input?.value ?? '';
-      this.triggerInputEvent(e);
-    });
-  }
-
-  /**
-   * React to attributes changing on the web-component
-   * @param {string} name The property name
-   * @param {string} oldValue The property old value
-   * @param {string} newValue The property new value
-   */
-  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-    super.attributeChangedCallback(name, oldValue, newValue);
-    if (oldValue === newValue) return;
-
-    if (name === attributes.VALUE) {
-      this.triggerInputEvent();
-    }
-  }
-
-  triggerInputEvent(nativeEvent?: Event | CustomEvent, element?: Element) {
-    element = element ?? (this.getRootNode() as ShadowRoot)?.host;
-
-    const value = this.value;
-    if (element) {
-      (element as HTMLInputElement).value = value;
-    }
-
-    const target = element ?? this;
-    this.triggerEvent(`input.${this.name ?? 'ids-input'}`, target, {
-      bubbles: true,
-      detail: {
-        elem: target,
-        value,
-        nativeEvent,
-      }
     });
   }
 

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -649,11 +649,15 @@ export default class IdsInput extends Base {
   }
 
   triggerInputEvent(nativeEvent?: Event | CustomEvent, element?: Element) {
-    const target = element ?? (this.getRootNode() as ShadowRoot)?.host ?? this;
+    element = element ?? (this.getRootNode() as ShadowRoot)?.host;
 
     const value = this.value;
-    target.setAttribute?.(attributes.VALUE, value);
+    // element?.setAttribute?.(attributes.VALUE, value);
+    if (element) {
+      (element as HTMLInputElement).value = value;
+    }
 
+    const target = element ?? this;
     this.triggerEvent(`input.${this.name ?? 'ids-input'}`, target, {
       bubbles: true,
       detail: {

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -616,21 +616,6 @@ export default class IdsInput extends Base {
    */
   #attachEventHandlers(): void {
     this.#attachNativeEvents();
-
-    // If the internal input value is updated and a change event is triggered,
-    // reflect that change on the WebComponent host element.
-    this.onEvent('change.input', this.container, (e: any) => {
-      this.triggeredByChange = true;
-      this.value = this.input?.value;
-      this.triggerEvent('change', this, {
-        bubbles: true,
-        detail: {
-          elem: this,
-          nativeEvent: e,
-          value: this.value
-        }
-      });
-    });
   }
 
   /**
@@ -909,20 +894,14 @@ export default class IdsInput extends Base {
    */
   set value(val: string | undefined) {
     let v = ['string', 'number'].includes(typeof val) ? String(val) : String(val || '');
-    const currentValue = this.getAttribute(attributes.VALUE) || '';
+    const currentValue = this.value;
+    // console.log({ currentValue, val });
+    // const currentValue = this.getAttribute(attributes.VALUE) || '';
 
     // If a mask is enabled, use the conformed value.
     // If no masking occurs, simply use the provided value.
     if (this.mask) {
       v = this.processMaskFromProperty(val) || v;
-    }
-
-    if (this.input && this.input?.value !== v) {
-      this.input.value = v;
-      if (!this.triggeredByChange) {
-        this.input?.dispatchEvent(new Event('change', { bubbles: true }));
-      }
-      this.triggeredByChange = false;
     }
 
     if (currentValue !== v) {

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -652,7 +652,6 @@ export default class IdsInput extends Base {
     element = element ?? (this.getRootNode() as ShadowRoot)?.host;
 
     const value = this.value;
-    // element?.setAttribute?.(attributes.VALUE, value);
     if (element) {
       (element as HTMLInputElement).value = value;
     }

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -619,6 +619,49 @@ export default class IdsInput extends Base {
         }
       });
     });
+
+    this.onEvent('input.native', this.input, (e: any) => {
+      this.triggeredByChange = true;
+      this.value = this.input?.value ?? '';
+      this.triggerInputEvent(e);
+    });
+
+    this.onEvent('change.native', this.input, (e: any) => {
+      this.triggeredByChange = true;
+      this.value = this.input?.value ?? '';
+      this.triggerInputEvent(e);
+    });
+  }
+
+  /**
+   * React to attributes changing on the web-component
+   * @param {string} name The property name
+   * @param {string} oldValue The property old value
+   * @param {string} newValue The property new value
+   */
+  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    if (oldValue === newValue) return;
+
+    if (name === attributes.VALUE) {
+      this.triggerInputEvent();
+    }
+  }
+
+  triggerInputEvent(nativeEvent?: Event | CustomEvent, element?: Element) {
+    const target = element ?? (this.getRootNode() as ShadowRoot)?.host ?? this;
+
+    const value = this.value;
+    target.setAttribute?.(attributes.VALUE, value);
+
+    this.triggerEvent(`input.${this.name ?? 'ids-input'}`, target, {
+      bubbles: true,
+      detail: {
+        elem: target,
+        value,
+        nativeEvent,
+      }
+    });
   }
 
   /**
@@ -919,7 +962,7 @@ export default class IdsInput extends Base {
   }
 
   get value(): string {
-    return this.input?.value || '';
+    return this.input?.value ?? '';
   }
 
   /**

--- a/src/components/ids-mask/ids-masks.ts
+++ b/src/components/ids-mask/ids-masks.ts
@@ -314,7 +314,7 @@ function getSplitterRegex(splitterStr: string) {
  */
 export function dateMask(rawValue = '', options: IdsMaskOptions = {}): IdsMaskGeneratorResult {
   // TODO: this function fails to properly convert new Date()
-  // TODO: Write a test for rawValue = Mon Sep 04 2023 18:24:50 GMT-0400 (Eastern Daylight Time) 
+  // TODO: Write a test for rawValue = Mon Sep 04 2023 18:24:50 GMT-0400 (Eastern Daylight Time)
   let thisOptions = deepClone(DEFAULT_DATETIME_MASK_OPTIONS);
   thisOptions = Object.assign(thisOptions, options);
 

--- a/src/components/ids-mask/ids-masks.ts
+++ b/src/components/ids-mask/ids-masks.ts
@@ -313,6 +313,8 @@ function getSplitterRegex(splitterStr: string) {
  * along with extra meta-data about the characters contained.
  */
 export function dateMask(rawValue = '', options: IdsMaskOptions = {}): IdsMaskGeneratorResult {
+  // TODO: this function fails to properly convert new Date()
+  // TODO: Write a test for rawValue = Mon Sep 04 2023 18:24:50 GMT-0400 (Eastern Daylight Time) 
   let thisOptions = deepClone(DEFAULT_DATETIME_MASK_OPTIONS);
   thisOptions = Object.assign(thisOptions, options);
 

--- a/src/components/ids-search-field/ids-search-field.ts
+++ b/src/components/ids-search-field/ids-search-field.ts
@@ -292,11 +292,10 @@ export default class IdsSearchField extends IdsTriggerField {
   set value(val: string) {
     super.value = val;
 
-    const newValue = super.value;
-    this.#previousSearchValue = newValue;
+    this.#previousSearchValue = val;
 
     if (typeof this.onSearch === 'function') {
-      this.onSearch(newValue);
+      this.onSearch(val);
     }
   }
 

--- a/src/components/ids-switch/ids-switch.ts
+++ b/src/components/ids-switch/ids-switch.ts
@@ -84,13 +84,14 @@ export default class IdsSwitch extends Base {
   template(): string {
     const disabled = stringToBool(this.disabled) ? ' disabled' : '';
     const checked = stringToBool(this.checked) ? ' checked' : '';
+    const value = checked ? ` value="${this.value}"` : '';
     const rootClass = ` class="ids-switch${disabled}"`;
     const checkboxClass = ` class="checkbox"`;
 
     return `
       <div${rootClass}>
         <label>
-          <input type="checkbox"${checkboxClass}${disabled}${checked} part="checkbox">
+          <input type="checkbox" part="checkbox" ${checkboxClass}${disabled}${checked}${value}>
           <span class="slider${checked}" part="slider"></span>
           <ids-text class="label-text" part="label">${this.label}</ids-text>
         </label>
@@ -113,8 +114,17 @@ export default class IdsSwitch extends Base {
           this.offEvent(eventName, this.input);
         }
       } else {
-        this.onEvent(eventName, this.input, () => {
+        this.onEvent(eventName, this.input, (e: Event) => {
           this.checked = !!this.input?.checked;
+
+          this.triggerEvent('input.ids-switch', this, {
+            bubbles: true,
+            detail: {
+              elem: this,
+              value: this.checked,
+              nativeEvent: e,
+            }
+          });
         });
       }
     }
@@ -245,9 +255,19 @@ export default class IdsSwitch extends Base {
       this.removeAttribute(attributes.VALUE);
     }
     this.input?.setAttribute(attributes.VALUE, (val || ''));
+    this.checked = !!val;
   }
 
-  get value(): string | null { return this.getAttribute(attributes.VALUE); }
+  /**
+   * Gets the checkbox `value` attribute
+   * @returns {string | null} the value property
+   *
+   * If a checkbox is unchecked when its form is submitted,
+   * neither the name nor the value is submitted to the server.
+   * If the value attribute is omitted, the default value for the checkbox is `on`.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox
+   */
+  get value(): string | null { return this.checked ? (this.getAttribute(attributes.VALUE) ?? 'on') : null; }
 
   /**
    * Overrides the standard "focus" behavior to instead pass focus to the inner HTMLInput element.

--- a/src/components/ids-switch/ids-switch.ts
+++ b/src/components/ids-switch/ids-switch.ts
@@ -32,10 +32,6 @@ const Base = IdsLocaleMixin(
 @customElement('ids-switch')
 @scss(styles)
 export default class IdsSwitch extends Base {
-  // input?: HTMLInputElement | null;
-
-  // labelEl?: HTMLLabelElement | null;
-
   /**
    * Call the constructor and then initialize
    */

--- a/src/components/ids-switch/ids-switch.ts
+++ b/src/components/ids-switch/ids-switch.ts
@@ -125,7 +125,7 @@ export default class IdsSwitch extends Base {
    */
   attachNativeEvents(option = '') {
     if (this.input) {
-      const events = ['change', 'focus', 'keydown', 'keypress', 'keyup', 'click', 'dbclick'];
+      const events = ['focus', 'keydown', 'keypress', 'keyup', 'click', 'dbclick'];
       events.forEach((evt: string) => {
         if (option === 'remove') {
           const handler = this.handledEvents?.get(evt);

--- a/src/components/ids-textarea/ids-textarea.ts
+++ b/src/components/ids-textarea/ids-textarea.ts
@@ -62,6 +62,7 @@ const CHAR_REMAINING_TEXT = 'Characters left {0}';
  * @type {IdsTextarea}
  * @inherits IdsElement
  * @mixes IdsEventsMixin
+ * @mixes IdsFormInputMixin
  * @mixes IdsClearableMixin
  * @mixes IdsDirtyTrackerMixin
  * @mixes IdsLabelStateMixin

--- a/src/components/ids-textarea/ids-textarea.ts
+++ b/src/components/ids-textarea/ids-textarea.ts
@@ -400,8 +400,17 @@ export default class IdsTextarea extends Base {
   handleTextareaChangeEvent(): void {
     const events = ['change', 'input', 'propertychange'];
     events.forEach((evt) => {
-      this.onEvent(evt, this.input, () => {
+      this.onEvent(evt, this.input, (e: Event) => {
         this.value = this.input?.value || '';
+
+        this.triggerEvent('input.ids-textarea', this, {
+          bubbles: true,
+          detail: {
+            elem: this,
+            value: this.value,
+            nativeEvent: e,
+          }
+        });
       });
     });
   }
@@ -423,7 +432,7 @@ export default class IdsTextarea extends Base {
            * @param {object} elem Actual event
            * @param {string} value The updated element value
            */
-          this.triggerEvent(e.type, this, {
+          this.triggerEvent(`${e.type}.ids-textarea`, this, {
             detail: { elem: this, nativeEvent: e, value: this.value }
           });
         });

--- a/src/components/ids-textarea/ids-textarea.ts
+++ b/src/components/ids-textarea/ids-textarea.ts
@@ -3,6 +3,7 @@ import { attributes } from '../../core/ids-attributes';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 
 import IdsEventsMixin from '../../mixins/ids-events-mixin/ids-events-mixin';
+import IdsFormInputMixin from '../../mixins/ids-form-input-mixin/ids-form-input-mixin';
 import IdsLabelStateMixin from '../../mixins/ids-label-state-mixin/ids-label-state-mixin';
 import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsClearableMixin from '../../mixins/ids-clearable-mixin/ids-clearable-mixin';
@@ -21,8 +22,10 @@ const Base = IdsDirtyTrackerMixin(
     IdsLabelStateMixin(
       IdsValidationMixin(
         IdsClearableMixin(
-          IdsEventsMixin(
-            IdsElement
+          IdsFormInputMixin(
+            IdsEventsMixin(
+              IdsElement
+            )
           )
         )
       )
@@ -160,7 +163,16 @@ export default class IdsTextarea extends Base {
    * @returns {HTMLTextAreaElement} reference to this component's inner text input element
    */
   get input(): HTMLTextAreaElement | null {
-    return this.container?.querySelector('textarea') || null;
+    return this.container?.querySelector<HTMLTextAreaElement>('textarea') ?? null;
+  }
+
+  /**
+   * @readonly
+   * @returns {HTMLTextAreaElement} the inner `textarea` element
+   * @see IdsFormInputMixin.formInput
+   */
+  get formInput(): HTMLInputElement | HTMLTextAreaElement | null {
+    return this.input;
   }
 
   /**
@@ -400,17 +412,8 @@ export default class IdsTextarea extends Base {
   handleTextareaChangeEvent(): void {
     const events = ['change', 'input', 'propertychange'];
     events.forEach((evt) => {
-      this.onEvent(evt, this.input, (e: Event) => {
+      this.onEvent(evt, this.input, () => {
         this.value = this.input?.value || '';
-
-        this.triggerEvent('input.ids-textarea', this, {
-          bubbles: true,
-          detail: {
-            elem: this,
-            value: this.value,
-            nativeEvent: e,
-          }
-        });
       });
     });
   }
@@ -767,7 +770,8 @@ export default class IdsTextarea extends Base {
    */
   set value(val: string) {
     const v = val || '';
-    this.setAttribute(attributes.VALUE, v);
+    super.value = v;
+
     if (this.input && this.input.value !== v) {
       this.input.value = this.getMaxValue(v);
       this.input.dispatchEvent(new Event('change', { bubbles: true }));

--- a/src/components/ids-time-picker/ids-time-picker-popup.ts
+++ b/src/components/ids-time-picker/ids-time-picker-popup.ts
@@ -178,8 +178,8 @@ class IdsTimePickerPopup extends Base {
   private attachEventListeners() {
     this.offEvent('change.time-picker-dropdowns');
     this.onEvent('change.time-picker-dropdowns', this.dropdownContainerEl, (e: any) => {
-      const currentId = e.detail?.elem?.id;
-      if (!currentId) return;
+      if (!e.target?.matches?.('ids-dropdown')) return;
+      const currentId = e.target?.id;
 
       this.setAttribute(currentId, e.detail.value);
       if (this.autoupdate) this.triggerSelectedEvent();

--- a/src/components/ids-time-picker/ids-time-picker.ts
+++ b/src/components/ids-time-picker/ids-time-picker.ts
@@ -767,11 +767,14 @@ export default class IdsTimePicker extends Base {
    * @param {string} value label value
    */
   onLabelChange(value: string | null) {
-    if (value) {
-      this.input?.setAttribute(attributes.LABEL, value);
-    } else {
-      this.input?.removeAttribute(attributes.LABEL);
-    }
+    if (this.input) this.input.label = value ?? '';
+    // if (this.input) this.input.label = this.label;
+
+    // if (value) {
+    //   this.input?.setAttribute(attributes.LABEL, value);
+    // } else {
+    //   this.input?.removeAttribute(attributes.LABEL);
+    // }
   }
 
   /**

--- a/src/components/ids-time-picker/ids-time-picker.ts
+++ b/src/components/ids-time-picker/ids-time-picker.ts
@@ -768,13 +768,6 @@ export default class IdsTimePicker extends Base {
    */
   onLabelChange(value: string | null) {
     if (this.input) this.input.label = value ?? '';
-    // if (this.input) this.input.label = this.label;
-
-    // if (value) {
-    //   this.input?.setAttribute(attributes.LABEL, value);
-    // } else {
-    //   this.input?.removeAttribute(attributes.LABEL);
-    // }
   }
 
   /**

--- a/src/components/ids-time-picker/ids-time-picker.ts
+++ b/src/components/ids-time-picker/ids-time-picker.ts
@@ -518,11 +518,7 @@ export default class IdsTimePicker extends Base {
    * Set the input-field's timestring value
    */
   #setTimeOnField(): void {
-    const value = this.#getTimeOnField();
-
-    if (this.input) {
-      this.input.value = value;
-    }
+    this.value = this.#getTimeOnField();
   }
 
   /**

--- a/src/mixins/ids-clearable-mixin/ids-clearable-mixin.ts
+++ b/src/mixins/ids-clearable-mixin/ids-clearable-mixin.ts
@@ -126,11 +126,13 @@ const IdsClearableMixin = <T extends Constraints>(superclass: T) => class extend
     const selfInput = this as IdsInputInterface;
 
     if (selfInput.input) {
-      selfInput.value = '';
+      const value = '';
+      selfInput.value = value;
+      this.triggerEvent('input.ids-clearable', this, { detail: { elem: this, value } });
       selfInput.input.dispatchEvent(new Event('change', { bubbles: true }));
       selfInput.input.focus();
       this.checkContents();
-      this.triggerEvent('cleared', this, { detail: { elem: this, value: selfInput.value } });
+      this.triggerEvent('cleared', this, { detail: { elem: this, value } });
     }
   }
 

--- a/src/mixins/ids-clearable-mixin/ids-clearable-mixin.ts
+++ b/src/mixins/ids-clearable-mixin/ids-clearable-mixin.ts
@@ -127,7 +127,7 @@ const IdsClearableMixin = <T extends Constraints>(superclass: T) => class extend
 
     if (selfInput.input) {
       selfInput.value = '';
-      selfInput.input.dispatchEvent(new Event('change'));
+      selfInput.input.dispatchEvent(new Event('change', { bubbles: true }));
       selfInput.input.focus();
       this.checkContents();
       this.triggerEvent('cleared', this, { detail: { elem: this, value: selfInput.value } });

--- a/src/mixins/ids-form-input-mixin/README.md
+++ b/src/mixins/ids-form-input-mixin/README.md
@@ -1,0 +1,26 @@
+# Ids Form Input Mixin
+
+This mixin adds the capability for custom-elements that implement form input fields
+to participate in a native form submission and validation process.
+
+It also provides a centralized place to trigger the `input` and `change` events on
+these custom-elements.  This is necessary Angular Reactive Forms to properly update binded values.
+
+To implement the form-input mixin:
+
+1. Import `IdsFormInputMixin` and add to the component-base.js
+2. Add `IdsFormInputMixin` to the @mixes comment section
+3. Make sure you attributes extend `return [...super.attributes` in the `attributes` property because `attributes.NAME` and `attributes.VALUE` are added.
+4. Make sure the `connectedCallback` calls `super.connectedCallback();`
+5. You may need to override the `formInput()` method on your custom-element's class.
+
+```js
+/**
+ * @readonly
+ * @returns {HTMLInputElement} the inner `input` element
+ * @see IdsFormInputMixin.formInput
+ */
+get formInput(): HTMLInputElement | null {
+  return this.container?.querySelector<HTMLInputElement>(`input`) ?? null;
+}
+```

--- a/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
+++ b/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
@@ -46,16 +46,19 @@ const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extend
   connectedCallback() {
     super.connectedCallback?.();
 
-    this.formInput?.addEventListener?.('input', (e: Event) => {
-      this.#internals.setFormValue(this.value);
-      this.triggerEvent(`input.${this.name ?? 'ids-form-input-mixin'}`, this, {
-        bubbles: true,
-        detail: {
-          elem: this,
-          value: this.value,
-          nativeEvent: e,
-        }
-      });
+    this.onEvent('change.native', this.formInput, (e: Event) => this.#handleInputEvent(e));
+    this.onEvent('input.native', this.formInput, (e: Event) => this.#handleInputEvent(e));
+  }
+
+  #handleInputEvent(e: Event) {
+    this.#internals.setFormValue(this.value);
+    this.triggerEvent(`input.${this.name ?? 'ids-form-input-mixin'}`, this, {
+      bubbles: true,
+      detail: {
+        elem: this,
+        value: this.value,
+        nativeEvent: e,
+      }
     });
   }
 
@@ -74,7 +77,6 @@ const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extend
   get type() { return this.localName; }
 
   get value() { return this.formInput?.getAttribute?.(attributes.VALUE) ?? ''; }
-  // get value() { return this.formInput?.value ?? ''; }
 
   set value(value: string) { this.formInput?.setAttribute?.(attributes.VALUE, value); }
 

--- a/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
+++ b/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
@@ -72,8 +72,6 @@ const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extend
 
   get form() { return this.#internals.form; }
 
-  get name() { return this.getAttribute(attributes.NAME); }
-
   get type() { return this.localName; }
 
   get value() { return this.formInput?.getAttribute?.(attributes.VALUE) ?? ''; }

--- a/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
+++ b/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
@@ -4,8 +4,6 @@ import { EventsMixinInterface } from '../ids-events-mixin/ids-events-mixin';
 
 type Constraints = IdsConstructor<EventsMixinInterface>;
 
-// class FormInputMixinCustomEvent extends CustomEvent {}
-
 /**
  * Adds validation to any input field
  * @param {any} superclass Accepts a superclass and creates a new subclass from it
@@ -91,16 +89,12 @@ const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extend
 
   #handleChangeEvent(e: Event) {
     const value = this.value;
-    // const value = this.getAttribute(attributes.VALUE);
-    // const formValue = this.#internals?.form;
     this.#internals?.setFormValue?.(value);
 
     if (e instanceof CustomEvent) {
       e.stopPropagation();
-      // e.stopImmediatePropagation();
     }
 
-    // e.preventDefault();
     this.triggerEvent(`change.${this.name ?? 'ids-form-input-mixin'}`, this, {
       bubbles: true,
       composed: true,
@@ -114,13 +108,11 @@ const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extend
 
   #handleInputEvent(e: Event) {
     const value = this.value;
-    // const value = this.getAttribute(attributes.VALUE);
     this.#internals?.setFormValue?.(value);
 
     const inputWrapper = (this.getRootNode() as ShadowRoot)?.host;
     if (inputWrapper) {
       try {
-        // console.log('HELLOWORLD', inputWrapper);
         (inputWrapper as HTMLInputElement).value = value;
       } catch (err) {
         inputWrapper.setAttribute?.(attributes.VALUE, value);

--- a/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
+++ b/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
@@ -1,0 +1,92 @@
+import { attributes } from '../../core/ids-attributes';
+import { IdsConstructor } from '../../core/ids-element';
+import { EventsMixinInterface } from '../ids-events-mixin/ids-events-mixin';
+import { LocaleHandler, LocaleMixinInterface } from '../ids-locale-mixin/ids-locale-mixin';
+
+type Constraints = IdsConstructor<EventsMixinInterface & LocaleMixinInterface & LocaleHandler>;
+
+/**
+ * Adds validation to any input field
+ * @param {any} superclass Accepts a superclass and creates a new subclass from it
+ * @returns {any} The extended object
+ */
+const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extends superclass {
+  #internals = this.attachInternals() as any;
+
+  static formAssociated = true;
+
+  constructor(...args: any[]) {
+    super(...args);
+  }
+
+  /**
+   * @returns {Array<string>} IdsInput component observable attributes
+   */
+  static get attributes() {
+    return [
+      ...(superclass as any).attributes,
+      ...attributes.NAME,
+      ...attributes.VALUE,
+    ];
+  }
+
+  /**
+   * React to attributes changing on the web-component
+   * @param {string} name The property name
+   * @param {string} oldValue The property old value
+   * @param {string} newValue The property new value
+   */
+  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    if (oldValue === newValue) return;
+
+    this.formInput?.setAttribute?.(name, newValue);
+  }
+
+  connectedCallback() {
+    super.connectedCallback?.();
+
+    this.formInput?.addEventListener?.('input', (e: Event) => {
+      this.#internals.setFormValue(this.value);
+      this.triggerEvent(`input.${this.name ?? 'ids-form-input-mixin'}`, this, {
+        bubbles: true,
+        detail: {
+          elem: this,
+          value: this.value,
+          nativeEvent: e,
+        }
+      });
+    });
+  }
+
+  /**
+   * @readonly
+   * @returns {HTMLInputElement} the inner `input` element
+   */
+  get formInput(): HTMLInputElement | undefined | null {
+    return this.container?.querySelector<HTMLInputElement>(`input`);
+  }
+
+  get form() { return this.#internals.form; }
+
+  get name() { return this.getAttribute(attributes.NAME); }
+
+  get type() { return this.localName; }
+
+  get value() { return this.formInput?.getAttribute?.(attributes.VALUE) ?? ''; }
+  // get value() { return this.formInput?.value ?? ''; }
+
+  set value(value: string) { this.formInput?.setAttribute?.(attributes.VALUE, value); }
+
+  get validity() { return this.#internals.validity; }
+
+  get validationMessage() { return this.#internals.validationMessage; }
+
+  get willValidate() { return this.#internals.willValidate; }
+
+  checkValidity() { return this.#internals.checkValidity(); }
+
+  reportValidity() { return this.#internals.reportValidity(); }
+};
+
+export default IdsFormInputMixin;

--- a/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
+++ b/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
@@ -316,7 +316,7 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
     const thisAsInput = this as IdsInputInterface;
 
     if (!id) return;
-    let elem = this.shadowRoot?.querySelector(`[validation-id="${id}"]`);
+    let elem = this.shadowRoot?.querySelector(`div[validation-id="${id}"]`);
     if (elem) return; // Already has this message
 
     // Add error and related details
@@ -391,7 +391,7 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
       }
     };
 
-    const el: any = this.shadowRoot?.querySelector(`[validation-id="${id}"]`);
+    const el: any = this.shadowRoot?.querySelector(`div[validation-id="${id}"]`);
     if (el) {
       removeMsg(el);
     } else if (type && (id === null || typeof id === 'undefined')) {

--- a/test/ids-data-grid/ids-data-grid-func-filters-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-filters-test.ts
@@ -111,6 +111,7 @@ describe('IdsDataGrid Component Filter Tests', () => {
       formatter: formatters.text,
       filterType: dataGrid.filters.dropdown,
       filterConditions: [
+        { value: 'not-filtered', label: '' },
         { value: 'Yes', label: 'Yes' },
         { value: 'No', label: 'No' }
       ]
@@ -663,8 +664,9 @@ describe('IdsDataGrid Component Filter Tests', () => {
   it('should renders filter with slot', () => {
     dataGrid = createFromTemplate(dataGrid, `<ids-data-grid>
       <div slot="filter-trackDeprecationHistory" column-id="trackDeprecationHistory">
-        <ids-dropdown label="Slotted dropdown" id="slotted-dropdown">
+        <ids-dropdown label="Slotted dropdown" id="slotted-dropdown" value="not-filtered">
           <ids-list-box>
+            <ids-list-box-option id="slotted-dropdown-opt-0" value="not-filtered"></ids-list-box-option>
             <ids-list-box-option id="slotted-dropdown-opt-1" value="Yes">Yes</ids-list-box-option>
             <ids-list-box-option id="slotted-dropdown-opt-2" value="No">No</ids-list-box-option>
           </ids-list-box>

--- a/test/ids-search-field/ids-search-field-func-test.ts
+++ b/test/ids-search-field/ids-search-field-func-test.ts
@@ -226,7 +226,7 @@ describe('IdsSearchField Component', () => {
     s.addEventListener('change', changeEventListener);
 
     s.value = 'new keyword here';
-    expect(changeEventListener).toBeCalledTimes(2);
+    expect(changeEventListener).toBeCalledTimes(1);
   });
 
   it('triggers "search" event when action-button clicked', async () => {

--- a/test/ids-switch/ids-switch-func-test.ts
+++ b/test/ids-switch/ids-switch-func-test.ts
@@ -104,7 +104,7 @@ describe('IdsSwitch Component', () => {
     el = document.querySelector('ids-switch') as IdsSwitch;
 
     el.attachNativeEvents('remove');
-    const events = ['change', 'focus', 'keydown', 'keypress', 'keyup', 'click', 'dbclick'];
+    const events = ['focus', 'keydown', 'keypress', 'keyup', 'click', 'dbclick'];
     events.forEach((evt) => {
       let response = null;
       el.addEventListener(evt, () => {

--- a/test/ids-switch/ids-switch-func-test.ts
+++ b/test/ids-switch/ids-switch-func-test.ts
@@ -80,8 +80,8 @@ describe('IdsSwitch Component', () => {
     el.value = value;
     expect(el.getAttribute('value')).toEqual(value);
     expect(el.input?.value).toEqual(value);
-    el.value = null;
-    expect(el.getAttribute('value')).toEqual(null);
+    el.value = '';
+    expect(el.getAttribute('value')).toEqual('');
   });
 
   it('should dispatch native events', () => {
@@ -98,7 +98,6 @@ describe('IdsSwitch Component', () => {
   });
 
   it('should remove events', () => {
-    el.input = null;
     document.body.innerHTML = '';
     const elem: any = new IdsSwitch();
     document.body.appendChild(elem);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Angular's ReactiveForms functionality does not work for some components. I have only tested ids-input, ids-date-picker, ids-time-picker, ids-dropdown, and ids-radio. Only ids-input currently works.

**Related github/jira issue (required)**:

Closes #1166    

**Steps necessary to review your pull request (required)**:

1. Check out this PRs' branch and run: `nvm use && npm run start`
2. Run `npm run publish:link`
3. Clone the WC examples repository: https://github.com/infor-design/enterprise-wc-examples
4. In the examples repository run: `rm -fr .angular/cache`
5. In the examples repository run: `npm install`
6. In the examples repository run: `npm link ids-enterprise-wc`
7. In the examples repository run: `npm run build && npm run start` 
8. Go to: http://localhost:4200/ids-reactive-forms/example
9. Change the values in the different field controls and then click the Submit button.
10. Check the developer console to see updated values of all the form-controls.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
