### PR TITLE
1410 - data-grid contextmenu submenu off-screen

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[DataGrid]` Added new colored header and related styles. ([#1285](https://github.com/infor-design/enterprise-wc/issues/1285))
 - `[DataGrid]` Fix virtual/infinite scroll when max rows in DOM reached. ([#1454](https://github.com/infor-design/enterprise-wc/issues/1454))
 - `[DataGrid]` Fix rowStart scrollbar position on load. ([#1497](https://github.com/infor-design/enterprise-wc/issues/1497))
+- `[DataGrid]` Fix contextmenu submenu so that it properly overflows if innumerable menu-items. ([#1410](https://github.com/infor-design/enterprise-wc/issues/1410))
 - `[Editor]` Added new toolbar styles in all themes. ([#7606](https://github.com/infor-design/enterprise-wc/issues/7606))
 - `[Editor]` Fixed issue where buttons are disabled in source view. ([#1195](https://github.com/infor-design/enterprise-wc/issues/1195))
 - `[Icons]` Fixes for new icons pipeline, new icons and cleanup. ([#518](https://github.com/infor-design/design-system/issues/518))

--- a/src/components/ids-data-grid/demos/contextmenu-submenu-mega.html
+++ b/src/components/ids-data-grid/demos/contextmenu-submenu-mega.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid - Contextmenu</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+
+        <ids-data-grid id="data-grid-contextmenu" row-selection="multiple" label="Books">
+
+          <!-- Header Contextmenu -->
+          <ids-popup-menu trigger-type="custom" slot="header-contextmenu">
+            <ids-menu-group>
+              <ids-menu-item value="header-split">Split</ids-menu-item>
+              <ids-menu-item value="header-sort">Sort</ids-menu-item>
+              <ids-menu-item value="header-hide">Hide</ids-menu-item>
+            </ids-menu-group>
+          </ids-popup-menu>
+
+          <!-- Contextmenu -->
+          <ids-popup-menu trigger-type="custom" slot="contextmenu">
+            <ids-menu-group>
+              <ids-menu-item value="item-one">Item One</ids-menu-item>
+              <ids-menu-item value="item-two">Item Two</ids-menu-item>
+              <ids-menu-item value="item-three">Item Three</ids-menu-item>
+              <ids-menu-item value="item-four">Item Four</ids-menu-item>
+              <ids-separator></ids-separator>
+              <ids-menu-item id="item-five" value="more-actions">
+                More Actions
+                <ids-popup-menu>
+                  <ids-menu-group>
+                    <ids-menu-item value="setting-one">Setting 1</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 2</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 3</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 4</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 5</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 6</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 7</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 8</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 9</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 10</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 11</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 12</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 13</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 14</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 15</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 16</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 17</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 18</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 19</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 20</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 21</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 22</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 23</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 24</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 25</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 26</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 27</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 28</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 29</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 30</ids-menu-item>
+                    <ids-menu-item value="setting-one">Setting 31</ids-menu-item>
+                    <ids-menu-item value="setting-two">Setting 32</ids-menu-item>
+                    <ids-menu-item value="setting-three">Setting 33</ids-menu-item>
+                  </ids-menu-group>
+                </ids-popup-menu>
+              </ids-menu-item>
+              <ids-menu-item id="item-six" value="even-more-actions">
+                Even More Actions
+                <ids-popup-menu>
+                  <ids-menu-group>
+                    <ids-menu-item icon="settings" value="change-settings">
+                      Change Settings
+                      <ids-popup-menu>
+                        <ids-menu-group>
+                          <ids-menu-item value="setting-one">Setting 1</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 2</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 3</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 4</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 5</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 6</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 7</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 8</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 9</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 10</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 11</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 12</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 13</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 14</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 15</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 16</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 17</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 18</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 19</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 20</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 21</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 22</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 23</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 24</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 25</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 26</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 27</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 28</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 29</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 30</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 31</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 32</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 33</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 34</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 35</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 36</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 37</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 38</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 39</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 40</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 41</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 42</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 43</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 44</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 45</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 46</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 47</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 48</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 49</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 50</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 51</ids-menu-item>
+                          <ids-menu-item value="setting-one">Setting 52</ids-menu-item>
+                          <ids-menu-item value="setting-two">Setting 53</ids-menu-item>
+                          <ids-menu-item value="setting-three">Setting 54</ids-menu-item>
+                          <ids-menu-item value="reaaaaalllly-long-setting-number-four">REAAAAALLLLY Long Setting Number Four</ids-menu-item>
+                        </ids-menu-group>
+                      </ids-popup-menu>
+                    </ids-menu-item>
+                    <ids-menu-item icon="mail" value="send-mail">Send Mail</ids-menu-item>
+                    <ids-menu-item icon="filter" value="filter-content">Filter Content</ids-menu-item>
+                  </ids-menu-group>
+                </ids-popup-menu>
+              </ids-menu-item>
+            </ids-menu-group>
+          </ids-popup-menu>
+
+        </ids-data-grid>
+
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/contextmenu-submenu-mega.ts
+++ b/src/components/ids-data-grid/demos/contextmenu-submenu-mega.ts
@@ -1,0 +1,141 @@
+import '../ids-data-grid';
+import booksJSON from '../../../assets/data/books.json';
+import IdsGlobal from '../../ids-global/ids-global';
+
+// Example for populating the DataGrid
+const dataGrid: any = document.querySelector('#data-grid-contextmenu');
+const locale = IdsGlobal.getLocale();
+
+if (dataGrid) {
+  (async function init() {
+    // Set Locale and wait for it to load
+    await locale.setLocale('en-US');
+
+    // Do an ajax request
+    const url: any = booksJSON;
+    const columns = [];
+
+    // Set up columns
+    columns.push({
+      id: 'selectionCheckbox',
+      name: 'selection',
+      sortable: false,
+      resizable: false,
+      formatter: dataGrid.formatters.selectionCheckbox,
+      align: 'center'
+    });
+    columns.push({
+      id: 'rowNumber',
+      name: '#',
+      formatter: dataGrid.formatters.rowNumber,
+      sortable: false,
+      readonly: true,
+      width: 65
+    });
+    columns.push({
+      id: 'description',
+      name: 'Description',
+      field: 'description',
+      sortable: true,
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'ledger',
+      name: 'Ledger',
+      field: 'ledger',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'publishDate',
+      name: 'Pub. Date',
+      field: 'publishDate',
+      formatter: dataGrid.formatters.date
+    });
+    columns.push({
+      id: 'publishTime',
+      name: 'Pub. Time',
+      field: 'publishDate',
+      formatter: dataGrid.formatters.time
+    });
+    columns.push({
+      id: 'price',
+      name: 'Price',
+      field: 'price',
+      formatter: dataGrid.formatters.decimal,
+      formatOptions: { locale: 'en-US' } // Data Values are in en-US
+    });
+    columns.push({
+      id: 'bookCurrency',
+      name: 'Currency',
+      field: 'bookCurrency',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'transactionCurrency',
+      name: 'Transaction Currency',
+      field: 'transactionCurrency',
+      formatter: dataGrid.formatters.text,
+    });
+    columns.push({
+      id: 'integer',
+      name: 'Price (Int)',
+      field: 'price',
+      formatter: dataGrid.formatters.integer,
+      formatOptions: { locale: 'en-US' } // Data Values are in en-US
+    });
+    columns.push({
+      id: 'location',
+      name: 'Location',
+      field: 'location',
+      formatter: dataGrid.formatters.hyperlink,
+      href: '#'
+    });
+    columns.push({
+      id: 'postHistory',
+      name: 'Post History',
+      field: 'postHistory',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'active',
+      name: 'Active',
+      field: 'active',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'convention',
+      name: 'Convention',
+      field: 'convention',
+      formatter: dataGrid.formatters.text
+    });
+    columns.push({
+      id: 'methodSwitch',
+      name: 'Method Switch',
+      field: 'methodSwitch',
+      formatter: dataGrid.formatters.text
+    });
+
+    dataGrid.columns = columns;
+    const setData = async () => {
+      const res = await fetch(url);
+      const data = await res.json();
+      dataGrid.data = data;
+
+      // Set veto before contextmenu show
+      dataGrid.addEventListener('beforemenushow', (e: any) => {
+        console.info('before contextmenu show', e.detail);
+        // e.detail.response(false);
+      });
+
+      dataGrid.addEventListener('menushow', (e: any) => {
+        console.info('After contextmenu show', e.detail);
+      });
+
+      dataGrid.addEventListener('menuselected', (e: any) => {
+        console.info('contextmenu item selected', e.detail);
+      });
+    };
+
+    setData();
+  }());
+}

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -68,6 +68,9 @@
   - link: contextmenu.html
     type: Example
     description: Shows a data grid with contextmenu
+  - link: contextmenu-submenu-mega.html
+    type: Example
+    description: Shows a data grid with contextmenu containing an extremely large submenu
   - link: contextmenu-thru-id.html
     type: Example
     description: Shows a data grid with contextmenu thru id

--- a/src/components/ids-menu/ids-menu-group.scss
+++ b/src/components/ids-menu/ids-menu-group.scss
@@ -7,4 +7,9 @@
 
 .ids-menu-group {
   @include reset-menu-style();
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  max-height: 90vh;
+  width: max-content; // Doesn't work in Safari and Firefox
 }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

The submenu on `IdsDataGrid` contextmenu was running off-screen whenever too many menu-items were included. This PR fixes CSS so that submenu-items flow into a grid and are properly displayed on-screen.

**Related github/jira issue (required)**:

Closes #1410     

**Steps necessary to review your pull request (required)**:

1. Check out this PRs' branch and run: `nvm use && npm run start`
2. Go to: http://localhost:4300/ids-data-grid/contextmenu-submenu-mega.html
3. Right-click on any cell in the datagrid.
4. See first submenu under "More Actions"
5. See second submenu under "Even More Actions" >> "Change Settings"

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
