### PR TITLE
1485 - data-grid tree-grid runtime-error during expand-all

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.16 Breaking Changes
 
 - `[Checkbox/Radio]` Removed the dirty tracker feature from checkbox and radio buttons. We want to limit how much the dirty indicator is used and the UI for these components just does not work. ([#1489](https://github.com/infor-design/enterprise-wc/issues/1489))
+- `[DataGrid]` Fixed runtime- error on tree-grid when `IdsDataGrid.expandAll()` is executed. ([#1485](https://github.com/infor-design/enterprise-wc/issues/1485))
 
 ### 1.0.0-beta.16 Features
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### 1.0.0-beta.16 Breaking Changes
 
 - `[Checkbox/Radio]` Removed the dirty tracker feature from checkbox and radio buttons. We want to limit how much the dirty indicator is used and the UI for these components just does not work. ([#1489](https://github.com/infor-design/enterprise-wc/issues/1489))
-- `[DataGrid]` Fixed runtime- error on tree-grid when `IdsDataGrid.expandAll()` is executed. ([#1485](https://github.com/infor-design/enterprise-wc/issues/1485))
 
 ### 1.0.0-beta.16 Features
 
 ### 1.0.0-beta.16 Fixes
 
 - `[DataGrid]` Fixed a bug on the size of the `xxs` filter row inputs. ([#1456](https://github.com/infor-design/enterprise-wc/issues/1456))
+- `[DataGrid]` Fixed runtime- error on tree-grid when `IdsDataGrid.expandAll()` is executed. ([#1485](https://github.com/infor-design/enterprise-wc/issues/1485))
 - `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 - `[Modal]` Removed overflow constraint on modal content area to enable proper display of lists/popups attached to inner components. ([#1436](https://github.com/infor-design/enterprise-wc/issues/1436))
 - `[Modal]` Changed the way z-index counting works to prevent a TypeScript/Angular compiler bug. ([#1476](https://github.com/infor-design/enterprise-wc/issues/1476))

--- a/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.html
+++ b/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.html
@@ -10,9 +10,22 @@
       <ids-layout-flex-item>
         <ids-theme-switcher mode="light"></ids-theme-switcher>
       </ids-layout-flex-item>
+
       <ids-layout-flex-item>
         <ids-text font-size="12" type="h1">Tree Grid (Virtual Scrolling)</ids-text>
       </ids-layout-flex-item>
+
+      <ids-layout-flex-item auto-fit="true" padding="md">
+        <ids-layout-flex-item-cell col-span="12" col-span-sm="6" col-span-lg="4">
+          <ids-button id="btn-expand-all" appearance="secondary">
+            <span>Expand All</span>
+          </ids-button>
+          <ids-button id="btn-collapse-all" appearance="secondary">
+            <span>Collapse All</span>
+          </ids-button>
+        </ids-layout-flex-item-cell>
+      </ids-layout-flex-item>
+
       <ids-layout-flex-item grow="1" overflow="hidden">
         <ids-data-grid id="tree-grid-virtual-scroll" suppress-tooltips="true" row-selection="multiple" tree-grid="true" auto-fit="true" virtual-scroll="true" row-height="md">
         </ids-data-grid>

--- a/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.ts
+++ b/src/components/ids-data-grid/demos/tree-grid-virtual-scroll-infinite-scroll.ts
@@ -4,13 +4,28 @@ import type { IdsDataGridColumn } from '../ids-data-grid-column';
 import treeLargeJSON from '../../../assets/data/tree-large.json';
 import '../../ids-layout-flex/ids-layout-flex';
 
+let expandAll = false;
+
 // Example for populating the DataGrid
 const dataGrid = document.querySelector<IdsDataGrid>('#tree-grid-virtual-scroll')!;
+const btnExpandAll = document.querySelector('#btn-expand-all');
+const btnCollapseAll = document.querySelector('#btn-collapse-all');
+
+btnExpandAll?.addEventListener('click', () => {
+  dataGrid?.expandAll();
+  expandAll = true;
+});
+
+btnCollapseAll?.addEventListener('click', () => {
+  dataGrid?.collapseAll();
+  expandAll = false;
+});
 
 // Do an ajax request
 const url: any = treeLargeJSON;
 const columns: IdsDataGridColumn[] = [];
 let currentId = 1000;
+
 // Set up columns
 columns.push({
   id: 'selectionCheckbox',
@@ -42,7 +57,6 @@ columns.push({
   readonly: true,
   width: 66
 });
-
 columns.push({
   id: 'id',
   name: 'Id',
@@ -99,6 +113,8 @@ dataGrid.addEventListener('selectionchanged', (e: Event) => {
 });
 
 dataGrid.addEventListener('scrollend', (e: Event) => {
+  console.info(`scrollend`, (<CustomEvent>e).detail);
+
   const newDataArray : any[] = [];
   for (let counter = 0; counter < 10; counter++) {
     currentId++;
@@ -110,7 +126,7 @@ dataGrid.addEventListener('scrollend', (e: Event) => {
       available: '2022-05-08T01:57:17Z',
       comments: 'integer pede justo lacinia eget tincidunt eget tempus vel pede morbi porttitor lorem id ligula suspendisse ornare consequat lectus',
       time: '22:14:42',
-      rowExpanded: false,
+      rowExpanded: expandAll,
       children: [
         {
           id: currentId + 0.1,
@@ -119,13 +135,15 @@ dataGrid.addEventListener('scrollend', (e: Event) => {
           capacity: 2,
           available: '2022-01-14T02:43:11Z',
           time: '7:20:19',
-          rowHidden: true
+          rowHidden: !expandAll
         }
       ]
     };
     newDataArray.push(newData);
   }
-  console.info(`append`, newDataArray);
-  dataGrid.appendData(newDataArray);
-  console.info(`scrollend`, (<CustomEvent>e).detail);
+
+  setTimeout(() => {
+    console.info(`appendData`, newDataArray);
+    dataGrid.appendData(newDataArray);
+  }, 1000);
 });

--- a/src/components/ids-data-grid/ids-data-grid-formatters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-formatters.ts
@@ -197,7 +197,7 @@ export default class IdsDataGridFormatters {
   /** Shows an Tree */
   tree(rowData: Record<string, unknown>, columnData: IdsDataGridColumn): string {
     const value = this.#extractValue(rowData, columnData.field);
-    const button = rowData?.children ? `<ids-button tabindex="-1" class="expand-button">
+    const button = (rowData?.children as any)?.length ? `<ids-button tabindex="-1" class="expand-button">
       <ids-icon icon="plusminus-folder-${rowData.rowExpanded === false ? 'closed' : 'open'}"></ids-icon>
     </ids-button>` : '&nbsp;';
     return `<span class="ids-data-grid-tree-container">${button}<span class="text-ellipsis">${value}</span></span>`;

--- a/src/components/ids-data-grid/ids-data-grid-header.ts
+++ b/src/components/ids-data-grid/ids-data-grid-header.ts
@@ -73,10 +73,10 @@ export default class IdsDataGridHeader extends IdsEventsMixin(IdsElement) {
         const isColumnHeaderExpander = e.target?.closest('.column-header-expander');
         if (!isColumnHeaderExpander && !this.dataGrid?.showHeaderExpander) return;
 
-        const isHeaderExpanderCollapsed = this.isHeaderExpanderCollapsed;
-        this.isHeaderExpanderCollapsed = !this.isHeaderExpanderCollapsed;
+        const wasHeaderExpanderCollapsed = this.isHeaderExpanderCollapsed;
+        this.isHeaderExpanderCollapsed = !wasHeaderExpanderCollapsed;
 
-        if (isHeaderExpanderCollapsed) {
+        if (wasHeaderExpanderCollapsed) {
           this.dataGrid.expandAll();
         } else {
           this.dataGrid.collapseAll();

--- a/src/components/ids-data-grid/ids-data-grid-header.ts
+++ b/src/components/ids-data-grid/ids-data-grid-header.ts
@@ -4,6 +4,7 @@ import IdsEventsMixin from '../../mixins/ids-events-mixin/ids-events-mixin';
 import { escapeHTML } from '../../utils/ids-xss-utils/ids-xss-utils';
 
 import type IdsDataGrid from './ids-data-grid';
+import type IdsIcon from '../ids-icon/ids-icon';
 import { IdsDataGridColumn, IdsDataGridColumnGroup } from './ids-data-grid-column';
 
 @customElement('ids-data-grid-header')
@@ -38,6 +39,11 @@ export default class IdsDataGridHeader extends IdsEventsMixin(IdsElement) {
     return (this.rootNode.host) as IdsDataGrid;
   }
 
+  /* Returns all the ids-icon.header-expander elements in an array */
+  get expanderIcons(): IdsIcon[] {
+    return [...this.querySelectorAll<IdsIcon>('ids-icon.header-expander')];
+  }
+
   /**
    * Handle all header related events
    * @private
@@ -67,9 +73,14 @@ export default class IdsDataGridHeader extends IdsEventsMixin(IdsElement) {
         const isColumnHeaderExpander = e.target?.closest('.column-header-expander');
         if (!isColumnHeaderExpander && !this.dataGrid?.showHeaderExpander) return;
 
-        if (this.isHeaderExpanderCollapsed) this.dataGrid.expandAll();
-        else this.dataGrid.collapseAll();
+        const isHeaderExpanderCollapsed = this.isHeaderExpanderCollapsed;
         this.isHeaderExpanderCollapsed = !this.isHeaderExpanderCollapsed;
+
+        if (isHeaderExpanderCollapsed) {
+          this.dataGrid.expandAll();
+        } else {
+          this.dataGrid.collapseAll();
+        }
         return;
       }
 
@@ -292,6 +303,26 @@ export default class IdsDataGridHeader extends IdsEventsMixin(IdsElement) {
     const all = this.dataGrid?.rows?.filter((r: any) => r?.hasAttribute('aria-expanded')) || [];
     const collapsedRows = all.filter((r: any) => r?.getAttribute('aria-expanded') === 'false');
     if (all.length && all.length === collapsedRows.length) this.isHeaderExpanderCollapsed = true;
+  }
+
+  /**
+   * Sets the state of the ids-icon.header-expander elements to open/expanded.
+   */
+  openExpanderIcons() {
+    this.isHeaderExpanderCollapsed = false;
+    this.expanderIcons?.forEach((iconElement: IdsIcon) => {
+      iconElement.icon = `plusminus-folder-open`;
+    });
+  }
+
+  /**
+   * Sets the state of the ids-icon.header-expander elements to closed/collapsed.
+   */
+  closeExpanderIcons() {
+    this.isHeaderExpanderCollapsed = true;
+    this.expanderIcons?.forEach((iconElement: IdsIcon) => {
+      iconElement.icon = `plusminus-folder-closed`;
+    });
   }
 
   /**

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -488,11 +488,11 @@ export default class IdsDataGridRow extends IdsElement {
     const rowData = this.dataGrid.data[this.rowIndex];
 
     if (this.dataGrid?.expandableRow) {
-      // expandableRows are collapsed by default
+      // expandableRows are collapsed by default, so only expand if rowExpanded is explicity "true"
       return rowData?.rowExpanded === true;
     }
 
-    // all other rows are expanded by default (i.e. in tree-grid)
+    // all rows are expanded by default (i.e. tree-grid), unless rowExpanded is explicitly "false"
     return rowData?.rowExpanded !== false;
   }
 

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -514,11 +514,13 @@ export default class IdsDataGridRow extends IdsElement {
 
     if (this.dataGrid?.treeGrid) {
       const level = Number(this.getAttribute('aria-level')) || 1;
+      const nextLevel = level + 1;
       let parentExpanded = this.isExpanded();
 
       nextUntil(this, `[aria-level="${level}"]`).forEach((childRow) => {
         const childAriaLevel = Number(childRow.getAttribute('aria-level')) || 1;
-        if (childAriaLevel > level && parentExpanded) {
+        const shouldExpand = (childAriaLevel === nextLevel) || parentExpanded;
+        if (shouldExpand) {
           const childRowIndex = Number(childRow.getAttribute('row-index'));
           this.dataGrid?.updateDataset(childRowIndex, { rowHidden: false });
           childRow.removeAttribute('hidden');

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -137,7 +137,7 @@ export default class IdsDataGridRow extends IdsElement {
   #setAttributes() {
     const rowIndex = this.rowIndex;
     const rowData = this.dataGrid.data[rowIndex];
-    const rowExpanded = rowData?.rowExpanded !== false;
+    const rowExpanded = this.isExpanded();
     const iconType = rowExpanded ? `plusminus-folder-open` : `plusminus-folder-closed`;
 
     this.setAttribute('data-index', String(rowIndex));
@@ -208,10 +208,7 @@ export default class IdsDataGridRow extends IdsElement {
    * @param {boolean} triggerEvent If true, will trigger event
    */
   toggleExpandCollapse(triggerEvent = true) {
-    const rowData = this.data[this.rowIndex];
-    // const isExpanded = !!(rowData?.rowExpanded ?? true);
-    // const isExpanded = this.getAttribute('aria-expanded') === 'true';
-    const isExpanded = rowData?.rowExpanded !== false;
+    const isExpanded = this.isExpanded();
     const shouldCollapse = isExpanded === true;
     const shouldExpand = !shouldCollapse;
 
@@ -435,7 +432,7 @@ export default class IdsDataGridRow extends IdsElement {
     let expandableRowHtml = '';
     if (dataGrid?.expandableRow) {
       const template = injectTemplate(dataGrid?.querySelector(`#${dataGrid?.expandableRowTemplate}`)?.innerHTML || '', row);
-      expandableRowHtml = `<div class="ids-data-grid-expandable-row"${row.rowExpanded === true ? '' : ` hidden`}>${template}</div>`;
+      expandableRowHtml = `<div class="ids-data-grid-expandable-row"${this.isExpanded() ? '' : ` hidden`}>${template}</div>`;
     }
 
     const frozenLast = dataGrid?.leftFrozenColumns.length;
@@ -481,6 +478,22 @@ export default class IdsDataGridRow extends IdsElement {
     columnIndex = Math.min(columnIndex, maxColumnIndex);
 
     return cells[columnIndex] ?? null;
+  }
+
+  /**
+   * Is this row currently expanded
+   * @returns {boolean} true if expanded
+   */
+  isExpanded(): boolean {
+    const rowData = this.dataGrid.data[this.rowIndex];
+
+    if (this.dataGrid?.expandableRow) {
+      // expandableRows are collapsed by default
+      return rowData?.rowExpanded === true;
+    }
+
+    // all other rows are expanded by default (i.e. in tree-grid)
+    return rowData?.rowExpanded !== false;
   }
 
   /**

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -509,21 +509,23 @@ export default class IdsDataGridRow extends IdsElement {
   doExpand() {
     this.dataGrid?.updateDataset(this.rowIndex, { rowExpanded: true, rowHidden: false });
 
+    // this.#setAttributes() will do this.setAttribute('aria-expanded', 'true');
+    this.#setAttributes();
+
     if (this.dataGrid?.treeGrid) {
       const level = Number(this.getAttribute('aria-level')) || 1;
+      let parentExpanded = this.isExpanded();
 
       nextUntil(this, `[aria-level="${level}"]`).forEach((childRow) => {
         const childAriaLevel = Number(childRow.getAttribute('aria-level')) || 1;
-        if (childAriaLevel > level) {
+        if (childAriaLevel > level && parentExpanded) {
           const childRowIndex = Number(childRow.getAttribute('row-index'));
           this.dataGrid?.updateDataset(childRowIndex, { rowHidden: false });
           childRow.removeAttribute('hidden');
+          parentExpanded = (childRow as IdsDataGridRow).isExpanded?.();
         }
       });
     }
-
-    // this.#setAttributes() will do this.setAttribute('aria-expanded', 'true');
-    this.#setAttributes();
   }
 
   /**
@@ -531,6 +533,9 @@ export default class IdsDataGridRow extends IdsElement {
    */
   doCollapse() {
     this.dataGrid?.updateDataset(this.rowIndex, { rowExpanded: false });
+
+    // this.#setAttributes() will do this.setAttribute('aria-expanded', 'false');
+    this.#setAttributes();
 
     if (this.dataGrid?.treeGrid) {
       const level = Number(this.getAttribute('aria-level')) || 1;
@@ -544,8 +549,5 @@ export default class IdsDataGridRow extends IdsElement {
         }
       });
     }
-
-    // this.#setAttributes() will do this.setAttribute('aria-expanded', 'false');
-    this.#setAttributes();
   }
 }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -276,7 +276,7 @@ export default class IdsDataGrid extends Base {
       .forEach((r: any) => {
         const row = Number(r.getAttribute('data-index'));
         rows.push({ row, data: this.data[row] });
-        r?.toggleExpandCollapse?.(true);
+        r?.toggleExpandCollapse?.(false);
       });
 
     this.triggerEvent(`row${opt === 'true' ? 'collapsed' : 'expanded'}`, this, {

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -247,16 +247,13 @@ export default class IdsDataGrid extends Base {
    * @returns {void}
    */
   collapseAll() {
-    const rows: any[] = [];
-    const icons = this.container?.querySelectorAll('ids-icon.header-expander');
-    icons?.forEach((iconEl: any) => {
-      if (iconEl) iconEl.icon = `plusminus-folder-closed`;
-    });
-
     this.data.forEach((rowData, rowIndex) => {
       this.updateDataset(rowIndex, { rowExpanded: false, rowHidden: !!rowData.parentElement });
     });
 
+    this.header?.closeExpanderIcons();
+
+    const rows: any[] = [];
     this.rows
       .forEach((row: IdsDataGridRow) => {
         const rowIndex = row.rowIndex;
@@ -275,16 +272,13 @@ export default class IdsDataGrid extends Base {
    * @returns {void}
    */
   expandAll() {
-    const rows: any[] = [];
-    const icons = this.container?.querySelectorAll('ids-icon.header-expander');
-    icons?.forEach((iconEl: any) => {
-      if (iconEl) iconEl.icon = `plusminus-folder-open`;
-    });
-
     this.data.forEach((rowData, rowIndex) => {
       this.updateDataset(rowIndex, { rowExpanded: true, rowHidden: false });
     });
 
+    this.header?.openExpanderIcons();
+
+    const rows: any[] = [];
     this.rows
       .forEach((row: IdsDataGridRow) => {
         const rowIndex = row.rowIndex;

--- a/src/core/ids-data-source.ts
+++ b/src/core/ids-data-source.ts
@@ -142,7 +142,13 @@ class IdsDataSource {
     if (!this.#flatten) return data;
 
     const newData: Array<Record<string, any>> = [];
-    const addRows = (subData: Record<string, any>, length: number, depth: number, parentElement: string) => {
+    const addRows = (
+      subData: Record<string, any>,
+      length: number,
+      depth: number,
+      parentElement: string,
+      hideChildren = false,
+    ) => {
       subData.map((row: Record<string, any>, index: number) => {
         row.parentElement = '';
         row.ariaLevel = depth;
@@ -155,14 +161,20 @@ class IdsDataSource {
             row.originalElement = index + ((this.pageNumber - 1) * this.pageSize);
           }
         }
-        if (depth > 1) row.parentElement = parentElement;
+        if (depth > 1) {
+          row.parentElement = parentElement;
+          row.rowHidden = hideChildren;
+        }
+
         newData.push(row);
 
         if (row.children) {
           if (this.pageNumber > 1) {
             index += ((this.pageNumber - 1) * this.pageSize);
           }
-          addRows(row.children, row.children.length, depth + 1, `${row.parentElement ? `${row.parentElement} ` : ''}${row.id}`);
+          const parentIds = `${row.parentElement ? `${row.parentElement} ` : ''}${row.id}`;
+          const childrenHidden = row.rowExpanded === false;
+          addRows(row.children, row.children.length, depth + 1, parentIds, childrenHidden);
         }
       });
     };

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -2606,6 +2606,11 @@ describe('IdsDataGrid Component', () => {
       expandButton2.dispatchEvent(mouseClick);
       expect(seventhRow.getAttribute('aria-expanded')).toEqual('true');
       expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(4);
+
+      dataGrid.collapseAll();
+      expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row:not([hidden])').length).toBe(6);
+      expandButton2.dispatchEvent(mouseClick);
+      expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row:not([hidden])').length).toBe(9);
     });
 
     it('handles selection without children', async () => {

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -2593,13 +2593,19 @@ describe('IdsDataGrid Component', () => {
       expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(0);
       const expandButton2 = seventhRow.querySelectorAll('.ids-data-grid-cell')[1].querySelector('ids-button');
 
+      const tenth = dataGrid.rowByIndex(9);
+      expect(tenth.getAttribute('aria-expanded')).toEqual('true');
+      const expandButton3 = tenth.querySelectorAll('.ids-data-grid-cell')[1].querySelector('ids-button');
+      expandButton3.dispatchEvent(mouseClick);
+      expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(4);
+
       expandButton2.dispatchEvent(mouseClick);
       expect(seventhRow.getAttribute('aria-expanded')).toEqual('false');
       expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(7);
 
       expandButton2.dispatchEvent(mouseClick);
       expect(seventhRow.getAttribute('aria-expanded')).toEqual('true');
-      expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(0);
+      expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(4);
     });
 
     it('handles selection without children', async () => {

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -2668,8 +2668,8 @@ describe('IdsDataGrid Component', () => {
       dataGrid.columns = treeColumns;
       dataGrid.data = datasetTree;
 
-      const firstRow = dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row')[1];
-      expect(firstRow.getAttribute('aria-expanded')).toEqual('true');
+      const firstRow = dataGrid.rowByIndex(0);
+      expect(firstRow.getAttribute('aria-expanded')).toEqual('false');
 
       dataGrid.setActiveCell(0, 0, true);
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
@@ -2677,7 +2677,7 @@ describe('IdsDataGrid Component', () => {
 
       const event2 = new KeyboardEvent('keydown', { key: ' ' });
       dataGrid.dispatchEvent(event2);
-      expect(firstRow.getAttribute('aria-expanded')).toEqual('false');
+      expect(firstRow.getAttribute('aria-expanded')).toEqual('true');
     });
 
     it('can set the suppressRowClickSelection setting', () => {

--- a/test/ids-data-grid/ids-data-grid-func-test.ts
+++ b/test/ids-data-grid/ids-data-grid-func-test.ts
@@ -2578,24 +2578,28 @@ describe('IdsDataGrid Component', () => {
       dataGrid.data = datasetTree;
       dataGrid.rowSelection = 'multiple';
 
-      const firstRow = dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row')[1];
+      const firstRow = dataGrid.rowByIndex(0);
       expect(firstRow.getAttribute('aria-expanded')).toEqual('false');
       expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(3);
-      const expandButton = dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row')[1].querySelectorAll('.ids-data-grid-cell')[1].querySelector('ids-button');
+      const expandButton = firstRow.querySelectorAll('.ids-data-grid-cell')[1].querySelector('ids-button');
 
       const mouseClick = new MouseEvent('click', { bubbles: true });
       expandButton.dispatchEvent(mouseClick);
       expect(firstRow.getAttribute('aria-expanded')).toEqual('true');
       expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(0);
 
-      const seventhRow = dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row')[7];
+      const seventhRow = dataGrid.rowByIndex(6);
       expect(seventhRow.getAttribute('aria-expanded')).toEqual('true');
       expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(0);
-      const expandButton2 = dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row')[7].querySelectorAll('.ids-data-grid-cell')[1].querySelector('ids-button');
+      const expandButton2 = seventhRow.querySelectorAll('.ids-data-grid-cell')[1].querySelector('ids-button');
 
       expandButton2.dispatchEvent(mouseClick);
       expect(seventhRow.getAttribute('aria-expanded')).toEqual('false');
       expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(7);
+
+      expandButton2.dispatchEvent(mouseClick);
+      expect(seventhRow.getAttribute('aria-expanded')).toEqual('true');
+      expect(dataGrid.shadowRoot.querySelectorAll('.ids-data-grid-row[hidden]').length).toBe(0);
     });
 
     it('handles selection without children', async () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Fixes runtime error on IdsDatagrid Treegrid when idsDatagrid.expandAll() is executed.

**Related github/jira issue (required)**:

Closes #1485

**Steps necessary to review your pull request (required)**:

1. Check out this PRs' branch and run: `nvm use && npm run start`
2. Go to: http://localhost:4300/ids-data-grid/tree-grid-virtual-scroll-infinite-scroll.html
3. Scroll down to row # 270
4. Click on `Expand All` Button
5. Ensure there is no Runtime error
6. Go to: http://localhost:4300/ids-data-grid/tree-grid-expand-collapse.html
7. Collapse row # 12, then collapse row # 10, then collapse row # 7
8. Expand row # 7, and ensure row # 10 is still collapsed.
9. Expand row # 10, and ensure row # 12 is still collapsed.
10. Click `Collapse All` button, then ensure you can fully expand each row one-by-one.
11. Click `Collapse All` button again, then ensure the header-expander icon works on first try.
12. Go to:  http://localhost:4300/ids-data-grid/show-header-expander.html
13. Test header-expanders while toggling `Expand All` and `Collapse All` buttons.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
