### PR TITLE
1435 - IdsNotificationBanner wrap messages

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Locale]` Made Locale a global instance and moved it off ids-container and related fixes. ([#663](https://github.com/infor-design/enterprise-wc/issues/663))
 - `[Message]` Fix modal button separator. ([#1414](https://github.com/infor-design/enterprise-wc/issues/1414))
 - `[ModuleNav]` Added IdsModuleNav component with basic Role Switcher, Settings component. ([#1226](https://github.com/infor-design/enterprise-wc/issues/1226))
+- `[NotificationBanner]` Added `wrap` setting for notification banner. ([#1435](https://github.com/infor-design/enterprise-wc/issues/1435))
 - `[PopupMenu]` Add support for RTL. ([#1429](https://github.com/infor-design/enterprise-wc/issues/1429))
 - `[Toolbar]` Added tooltip to the more button on toolbars. ([#1318](https://github.com/infor-design/enterprise-wc/issues/1318))
 

--- a/src/components/ids-notification-banner/demos/example.html
+++ b/src/components/ids-notification-banner/demos/example.html
@@ -38,6 +38,14 @@
       type="error"
       link="https://infor.com">
     </ids-notification-banner>
+
+    <ids-notification-banner
+      id="ids-notification-banner-4"
+      message-text="Notification Banner with text wrapping Sept 30, 2023."
+      type="info"
+      link="https://infor.com"
+      wrap="true">
+    </ids-notification-banner>
   </ids-container>
 </body>
 </html>

--- a/src/components/ids-notification-banner/demos/example.html
+++ b/src/components/ids-notification-banner/demos/example.html
@@ -41,7 +41,7 @@
 
     <ids-notification-banner
       id="ids-notification-banner-4"
-      message-text="Notification Banner with text wrapping Sept 30, 2023."
+      message-text="Notification Banner with text wrapping. Shrink browser to see effect. Updated Sept 15, 2023."
       type="info"
       link="https://infor.com"
       wrap="true">

--- a/src/components/ids-notification-banner/ids-notification-banner.scss
+++ b/src/components/ids-notification-banner/ids-notification-banner.scss
@@ -50,7 +50,7 @@ ids-button::part(button):hover {
 
   &.wrap {
     white-space: unset;
-    padding-block: var(--ids-space-40);
+    padding-block: var(--ids-space-50);
   }
 }
 

--- a/src/components/ids-notification-banner/ids-notification-banner.scss
+++ b/src/components/ids-notification-banner/ids-notification-banner.scss
@@ -3,7 +3,7 @@
   display: flex;
   padding-inline-start: var(--ids-notification-padding);
   align-items: center;
-  height: var(--ids-notification-banner-height);
+  min-height: var(--ids-notification-banner-height);
 }
 
 ids-alert,
@@ -47,6 +47,10 @@ ids-button::part(button):hover {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  &.wrap {
+    white-space: unset;
+  }
 }
 
 .ids-notification-banner[type='success'],

--- a/src/components/ids-notification-banner/ids-notification-banner.scss
+++ b/src/components/ids-notification-banner/ids-notification-banner.scss
@@ -50,6 +50,7 @@ ids-button::part(button):hover {
 
   &.wrap {
     white-space: unset;
+    padding-block: var(--ids-space-40);
   }
 }
 

--- a/src/components/ids-notification-banner/ids-notification-banner.ts
+++ b/src/components/ids-notification-banner/ids-notification-banner.ts
@@ -13,6 +13,7 @@ import IdsKeyboardMixin from '../../mixins/ids-keyboard-mixin/ids-keyboard-mixin
 import IdsElement from '../../core/ids-element';
 
 import styles from './ids-notification-banner.scss';
+import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 
 const Base = IdsKeyboardMixin(
   IdsEventsMixin(
@@ -56,7 +57,8 @@ export default class IdsNotificationBanner extends Base {
       attributes.MESSAGE_TEXT,
       attributes.LINK,
       attributes.LINK_TEXT,
-      attributes.TYPE
+      attributes.TYPE,
+      attributes.WRAP
     ];
   }
 
@@ -74,12 +76,13 @@ export default class IdsNotificationBanner extends Base {
     }
 
     const type = (!this.type || TYPES[this.type] === undefined) ? TYPES.success.type : this.type;
+    const overflow = this.wrap ? '' : 'overflow="ellipsis"';
 
     return `
       <div class="ids-notification-banner" part="container" type="${type}">
         <ids-alert icon="${alertIcon === 'warning' ? 'alert' : alertIcon}"></ids-alert>
-        <div class="ids-notification-banner-message" part="message">
-          <ids-text overflow="ellipsis">${this.messageText !== null ? this.messageText : 'Enter Message Text.'}</ids-text>
+        <div class="ids-notification-banner-message ${this.wrap ? 'wrap' : ''}" part="message">
+          <ids-text ${overflow}>${this.messageText !== null ? this.messageText : 'Enter Message Text.'}</ids-text>
         </div>
 
         ${this.link !== null ? `<div part="link">
@@ -94,6 +97,30 @@ export default class IdsNotificationBanner extends Base {
         </div>
       </div>
     `;
+  }
+
+  /**
+   * Toggle text wrapping for overflowing messages.
+   * Text overflow style is ellipsis by default.
+   * @param {boolean | null} value wrapText value
+   */
+  set wrap(value: boolean | null) {
+    const messageContainer = this.container?.querySelector('.ids-notification-banner-message');
+    const messageText = messageContainer?.querySelector('ids-text');
+
+    if (stringToBool(value)) {
+      this.setAttribute(attributes.WRAP, '');
+      messageContainer?.classList.add('wrap');
+      messageText?.setAttribute(attributes.OVERFLOW, 'none');
+    } else {
+      this.removeAttribute(attributes.WRAP);
+      messageContainer?.classList.remove('wrap');
+      messageText?.setAttribute(attributes.OVERFLOW, 'ellipsis');
+    }
+  }
+
+  get wrap(): boolean {
+    return stringToBool(this.getAttribute(attributes.WRAP));
   }
 
   /**
@@ -194,6 +221,7 @@ export default class IdsNotificationBanner extends Base {
     } = notification;
     const messageTextEl = this.container?.querySelector('[part="message"]');
     const alertIcon = this.container?.querySelector('ids-alert');
+    const overflow = this.wrap ? '' : 'overflow="ellipsis"';
 
     // Set properties
     if (id) {
@@ -202,7 +230,7 @@ export default class IdsNotificationBanner extends Base {
     this.type = type;
     this.messageText = messageText;
     alertIcon?.setAttribute('icon', this.type ?? '');
-    if (messageTextEl) messageTextEl.innerHTML = `<ids-text overflow="ellipsis">${this.messageText}</ids-text>`;
+    if (messageTextEl) messageTextEl.innerHTML = `<ids-text ${overflow}>${this.messageText}</ids-text>`;
 
     // Check for link and create the necassary elements.
     if (notification.link) {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Add `wrap` setting to allow message texts to wrap when overflowing. 
Text overflow is ellipsis by default.

**Related github/jira issue (required)**:
Closes #1435 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-notification-banner/example.html
3. The last notification banner has `wrap` enabled
4. Decrease browser size to test text wrapping behavior/style
5. Try setting `wrap` attribute on the other banners via dev tools to ensure the setting works during runtime

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
