### PR TITLE
1473 - IdsCalendar hide month view legend

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.15 Features
 
 - `[AppNav]` Fixed an issue when loading in angular templates/router-outlets. ([#1428](https://github.com/infor-design/enterprise-wc/issues/1428))
+- `[Calendar]` Fix hiding legend in mobilde view. ([#1473](https://github.com/infor-design/enterprise-wc/issues/1473))
 - `[Calendar]` Fix calendar dependency on ids container. ([#1359](https://github.com/infor-design/enterprise-wc/issues/1359))
 - `[DataGrid]` Tree grid `appendData()` no longer breaks rendering of existing rows, and `scrollend` triggers properly. ([#1425](https://github.com/infor-design/enterprise-wc/issues/1425))
 - `[DataGrid]` Prevent scroll when resize columns. ([#1209](https://github.com/infor-design/enterprise-wc/issues/1209))

--- a/src/components/ids-calendar/ids-calendar.ts
+++ b/src/components/ids-calendar/ids-calendar.ts
@@ -1222,7 +1222,7 @@ export default class IdsCalendar extends Base {
 
     let legendData: Array<any> | null = null;
 
-    if (show && Array.isArray(eventTypes) && eventTypes.length) {
+    if (show && this.showLegend && Array.isArray(eventTypes) && eventTypes.length) {
       legendData = eventTypes.map((item: CalendarEventTypeData) => ({
         name: item.label,
         color: `${item.color}-60`,


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fix hiding month view legend in mobile views when `showLegend="false"`

**Related github/jira issue (required)**:
Fixes #1473 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-calendar/example.html
3. Run `$('ids-calendar').showLegend = false;` in dev console
4. Resize browser to mobile view and check that the legend isn't showing

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
