### PR TITLE
1498 - Added support for base href

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 1.0.0-beta.16 Features
 
+- `[Themes]` For theme switching added logic to check for a `<base href="">` tag. ([#1498](https://github.com/infor-design/enterprise-wc/issues/1498))
+
 ### 1.0.0-beta.16 Fixes
 
 - `[DataGrid]` Fixed a bug on the size of the `xxs` filter row inputs. ([#1456](https://github.com/infor-design/enterprise-wc/issues/1456))

--- a/src/components/ids-theme-switcher/demos/base-href.html
+++ b/src/components/ids-theme-switcher/demos/base-href.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <ids-container role="main" padding="8" hidden>
-    <ids-theme-switcher mode="light" self-managed></ids-theme-switcher>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
     <ids-layout-grid auto-fit="true" padding="md">
       <ids-text font-size="12" type="h1">Themes</ids-text>
     </ids-layout-grid>

--- a/src/components/ids-theme-switcher/demos/base-href.html
+++ b/src/components/ids-theme-switcher/demos/base-href.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+  <base href="/myappui/">
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" self-managed></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Themes</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-tag>Normal Tag</ids-tag>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-theme-switcher/demos/base-href.ts
+++ b/src/components/ids-theme-switcher/demos/base-href.ts
@@ -1,0 +1,1 @@
+import '../../ids-tag/ids-tag';

--- a/src/components/ids-theme-switcher/demos/index.yaml
+++ b/src/components/ids-theme-switcher/demos/index.yaml
@@ -3,26 +3,29 @@
  link: ids-theme-switcher
  description: Set and control themes
  category: Navigation and Interaction
- keywords: theme, color, switcher
+ keywords: theme, color, switcher, personalization
  examples:
   - link: example.html
     type: Main Example
     description: Showing a tag with the switcher
+  - link: base-href.html
+    type: Example
+    description: Showing theme switcher works with a base href
   - link: hidden.html
     type: Example
     description: Showing a switcher that is hidden but still functional
   - link: self-managed.html
     type: Example
     description: Showing ignoreing fetch attempts
-  - link: use-link.html
-    type: Example
-    description: Showing using a link for the css files
   - link: theme-builder.html
     type: Example
     description: Showing a theme builder example
   - link: theme-builder-minimal.html
     type: Example
     description: Showing a theme builder example with just what changes
+  - link: use-link.html
+    type: Example
+    description: Showing using a link for the css files
 
 
 

--- a/src/core/ids-element.ts
+++ b/src/core/ids-element.ts
@@ -255,7 +255,9 @@ export default class IdsElement extends HTMLElement {
     if (isSelfManaged) return;
 
     // Handle auto themes
-    const response = await fetch(`../themes/ids-theme-${theme}.css`, { cache: 'reload' });
+    const baseHref = document.querySelector('base');
+    const subUrl = baseHref?.getAttribute('href') || '/';
+    const response = await fetch(`..${subUrl}themes/ids-theme-${theme}.css`, { cache: 'reload' });
     const themeStyles = await response.text();
     const head = (document.head as any);
     const styleElem = document.querySelector('#ids-theme');

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -143,6 +143,21 @@ module.exports = {
             return css;
           }
         },
+        { // used to test base-href
+          from: './src/themes/**/*.scss',
+          to({ absoluteFilename }) {
+            const baseName = path.basename(absoluteFilename);
+            return `myappui/themes/${baseName.replace('scss', 'css')}`;
+          },
+          transform(content, transFormPath) {
+            const result = sass.renderSync({
+              file: transFormPath
+            });
+            let css = result.css.toString();
+            css = css.replace(':host {', ':root {');
+            return css;
+          }
+        },
       ]
     }),
   ].concat(htmlExamples)


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Changed the theme fetching logic to use any `<base>` tags if they exist in the page.

**Related github/jira issue (required)**:
Fixes #1498

**Steps necessary to review your pull request (required)**:
- go to page http://localhost:4300/ids-theme-switcher/example.html
- check the network tab in dev tools
- switch themes to dark and contrast
- in all cases theme should work and the path should be like `http://localhost:4300/themes/...`
- http://localhost:4300/ids-theme-switcher/base-href.html
- switch themes to dark and contrast
- in all cases theme should work and the path should be like `http://localhost:4300/myappui/themes/...`

**Included in this Pull Request**:
- [x] A note to the change log.