### PR TITLE
1285 - Fix templating issue in NG

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.15 Features
 
+- `[AppNav]` Fixed an issue when loading in angular templates/router-outlets. ([#1428](https://github.com/infor-design/enterprise-wc/issues/1428))
 - `[DataGrid]` Treegrid `appendData()` no longer breaks rendering of existing rows, and `scrollend` triggers properly. ([#1425](https://github.com/infor-design/enterprise-wc/issues/1425))
 - `[DataGrid]` Prevent scroll when resize columns. ([#1209](https://github.com/infor-design/enterprise-wc/issues/1209))
 - `[Editor]` Added new toolbar styles in all themes. ([#7606](https://github.com/infor-design/enterprise-wc/issues/7606))

--- a/src/components/ids-accordion/ids-accordion.ts
+++ b/src/components/ids-accordion/ids-accordion.ts
@@ -63,6 +63,8 @@ export default class IdsAccordion extends Base {
     this.#contentObserver?.observe((this as any), {
       childList: true
     });
+    if (this.parentElement?.nodeName === 'IDS-APP-MENU') this.colorVariant = 'app-menu';
+    if (this.parentElement?.nodeName === 'IDS-MODULE-NAV-BAR') this.colorVariant = 'module-nav';
   }
 
   disconnectedCallback(): void {

--- a/src/components/ids-app-menu/ids-app-menu.scss
+++ b/src/components/ids-app-menu/ids-app-menu.scss
@@ -7,7 +7,6 @@
   align-items: stretch;
 }
 
-.ids-app-menu-branding,
 .ids-app-menu-footer,
 .ids-app-menu-header,
 .ids-app-menu-search,
@@ -44,9 +43,16 @@
   margin-block-end: var(--ids-space-40);
 }
 
-.ids-app-menu-branding {
-  // Specific Infor Logo sizing (@TODO: maybe make this its own component)
-  ::slotted(ids-icon[icon='logo']) {
-    padding: var(--ids-space-40);
-  }
+// Style Sub Components
+:host {
+  // Buttons
+  --ids-button-color-text-default: var(--ids-button-app-menu-color-text-default);
+  --ids-button-tertiary-color-text-default: var(--ids-button-app-menu-color-text-default);
+  --ids-button-tertiary-color-background-hover: var(--ids-button-app-menu-color-background-hover);
+  --ids-button-tertiary-color-text-hover: var(--ids-button-app-menu-color-text-hover);
+  --ids-button-tertiary-color-text-disabled: var(--ids-button-app-menu-color-text-disabled);
+
+  // Search Field
+  --ids-search-field-header-color-icon-hover: var(--ids-button-app-menu-color-background-hover);
+  --ids-button-formatter-color-text-hover: var(--ids-button-app-menu-color-text-default);
 }

--- a/src/components/ids-app-menu/ids-app-menu.ts
+++ b/src/components/ids-app-menu/ids-app-menu.ts
@@ -11,7 +11,6 @@ import { getClosest } from '../../utils/ids-dom-utils/ids-dom-utils';
 
 import styles from './ids-app-menu.scss';
 import type IdsAccordion from '../ids-accordion/ids-accordion';
-import type IdsButton from '../ids-button/ids-button';
 import type IdsSearchField from '../ids-search-field/ids-search-field';
 import type IdsContainer from '../ids-container/ids-container';
 
@@ -45,7 +44,6 @@ export default class IdsAppMenu extends Base {
     this.edge = 'start';
     this.type = 'app-menu';
     this.#connectSearchField();
-    this.#refreshVariants();
     this.#setContainer();
     this.#attachEventHandlers();
   }
@@ -85,9 +83,6 @@ export default class IdsAppMenu extends Base {
       <div class="ids-app-menu-footer">
         <slot name="footer"></slot>
       </div>
-      <div class="ids-app-menu-branding">
-        <slot name="icon"></slot>
-      </div>
     </div>`;
   }
 
@@ -104,18 +99,6 @@ export default class IdsAppMenu extends Base {
    * @property {boolean} isFiltered true if the inner navigation accordion is currently being filtered
    */
   isFiltered = false;
-
-  #refreshVariants() {
-    const accordions = [...this.querySelectorAll<IdsAccordion>('ids-accordion')];
-    accordions.forEach((acc) => {
-      acc.colorVariant = 'app-menu';
-    });
-
-    const btns = [...this.querySelectorAll<IdsButton>('ids-button')];
-    btns.forEach((btn) => {
-      btn.colorVariant = 'alternate';
-    });
-  }
 
   #attachEventHandlers() {
     this.#detachEventHandlers();

--- a/src/components/ids-button/ids-button-base.scss
+++ b/src/components/ids-button/ids-button-base.scss
@@ -54,7 +54,7 @@
 
   border: 1px solid transparent;
   background-color: transparent;
-  color: currentColor;
+  color: var(--ids-button-color-text-default);
 
   // Animate BG/Text/Border color changes on all styles
   transition:
@@ -297,7 +297,6 @@
       background-color: rgba(255 255 255 / 0.15);
     }
   }
-
 
   // These appear in places with dark background like app menu and masthead, generally default/tertiary buttons
   &.color-variant-alternate,

--- a/src/components/ids-button/ids-button.scss
+++ b/src/components/ids-button/ids-button.scss
@@ -120,8 +120,6 @@ button {
   @include ids-base-button-styles();
   @include ids-standard-button-colors();
 
-  color: var(--ids-button-color-text-default);
-
   // Everything below is only for icon buttons
   padding-inline-start: var(--ids-button-icon-padding);
   padding-inline-end: var(--ids-button-icon-padding);

--- a/src/components/ids-button/ids-button.scss
+++ b/src/components/ids-button/ids-button.scss
@@ -120,6 +120,8 @@ button {
   @include ids-base-button-styles();
   @include ids-standard-button-colors();
 
+  color: var(--ids-button-color-text-default);
+
   // Everything below is only for icon buttons
   padding-inline-start: var(--ids-button-icon-padding);
   padding-inline-end: var(--ids-button-icon-padding);

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -290,6 +290,7 @@
   --ids-box-width: auto;
 
   // Button (Primary)
+  --ids-button-color-text-default: currentColor;
   --ids-button-primary-color-border-default: var(--ids-color-primary);
   --ids-button-primary-color-background-default: var(--ids-color-primary);
   --ids-button-primary-color-text-default: var(--ids-color-text-on-primary);
@@ -328,6 +329,12 @@
 
   // Button (Destructive)
   --ids-button-destructive-color-background-hover: var(--ids-color-error-10);
+
+  // Button (App Menu)
+  --ids-button-app-menu-color-text-default: var(--ids-color-neutral-20);
+  --ids-button-app-menu-color-background-hover: var(--ids-color-neutral-90);
+  --ids-button-app-menu-color-text-hover: var(--ids-color-neutral-00);
+  --ids-button-app-menu-color-text-disabled: var(--ids-color-neutral-50);
 
   // Button (Alternate)
   --ids-button-alternate-color-text-default: var(--ids-color-neutral-10);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

- Fixed an issue when including app nav as a component in sub components. And a related icon hover color issue. This was done by removing color-variant mixin from app-menu, and adding some tokens for the app menu buttons. Then do a reverse lookup to fix accordion since it was too tricky to refactor to css vars right now.
- Fixed an issue on button color hover too 
- Removed branding from app menu (deprecated)
- I need to monitor Percy tests for issues.

**Related github/jira issue (required)**:
Fixes #1285 
Fixes #1404 

**Steps necessary to review your pull request (required)**:
- first take this zip of a NG project atttached, then unzip it into any folder, then run `npm i && npm run start`
- open each menu on the example NG app and see the menu is messed up
- pull this down then run `npm run build:dist`
- copy `dist/develop` or npm link to `node_modules/ids-enterprise-wc` in the ng project
- restart  NG app and see each menu on the example is fixed
- for #1285 run http://localhost:4300/ids-app-menu/example.html and make sure it looks ok generally and the X hover is fixed
- test accordion and buttons (smoke test) or anything else you think

**Included in this Pull Request**:
- [x] A note to the change log.

