### PR TITLE
1453 - IdsDataGrid fixed datagrid contextmenu focus state

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 1.0.0-beta.16 Fixes
 
+- `[DataGrid]` Fixed contextmenu focused menu item in datagrid. ([#1453](https://github.com/infor-design/enterprise-wc/issues/1453))
 - `[DataGrid]` Fixed a bug on the size of the `xxs` filter row inputs. ([#1456](https://github.com/infor-design/enterprise-wc/issues/1456))
 - `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 - `[Modal]` Removed overflow constraint on modal content area to enable proper display of lists/popups attached to inner components. ([#1436](https://github.com/infor-design/enterprise-wc/issues/1436))

--- a/src/components/ids-menu/ids-menu.ts
+++ b/src/components/ids-menu/ids-menu.ts
@@ -337,6 +337,10 @@ export default class IdsMenu extends Base {
       return;
     }
 
+    // Unset cached focus menu items
+    this.lastHovered = undefined;
+    this.lastNavigated = undefined;
+
     // Re-apply template (picks up top-level attributes from menu data)
     const template = document.createElement('template');
     const html = this.template();


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fix popup menu item focused state when opening context menu

**Related github/jira issue (required)**:
Fixes #1453 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/editable-contextmenu-before-show.html
3. Click on any cell
4. Open context menu via Shift + F10
5. Check that context menu items are navigable via keyboard arrows

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
