### PR TITLE
1497 - IdsDataGrid fix rowStart scrollbar position

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[DataGrid]` Prevent scroll when resize columns. ([#1209](https://github.com/infor-design/enterprise-wc/issues/1209))
 - `[DataGrid]` Added new colored header and related styles. ([#1285](https://github.com/infor-design/enterprise-wc/issues/1285))
 - `[DataGrid]` Fix virtual/infinite scroll when max rows in dom reached. ([#1454](https://github.com/infor-design/enterprise-wc/issues/1454))
+- `[DataGrid]` Fix rowStart scrollbar position on load. ([#1497](https://github.com/infor-design/enterprise-wc/issues/1497))
 - `[Editor]` Added new toolbar styles in all themes. ([#7606](https://github.com/infor-design/enterprise-wc/issues/7606))
 - `[Editor]` Fixed issue where buttons are disabled in source view. ([#1195](https://github.com/infor-design/enterprise-wc/issues/1195))
 - `[Locale]` Made Locale a global instance and moved it off ids-container and related fixes. ([#663](https://github.com/infor-design/enterprise-wc/issues/663))

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -9,6 +9,8 @@
 
 :host {
   --ids-data-grid-column-widths: repeat(1, minmax(110px, 1fr));
+
+  contain: content;
 }
 
 .ids-data-grid {
@@ -18,7 +20,6 @@
   border-radius: var(--ids-border-radius-01);
   border-collapse: collapse;
   box-sizing: border-box;
-  contain: content;
   overflow: auto;
   width: 100%;
 
@@ -159,16 +160,20 @@
   &.is-list-style {
     border-width: 0;
   }
+
+  // Used for row start
+  &.waiting-load {
+    overflow: hidden;
+
+    .ids-data-grid-body {
+      visibility: hidden;
+    }
+  }
 }
 
 // Used for Frozen Columns
 .ids-data-grid-body {
   min-width: fit-content;
-}
-
-// Used for row start
-.ids-data-grid-body.hidden {
-  visibility: hidden;
 }
 
 // Standalone Css Borders

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -221,6 +221,7 @@ export default class IdsDataGrid extends Base {
 
     let cssClasses = `${this.alternateRowShading ? ' alt-row-shading' : ''}`;
     cssClasses += `${this.listStyle ? ' is-list-style' : ''}`;
+    cssClasses += ' waiting-load';
     const emptyMesageTemplate = emptyMessageTemplate.apply(this);
 
     const html = `<div class="ids-data-grid-wrapper">
@@ -369,6 +370,7 @@ export default class IdsDataGrid extends Base {
     // Handle ready state
     const handleReady = () => {
       this.header?.setIsHeaderExpanderCollapsed?.();
+      this.container?.classList.remove('waiting-load');
       this.triggerEvent('afterrendered', this, { bubbles: true, detail: { elem: this } });
     };
 
@@ -381,7 +383,6 @@ export default class IdsDataGrid extends Base {
     } else {
       await IdsGlobal.onThemeLoaded().promise;
       this.#scrollRowIntoView(rowStart);
-      this.body?.classList.remove('hidden');
       handleReady();
     }
   }
@@ -408,10 +409,7 @@ export default class IdsDataGrid extends Base {
    * @returns {string} The template
    */
   bodyTemplate() {
-    let extraCss = '';
-    extraCss += this.rowStart ? 'hidden' : '';
-
-    return `<div class="ids-data-grid-body ${extraCss}" part="contents" role="rowgroup">${this.bodyInnerTemplate()}</div>`;
+    return `<div class="ids-data-grid-body" part="contents" role="rowgroup">${this.bodyInnerTemplate()}</div>`;
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fix scrollbar position on page load when rowStart is set

**Related github/jira issue (required)**:
Fixes #1497 
Related to #1368 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to following examples
3. http://localhost:4300/ids-data-grid/row-start.html
4. http://localhost:4300/ids-data-grid/virtual-scroll-infinite-scroll-m3.html
5. http://localhost:4300/ids-data-grid/virtual-scroll-infinite-scroll-m3.html
6. Check that the scrollbar is first rendered/appears at the rowStart position

**Additional**
`contain: content` was moved to IdsDataGrid's `:host` element
This fixes the cut off border top of the datagrid when using `scrollIntoView` 
Can be seen here (https://main.wc.design.infor.com/ids-data-grid/row-start.html)

Please check that this doesn't break any popup positions inside the data grid (datapicker, timepicker, filter etc.)
http://localhost:4300/ids-data-grid/editable.html
http://localhost:4300/ids-data-grid/filter.html

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
