### PR TITLE
1359 - IdsCalendar fix resizeObserver error

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.15 Features
 
+- `[Calendar]` Fix calendar dependency on ids container. ([#1359](https://github.com/infor-design/enterprise-wc/issues/1359))
 - `[DataGrid]` Treegrid `appendData()` no longer breaks rendering of existing rows, and `scrollend` triggers properly. ([#1425](https://github.com/infor-design/enterprise-wc/issues/1425))
 - `[DataGrid]` Prevent scroll when resize columns. ([#1209](https://github.com/infor-design/enterprise-wc/issues/1209))
 - `[Editor]` Added new toolbar styles in all themes. ([#7606](https://github.com/infor-design/enterprise-wc/issues/7606))

--- a/src/components/ids-accordion/ids-accordion-panel.ts
+++ b/src/components/ids-accordion/ids-accordion-panel.ts
@@ -220,7 +220,7 @@ export default class IdsAccordionPanel extends Base {
    * @returns {void}
    * @private
    */
-  #toggleExpanded(isExpanded: any): void {
+  #toggleExpanded(isExpanded: boolean): void {
     this.header?.setAttribute('aria-expanded', `${isExpanded}`);
 
     if (!isExpanded) {

--- a/src/components/ids-accordion/ids-accordion.ts
+++ b/src/components/ids-accordion/ids-accordion.ts
@@ -483,7 +483,7 @@ export default class IdsAccordion extends Base {
     if (this.panels.length) {
       this.panels.forEach((panel) => {
         if (!excluded || panel !== excluded) {
-          panel.expanded = false;
+          panel.setAttribute(attributes.EXPANDED, String(false));
         }
       });
     }

--- a/src/components/ids-calendar/ids-calendar.ts
+++ b/src/components/ids-calendar/ids-calendar.ts
@@ -227,8 +227,13 @@ export default class IdsCalendar extends Base {
    * Configures IdsCalendar's resize observer
    */
   #configureResizeObserver() {
-    this.#resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => this.#onResize(entries));
-    this.#resizeObserver.observe(getClosest(this, 'ids-container'));
+    const observedElem = getClosest(this, 'ids-container') || this.container;
+    let rafRef: number;
+    this.#resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+      cancelAnimationFrame(rafRef);
+      rafRef = requestAnimationFrame(() => this.#onResize(entries));
+    });
+    this.#resizeObserver.observe(observedElem);
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes calendar's resizeObserver dependency on ids-container. Switched to observing calendar's container element when ids-container isn't in the DOM.

**Additional**
https://github.com/infor-design/enterprise-wc/blob/f58a515a078b3ae883cb41ef680abd9568101291/src/components/ids-accordion/ids-accordion.ts#L486C34-L486C34
The line above was overriding the `expanded` setter inside IdsAccordionPanel to be a simple key/value property (not sure why)
Switched to using `setAttribute` to set `expanded` value

**Related github/jira issue (required)**:
Closes #1359 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to `src\components\ids-calendar\demos\example.ts`
3. Remove the `ids-container` element
4. Check that the [calendar example](http://localhost:4300/ids-calendar/example.html) loads without errors

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
