### PR TITLE
1470 - IdsCalendar propagate dayselected event

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 1.0.0-beta.16 Fixes
 
+- `[Calendar]` Allow propagation of `dayselected` event from calendar. ([#1470](https://github.com/infor-design/enterprise-wc/issues/1470))
 - `[DataGrid]` Fixed a bug on the size of the `xxs` filter row inputs. ([#1456](https://github.com/infor-design/enterprise-wc/issues/1456))
 - `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 - `[Modal]` Removed overflow constraint on modal content area to enable proper display of lists/popups attached to inner components. ([#1436](https://github.com/infor-design/enterprise-wc/issues/1436))

--- a/src/components/ids-calendar/demos/example.ts
+++ b/src/components/ids-calendar/demos/example.ts
@@ -46,6 +46,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         break;
     }
   });
+
+  // Listen to dayselected events
+  calendar.addEventListener('dayselected', (evt: any) => {
+    console.info('dayselected', evt.detail);
+  });
 });
 
 const monthview = document.querySelector('ids-calendar');

--- a/src/components/ids-calendar/ids-calendar.ts
+++ b/src/components/ids-calendar/ids-calendar.ts
@@ -500,7 +500,6 @@ export default class IdsCalendar extends Base {
 
     this.offEvent('dayselected.calendar-container');
     this.onEvent('dayselected.calendar-container', this.container, (evt: CustomEvent) => {
-      evt.stopPropagation();
       clearTimeout(daySelectTimer);
       daySelectCount++;
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Allows propagation of `dayselected` event from IdsCalendar component

**Related github/jira issue (required)**:
Fixes #1470 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-calendar/example.html
3. Click on any day while calendar is in month view
4. Check console logs for `dayselected` event handling 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
