### PR TITLE
1519 - Fix icon sizes in safari

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,13 +7,14 @@
 ### 1.0.0-beta.16 Fixes
 
 - `[Modal]` Changed the way z-index counting works to prevent a TypeScript/Angular compiler bug. ([#1476](https://github.com/infor-design/enterprise-wc/issues/1476))
+- `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 
 ## 1.0.0-beta.15
 
 ### 1.0.0-beta.15 Features
 
 - `[AppNav]` Fixed an issue when loading in angular templates/router-outlets. ([#1428](https://github.com/infor-design/enterprise-wc/issues/1428))
-- `[Calendar]` Fix hiding legend in mobilde view. ([#1473](https://github.com/infor-design/enterprise-wc/issues/1473))
+- `[Calendar]` Fix hiding legend in mobile view. ([#1473](https://github.com/infor-design/enterprise-wc/issues/1473))
 - `[Calendar]` Fix calendar dependency on ids container. ([#1359](https://github.com/infor-design/enterprise-wc/issues/1359))
 - `[DataGrid]` Tree grid `appendData()` no longer breaks rendering of existing rows, and `scrollend` triggers properly. ([#1425](https://github.com/infor-design/enterprise-wc/issues/1425))
 - `[DataGrid]` Prevent scroll when resize columns. ([#1209](https://github.com/infor-design/enterprise-wc/issues/1209))

--- a/src/components/ids-icon/ids-icon.scss
+++ b/src/components/ids-icon/ids-icon.scss
@@ -7,16 +7,10 @@
   position: relative;
 }
 
-svg:not([height]) {
-  height: var(--ids-icon-height-default);
-}
-
-svg:not([width]) {
-  width: var(--ids-icon-width-default);
-}
-
 svg {
   color: var(--ids-icon-color-default);
+  height: var(--ids-icon-height-default);
+  width: var(--ids-icon-width-default);
 }
 
 :host([hidden]) {

--- a/src/components/ids-icon/ids-icon.ts
+++ b/src/components/ids-icon/ids-icon.ts
@@ -307,7 +307,7 @@ export default class IdsIcon extends Base {
     if (value) {
       this.removeAttribute(attributes.SIZE);
       this.setAttribute(attributes.HEIGHT, value);
-      this.container?.setAttribute('height', value);
+      this?.style.setProperty('--ids-icon-height-default', `${value}px`);
     } else {
       this.removeAttribute(attributes.HEIGHT);
     }
@@ -368,7 +368,7 @@ export default class IdsIcon extends Base {
     if (value) {
       this.removeAttribute(attributes.SIZE);
       this.setAttribute(attributes.WIDTH, value);
-      this.container?.setAttribute('width', value);
+      this?.style.setProperty('--ids-icon-width-default', `${value}px`);
     } else {
       this.removeAttribute(attributes.WIDTH);
     }
@@ -417,8 +417,8 @@ export default class IdsIcon extends Base {
     if (value && sizes[value]) {
       const size = sizes[this.size];
       this.setAttribute(attributes.SIZE, value);
-      this.container?.setAttribute('height', String(size));
-      this.container?.setAttribute('width', String(size));
+      this?.style.setProperty('--ids-icon-height-default', `${String(size)}px`);
+      this?.style.setProperty('--ids-icon-width-default', `${String(size)}px`);
     } else {
       this.removeAttribute(attributes.SIZE);
     }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Fixed an issue with sizes of icons in safari / how css variables are applied on them

**Related github/jira issue (required)**:
Fixes #1519 

**Steps necessary to review your pull request (required)**:
- check icon size on http://localhost:4300/ids-hyperlink/box.html
- check sizes on http://localhost:4300/ids-icon/example.html (scroll down to bottom to see the different sizes empty states)
- NOTE: Test in both safari and chrome (and ff) and ensure icons are all sized correctly now

**Included in this Pull Request**:
- [x] A note to the change log.