### PR TITLE
1229 - Add nesting/alignment to inline-editable data grids using tree formatter

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -10,6 +10,7 @@
         "each",
         "for",
         "if",
+        "else",
         "error",
         "include",
         "mixin",
@@ -17,7 +18,17 @@
       ]
     }],
     "max-nesting-depth": [4, {
-      "ignore": ["pseudo-classes"]
+      "ignore": ["pseudo-classes"],
+      "ignoreAtRules": [
+        "each",
+        "for",
+        "if",
+        "else",
+        "error",
+        "include",
+        "mixin",
+        "use"
+      ]
     }],
     "no-descending-specificity": null,
     "selector-pseudo-class-no-unknown": [true, {

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[DataGrid]` Fixed contextmenu focused menu item in datagrid. ([#1453](https://github.com/infor-design/enterprise-wc/issues/1453))
 - `[DataGrid]` Fixed a bug on the size of the `xxs` filter row inputs. ([#1456](https://github.com/infor-design/enterprise-wc/issues/1456))
 - `[DataGrid]` Fixed runtime- error on tree-grid when `IdsDataGrid.expandAll()` is executed. ([#1485](https://github.com/infor-design/enterprise-wc/issues/1485))
+- `[DataGrid]` Improve/implement style for inline-editable data grid cells. ([#1229](https://github.com/infor-design/enterprise-wc/issues/1229))
 - `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 - `[Modal]` Removed overflow constraint on modal content area to enable proper display of lists/popups attached to inner components. ([#1436](https://github.com/infor-design/enterprise-wc/issues/1436))
 - `[Modal]` Changed the way z-index counting works to prevent a TypeScript/Angular compiler bug. ([#1476](https://github.com/infor-design/enterprise-wc/issues/1476))

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -273,7 +273,7 @@ To cancel or disabled editing there are a few ways:
 
 The following settings are available on editors.
 
-`type` As of now can be `checkbox`, `input`, `datepicker`, `timepicker`, or `dropdown` but more will be added.
+`type` As of now can be `checkbox`, `input`, `datepicker`, `timepicker`, `dropdown`, or `tree` but more will be added.
 `inline` Default is false. If true the editor (for example an input) will be visible in a field.
 `editorSettings` Is an object that is loosely typed that lets you pass any option the editor supports in. For example any of the IdsInput or IdsCheckbox options can be passing in. Some special ones are:
 `editorSettings.autoselect` Text will be selected when entering edit mode

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -182,6 +182,9 @@
   - link: tree-grid-filter.html
     type: Example
     description: Shows a tree with filter
+  - link: tree-grid-inline.html
+    type: Example
+    description: Shows displaying hierarchical data with "inline" editing style
   - link: tree-grid-paging.html
     type: Example
     description: Shows a tree with paging

--- a/src/components/ids-data-grid/demos/tree-grid-expand-collapse.html
+++ b/src/components/ids-data-grid/demos/tree-grid-expand-collapse.html
@@ -37,8 +37,8 @@
                 <ids-menu-item value="xxs">Extra Extra Small</ids-menu-item>
                 <ids-menu-item value="xs">Extra Small</ids-menu-item>
                 <ids-menu-item value="sm">Small</ids-menu-item>
-                <ids-menu-item value="md">Medium</ids-menu-item>
-                <ids-menu-item value="lg" selected="true">Large</ids-menu-item>
+                <ids-menu-item value="md" selected="true">Medium</ids-menu-item>
+                <ids-menu-item value="lg">Large</ids-menu-item>
               </ids-menu-group>
             </ids-popup-menu>
           </ids-toolbar-section>

--- a/src/components/ids-data-grid/demos/tree-grid-expand-collapse.ts
+++ b/src/components/ids-data-grid/demos/tree-grid-expand-collapse.ts
@@ -1,4 +1,6 @@
 import type IdsDataGrid from '../ids-data-grid';
+import type IdsPopupMenu from '../../ids-popup-menu/ids-popup-menu';
+import type IdsMenuItem from '../../ids-menu/ids-menu-item';
 import '../ids-data-grid';
 import type { IdsDataGridColumn } from '../ids-data-grid-column';
 import buildingsJSON from '../../../assets/data/tree-buildings.json';
@@ -11,6 +13,27 @@ const btnExpandAll = document.querySelector('#btn-expand-all');
 const btnCollapseAll = document.querySelector('#btn-collapse-all');
 btnExpandAll?.addEventListener('click', () => dataGrid?.expandAll());
 btnCollapseAll?.addEventListener('click', () => dataGrid?.collapseAll());
+
+// Row Height menu
+const rowHeightMenu = document.querySelector<IdsPopupMenu>('#row-height-menu')!;
+
+// Change row height with popup menu
+rowHeightMenu?.addEventListener('selected', (e: Event) => {
+  const value = (e.target as IdsMenuItem).value;
+  if (value !== 'is-list') {
+    dataGrid.rowHeight = value as string;
+  }
+  if (value === 'is-list') {
+    dataGrid.listStyle = !dataGrid.listStyle;
+  }
+});
+
+rowHeightMenu?.addEventListener('deselected', (e: Event) => {
+  const value = (e.target as IdsMenuItem).value;
+  if (value === 'is-list') {
+    dataGrid.listStyle = !dataGrid.listStyle;
+  }
+});
 
 if (dataGrid) {
   (async function init() {

--- a/src/components/ids-data-grid/demos/tree-grid-inline.html
+++ b/src/components/ids-data-grid/demos/tree-grid-inline.html
@@ -35,7 +35,15 @@
           </ids-toolbar-section>
         </ids-toolbar>
 
-        <ids-data-grid id="tree-grid" row-selection="multiple" suppress-row-click-selection="true" label="Buildings" row-height="md" tree-grid="true" group-selects-children="true"></ids-data-grid>
+        <ids-data-grid
+          id="tree-grid"
+          row-selection="multiple"
+          suppress-row-click-selection="true"
+          label="Buildings"
+          row-height="md"
+          tree-grid="true"
+          group-selects-children="true"
+          editable="true"></ids-data-grid>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-data-grid/demos/tree-grid-inline.html
+++ b/src/components/ids-data-grid/demos/tree-grid-inline.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Tree Grid</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-toolbar>
+          <ids-toolbar-section align="end" favor>
+            <ids-menu-button id="menu-button" menu="row-height-menu">
+              <ids-icon icon="more"></ids-icon>
+              <span class="audible">Settings Menu Button</span>
+            </ids-menu-button>
+            <ids-popup-menu id="row-height-menu" target="menu-button" trigger-type="click">
+              <ids-menu-group select="single">
+                <ids-menu-header><ids-text font-weight="semi-bold">Style</ids-text></ids-menu-header>
+                <ids-menu-item value="is-list" toggleable>List</ids-menu-item>
+              </ids-menu-group>
+              <ids-menu-group select="single">
+                <ids-menu-header><ids-text font-weight="semi-bold">Row Height</ids-text></ids-menu-header>
+                <ids-menu-item value="xxs">Extra Extra Small</ids-menu-item>
+                <ids-menu-item value="xs">Extra Small</ids-menu-item>
+                <ids-menu-item value="sm">Small</ids-menu-item>
+                <ids-menu-item value="md" selected="true">Medium</ids-menu-item>
+                <ids-menu-item value="lg">Large</ids-menu-item>
+              </ids-menu-group>
+            </ids-popup-menu>
+          </ids-toolbar-section>
+        </ids-toolbar>
+
+        <ids-data-grid id="tree-grid" row-selection="multiple" suppress-row-click-selection="true" label="Buildings" row-height="md" tree-grid="true" group-selects-children="true"></ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/tree-grid-inline.ts
+++ b/src/components/ids-data-grid/demos/tree-grid-inline.ts
@@ -1,12 +1,33 @@
 import type IdsDataGrid from '../ids-data-grid';
+import type IdsPopupMenu from '../../ids-popup-menu/ids-popup-menu';
+import type IdsMenuItem from '../../ids-menu/ids-menu-item';
 import '../ids-data-grid';
 import type { IdsDataGridColumn } from '../ids-data-grid-column';
 import buildingsJSON from '../../../assets/data/tree-buildings.json';
 
 // Example for populating the DataGrid
 const dataGrid = document.querySelector<IdsDataGrid>('#tree-grid')!;
+const rowHeightMenu = document.querySelector<IdsPopupMenu>('#row-height-menu')!;
 
 if (dataGrid) {
+  // Change row height with popup menu
+  rowHeightMenu?.addEventListener('selected', (e: Event) => {
+    const value = (e.target as IdsMenuItem).value;
+    if (value !== 'is-list') {
+      dataGrid.rowHeight = value as string;
+    }
+    if (value === 'is-list') {
+      dataGrid.listStyle = !dataGrid.listStyle;
+    }
+  });
+
+  rowHeightMenu?.addEventListener('deselected', (e: Event) => {
+    const value = (e.target as IdsMenuItem).value;
+    if (value === 'is-list') {
+      dataGrid.listStyle = !dataGrid.listStyle;
+    }
+  });
+
   (async function init() {
     // Do an ajax request
     const url: any = buildingsJSON;
@@ -23,17 +44,27 @@ if (dataGrid) {
       frozen: 'left'
     });
     columns.push({
-      id: 'name',
-      name: 'Name',
-      field: 'name',
+      id: 'id',
+      name: 'Id',
+      field: 'id',
       sortable: true,
       resizable: true,
+      editor: {
+        type: 'input',
+        inline: true,
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true,
+          validate: 'required'
+        }
+      },
       formatter: dataGrid.formatters.tree,
       click: (info: any) => {
         console.info('Tree Expander Clicked', info);
       },
       width: 220,
-      frozen: 'left'
+      frozen: 'left',
+      align: 'right'
     });
     columns.push({
       id: 'rowNumber',
@@ -44,9 +75,9 @@ if (dataGrid) {
       width: 65
     });
     columns.push({
-      id: 'id',
-      name: 'Id',
-      field: 'id',
+      id: 'name',
+      name: 'Name',
+      field: 'name',
       sortable: true,
       resizable: true,
       formatter: dataGrid.formatters.text
@@ -93,12 +124,29 @@ if (dataGrid) {
 
     setData();
 
+    // Event Handlers
     dataGrid.addEventListener('rowexpanded', (e: Event) => {
       console.info(`Row Expanded`, (<CustomEvent>e).detail);
     });
 
     dataGrid.addEventListener('rowcollapsed', (e: Event) => {
       console.info(`Row Collapsed`, (<CustomEvent>e).detail);
+    });
+
+    dataGrid.addEventListener('beforecelledit', (e: Event) => {
+      console.info(`Edit Started`, (<CustomEvent>e).detail);
+    });
+
+    dataGrid.addEventListener('celledit', (e: Event) => {
+      console.info(`Currently Editing`, (<CustomEvent>e).detail);
+    });
+
+    dataGrid.addEventListener('endcelledit', (e: Event) => {
+      console.info(`Edit Ended`, (<CustomEvent>e).detail);
+    });
+
+    dataGrid.addEventListener('cancelcelledit', (e: Event) => {
+      console.info(`Edit Was Cancelled`, (<CustomEvent>e).detail);
     });
   }());
 }

--- a/src/components/ids-data-grid/demos/tree-grid-inline.ts
+++ b/src/components/ids-data-grid/demos/tree-grid-inline.ts
@@ -50,7 +50,7 @@ if (dataGrid) {
       sortable: true,
       resizable: true,
       editor: {
-        type: 'input',
+        type: 'tree',
         inline: true,
         editorSettings: {
           autoselect: true,

--- a/src/components/ids-data-grid/demos/tree-grid.ts
+++ b/src/components/ids-data-grid/demos/tree-grid.ts
@@ -22,18 +22,28 @@ if (dataGrid) {
       align: 'center',
       frozen: 'left'
     });
-    columns.push({
-      id: 'name',
-      name: 'Name',
-      field: 'name',
+    columns.push({id: 'id',
+      name: 'Id',
+      field: 'id',
       sortable: true,
       resizable: true,
+      editor: {
+        type: 'input',
+        inline: true,
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true,
+          validate: 'required'
+        }
+      },
       formatter: dataGrid.formatters.tree,
+      // dataGrid.formatters.tree,
       click: (info: any) => {
         console.info('Tree Expander Clicked', info);
       },
       width: 220,
-      frozen: 'left'
+      frozen: 'left',
+      align: 'right'
     });
     columns.push({
       id: 'rowNumber',
@@ -44,9 +54,9 @@ if (dataGrid) {
       width: 65
     });
     columns.push({
-      id: 'id',
-      name: 'Id',
-      field: 'id',
+      id: 'name',
+      name: 'Name',
+      field: 'name',
       sortable: true,
       resizable: true,
       formatter: dataGrid.formatters.text

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -88,14 +88,22 @@
   }
 
   // Text Alignment
-  &.align-center > *:first-child {
-    display: inline-flex;
-    margin: 0 auto;
+  &.align-center {
+    & > *:first-child {
+      display: inline-flex;
+      margin: 0 auto;
+    }
   }
 
-  &.align-right > *:first-child {
-    margin-inline-start: auto;
-    margin-inline-end: 0;
+  &.align-right {
+    & > *:first-child {
+      margin-inline-start: auto;
+      margin-inline-end: 0;
+    }
+
+    ids-input {
+      text-align: right;
+    }
   }
 
   // Readonly and disabled Cells

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -1,3 +1,30 @@
+@mixin ids-data-grid-inline-editable-outline-large {
+  box-shadow: inset 0 0 0 4px var(--ids-data-grid-cell-color-background-default),
+    inset 0 0 0 5px var(--ids-input-color-border-default);
+}
+
+@mixin ids-data-grid-inline-editable-outline-small {
+  box-shadow: inset 0 0 0 2px var(--ids-input-color-background-default),
+    inset 0 0 0 3px var(--ids-input-color-border-default);
+}
+
+@mixin ids-data-grid-inline-editable-outline-medium {
+  box-shadow: inset 0 0 0 3px var(--ids-input-color-background-default),
+    inset 0 0 0 4px var(--ids-input-color-border-default);
+}
+
+@mixin ids-data-grid-cell-dirty-tracker-icon {
+  border-color: var(--ids-input-dirty-indicator-color-background-dirty) transparent transparent var(--ids-input-dirty-indicator-color-background-dirty);
+  border-style: solid;
+  border-width: 5px;
+  content: '';
+  display: inline-block;
+  margin-inline: 2px;
+  position: absolute;
+  inset-block-start: 2px;
+  z-index: 1;
+}
+
 /* Ids Data Grid Component - Cells */
 .ids-data-grid-cell {
   // Border and Background and Sizing
@@ -91,7 +118,32 @@
 
   &.is-editable {
     &.is-inline {
-      box-shadow: inset 0 0 0 4px var(--ids-data-grid-cell-color-background-default), inset 0 0 0 5px var(--ids-input-color-border-default);
+
+      &:not(.formatter-tree) {
+        @include ids-data-grid-inline-editable-outline-large;
+      }
+
+      &.formatter-tree {
+        .ids-data-grid-tree-container {
+          height: 100%;
+          width: 100%;
+        }
+
+        .ids-data-grid-tree-field-container {
+          height: 100%;
+          width: 100%;
+        }
+
+        .text-ellipsis {
+          @include ids-data-grid-inline-editable-outline-large;
+
+          align-items: center;
+          display: flex;
+          height: 100%;
+          justify-content: end;
+          width: 100%;
+        }
+      }
 
       ids-icon.editor-cell-icon {
         --ids-trigger-field-button-margin: 0;
@@ -235,20 +287,34 @@
   }
 
   &.is-dirty::before {
-    border-color: var(--ids-input-dirty-indicator-color-background-dirty) transparent transparent var(--ids-input-dirty-indicator-color-background-dirty);
-    border-style: solid;
-    border-width: 5px;
-    content: '';
-    display: inline-block;
-    margin-inline: 2px;
-    position: absolute;
-    top: 2px;
-    z-index: 1;
+    @include ids-data-grid-cell-dirty-tracker-icon;
   }
 
-  &.is-dirty.is-inline::before {
-    margin-inline: 6px;
-    top: 6px;
+  &.is-dirty.is-inline {
+    &:not(.formatter-tree) {
+      &::before {
+        margin-inline: 6px;
+        inset-block-start: 6px;
+      }
+    }
+
+    &.formatter-tree {
+      &::before {
+        display: none;
+        content: none;
+      }
+
+      .ids-data-grid-tree-field-container {
+        position: relative;
+
+        &::before {
+          @include ids-data-grid-cell-dirty-tracker-icon;
+
+          margin-inline: 6px;
+          inset-block-start: 6px;
+        }
+      }
+    }
   }
 
   &.is-invalid {
@@ -271,7 +337,15 @@
   }
 
   .is-editable.is-inline {
-    box-shadow: inset 0 0 0 2px var(--ids-input-color-background-default), inset 0 0 0 3px var(--ids-input-color-border-default);
+    &:not(.formatter-tree) {
+      @include ids-data-grid-inline-editable-outline-small;
+    }
+
+    &.formatter-tree {
+      .text-ellipsis {
+        @include ids-data-grid-inline-editable-outline-small;
+      }
+    }
   }
 
   ids-button {
@@ -321,7 +395,15 @@
   }
 
   .is-editable.is-inline {
-    box-shadow: inset 0 0 0 2px var(--ids-input-color-background-default), inset 0 0 0 3px var(--ids-input-color-border-default);
+    &:not(.formatter-tree) {
+      @include ids-data-grid-inline-editable-outline-small;
+    }
+
+    &.formatter-tree {
+      .text-ellipsis {
+        @include ids-data-grid-inline-editable-outline-small;
+      }
+    }
   }
 
   ids-button {
@@ -359,7 +441,15 @@
 
 [data-row-height='sm'] {
   .is-editable.is-inline {
-    box-shadow: inset 0 0 0 3px var(--ids-input-color-background-default), inset 0 0 0 4px var(--ids-input-color-border-default);
+    &:not(.formatter-tree) {
+      @include ids-data-grid-inline-editable-outline-medium;
+    }
+
+    &.formatter-tree {
+      .text-ellipsis {
+        @include ids-data-grid-inline-editable-outline-medium;
+      }
+    }
   }
 
   .ids-data-grid-cell.is-dirty.is-inline::before {

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -1,18 +1,25 @@
-@mixin ids-data-grid-inline-editable-outline-large {
-  box-shadow: inset 0 0 0 4px var(--ids-data-grid-cell-color-background-default),
-    inset 0 0 0 5px var(--ids-input-color-border-default);
+// ================================================
+// Generates a pseudo-element in the form of an "outline"
+// in a cell that represents the "inline, editable" state.
+@mixin ids-data-grid-inline-editable-outline($margin, $heightOffset, $widthOffset) {
+  position: relative;
+
+  &::after {
+    border: 1px solid var(--ids-input-color-border-default);
+    border-radius: var(--ids-border-radius-01);
+    box-sizing: border-box;
+    display: block;
+    content: '';
+    margin: $margin;
+    height: calc(100% - $heightOffset);
+    position: absolute;
+    width: calc(100% - $widthOffset);
+  }
 }
 
-@mixin ids-data-grid-inline-editable-outline-small {
-  box-shadow: inset 0 0 0 2px var(--ids-input-color-background-default),
-    inset 0 0 0 3px var(--ids-input-color-border-default);
-}
-
-@mixin ids-data-grid-inline-editable-outline-medium {
-  box-shadow: inset 0 0 0 3px var(--ids-input-color-background-default),
-    inset 0 0 0 4px var(--ids-input-color-border-default);
-}
-
+// ================================================
+// Generates a pseudo-element representing the dirty tracker
+// icon in a cell that's been edited.
 @mixin ids-data-grid-cell-dirty-tracker-icon {
   border-color: var(--ids-input-dirty-indicator-color-background-dirty) transparent transparent var(--ids-input-dirty-indicator-color-background-dirty);
   border-style: solid;
@@ -120,7 +127,7 @@
     &.is-inline {
 
       &:not(.formatter-tree) {
-        @include ids-data-grid-inline-editable-outline-large;
+        @include ids-data-grid-inline-editable-outline(4px, 8px, 8px);
       }
 
       &.formatter-tree {
@@ -135,13 +142,17 @@
         }
 
         .text-ellipsis {
-          @include ids-data-grid-inline-editable-outline-large;
+          @include ids-data-grid-inline-editable-outline(4px, 8px, 8px);
 
           align-items: center;
           display: flex;
           height: 100%;
           justify-content: end;
           width: 100%;
+
+          &::after {
+            margin-inline-end: -8px;
+          }
         }
       }
 
@@ -255,7 +266,6 @@
 
   // Frozen Cells
   &.frozen {
-    background-color: var(--ids-data-grid-cell-color-background-default);
     position: sticky;
     z-index: 3;
   }
@@ -291,13 +301,6 @@
   }
 
   &.is-dirty.is-inline {
-    &:not(.formatter-tree) {
-      &::before {
-        margin-inline: 6px;
-        inset-block-start: 6px;
-      }
-    }
-
     &.formatter-tree {
       &::before {
         display: none;
@@ -309,9 +312,6 @@
 
         &::before {
           @include ids-data-grid-cell-dirty-tracker-icon;
-
-          margin-inline: 6px;
-          inset-block-start: 6px;
         }
       }
     }
@@ -326,6 +326,10 @@
   }
 }
 
+// =============================================
+// Row height: 'xxs'
+// =============================================
+
 [data-row-height='xxs'] {
   .ids-data-grid-cell.is-dirty::before {
     border-width: 4px;
@@ -338,12 +342,18 @@
 
   .is-editable.is-inline {
     &:not(.formatter-tree) {
-      @include ids-data-grid-inline-editable-outline-small;
+      @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
     }
 
     &.formatter-tree {
       .text-ellipsis {
-        @include ids-data-grid-inline-editable-outline-small;
+        @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
+
+        margin-inline-end: 2px;
+
+        &::after {
+          margin-inline-end: -2px;
+        }
       }
     }
   }
@@ -384,6 +394,10 @@
   }
 }
 
+// =============================================
+// Row height: 'xs'
+// =============================================
+
 [data-row-height='xs'] {
   .ids-data-grid-cell.is-dirty::before {
     border-width: 4px;
@@ -396,12 +410,16 @@
 
   .is-editable.is-inline {
     &:not(.formatter-tree) {
-      @include ids-data-grid-inline-editable-outline-small;
+      @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
     }
 
     &.formatter-tree {
       .text-ellipsis {
-        @include ids-data-grid-inline-editable-outline-small;
+        @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
+
+        &::after {
+          margin-inline-end: -2px;
+        }
       }
     }
   }
@@ -439,15 +457,23 @@
   }
 }
 
+// =============================================
+// Row height: 'sm'
+// =============================================
+
 [data-row-height='sm'] {
   .is-editable.is-inline {
     &:not(.formatter-tree) {
-      @include ids-data-grid-inline-editable-outline-medium;
+      @include ids-data-grid-inline-editable-outline(3px, 6px, 6px);
     }
 
     &.formatter-tree {
       .text-ellipsis {
-        @include ids-data-grid-inline-editable-outline-medium;
+        @include ids-data-grid-inline-editable-outline(3px, 6px, 6px);
+
+        &::after {
+          margin-inline-end: -5px;
+        }
       }
     }
   }
@@ -477,6 +503,10 @@
   }
 }
 
+// =============================================
+// Row height: 'md'
+// =============================================
+
 [data-row-height='md'] {
   // Adjust dropdown editor
   .ids-data-grid-cell.is-editable.is-inline ids-icon.editor-cell-icon {
@@ -486,6 +516,22 @@
   .ids-data-grid-cell.is-editable.is-inline {
     --ids-trigger-field-button-margin: -3px;
     --ids-button-tertiary-color-background-hover: transparent;
+  }
+}
+
+// =============================================
+// Row height: 'lg'
+// =============================================
+
+[data-row-height='lg'] {
+  .is-editable.is-inline {
+    &.formatter-tree {
+      .text-ellipsis {
+        &::after {
+          margin-inline-end: -12px;
+        }
+      }
+    }
   }
 }
 

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -133,7 +133,6 @@
 
   &.is-editable {
     &.is-inline {
-
       &:not(.formatter-tree) {
         @include ids-data-grid-inline-editable-outline(4px, 8px, 8px);
       }
@@ -157,10 +156,10 @@
           height: 100%;
           justify-content: end;
           width: 100%;
+        }
 
-          &::after {
-            margin-inline-end: -8px;
-          }
+        .text-ellipsis::after {
+          margin-inline-end: -8px;
         }
       }
 

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -1,37 +1,3 @@
-// ================================================
-// Generates a pseudo-element in the form of an "outline"
-// in a cell that represents the "inline, editable" state.
-@mixin ids-data-grid-inline-editable-outline($margin, $heightOffset, $widthOffset) {
-  position: relative;
-
-  &::after {
-    border: 1px solid var(--ids-input-color-border-default);
-    border-radius: var(--ids-border-radius-01);
-    box-sizing: border-box;
-    display: block;
-    content: '';
-    margin: $margin;
-    height: calc(100% - $heightOffset);
-    position: absolute;
-    width: calc(100% - $widthOffset);
-  }
-}
-
-// ================================================
-// Generates a pseudo-element representing the dirty tracker
-// icon in a cell that's been edited.
-@mixin ids-data-grid-cell-dirty-tracker-icon {
-  border-color: var(--ids-input-dirty-indicator-color-background-dirty) transparent transparent var(--ids-input-dirty-indicator-color-background-dirty);
-  border-style: solid;
-  border-width: 5px;
-  content: '';
-  display: inline-block;
-  margin-inline: 2px;
-  position: absolute;
-  inset-block-start: 2px;
-  z-index: 1;
-}
-
 /* Ids Data Grid Component - Cells */
 .ids-data-grid-cell {
   // Border and Background and Sizing
@@ -133,10 +99,6 @@
 
   &.is-editable {
     &.is-inline {
-      &:not(.formatter-tree) {
-        @include ids-data-grid-inline-editable-outline(4px, 8px, 8px);
-      }
-
       &.formatter-tree {
         .ids-data-grid-tree-container {
           height: 100%;
@@ -149,8 +111,6 @@
         }
 
         .text-ellipsis {
-          @include ids-data-grid-inline-editable-outline(4px, 8px, 8px);
-
           align-items: center;
           display: flex;
           height: 100%;
@@ -347,24 +307,6 @@
     top: 3px;
   }
 
-  .is-editable.is-inline {
-    &:not(.formatter-tree) {
-      @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
-    }
-
-    &.formatter-tree {
-      .text-ellipsis {
-        @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
-
-        margin-inline-end: 2px;
-
-        &::after {
-          margin-inline-end: -2px;
-        }
-      }
-    }
-  }
-
   ids-button {
     --ids-button-icon-padding: 2px;
   }
@@ -415,22 +357,6 @@
     top: 3px;
   }
 
-  .is-editable.is-inline {
-    &:not(.formatter-tree) {
-      @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
-    }
-
-    &.formatter-tree {
-      .text-ellipsis {
-        @include ids-data-grid-inline-editable-outline(2px, 4px, 4px);
-
-        &::after {
-          margin-inline-end: -2px;
-        }
-      }
-    }
-  }
-
   ids-button {
     --ids-button-icon-padding: 3px;
   }
@@ -469,27 +395,6 @@
 // =============================================
 
 [data-row-height='sm'] {
-  .is-editable.is-inline {
-    &:not(.formatter-tree) {
-      @include ids-data-grid-inline-editable-outline(3px, 6px, 6px);
-    }
-
-    &.formatter-tree {
-      .text-ellipsis {
-        @include ids-data-grid-inline-editable-outline(3px, 6px, 6px);
-
-        &::after {
-          margin-inline-end: -5px;
-        }
-      }
-    }
-  }
-
-  .ids-data-grid-cell.is-dirty.is-inline::before {
-    margin-inline: 5px;
-    top: 5px;
-  }
-
   ids-button {
     --ids-button-icon-padding: 4px;
   }
@@ -523,22 +428,6 @@
   .ids-data-grid-cell.is-editable.is-inline {
     --ids-trigger-field-button-margin: -3px;
     --ids-button-tertiary-color-background-hover: transparent;
-  }
-}
-
-// =============================================
-// Row height: 'lg'
-// =============================================
-
-[data-row-height='lg'] {
-  .is-editable.is-inline {
-    &.formatter-tree {
-      .text-ellipsis {
-        &::after {
-          margin-inline-end: -12px;
-        }
-      }
-    }
   }
 }
 

--- a/src/components/ids-data-grid/ids-data-grid-cell.ts
+++ b/src/components/ids-data-grid/ids-data-grid-cell.ts
@@ -207,6 +207,14 @@ export default class IdsDataGridCell extends IdsElement {
     if (column.editor.inline) this.classList.add('is-inline');
     this.isEditing = true;
 
+    // Pass column text alignment rules into the cell editor
+    if (column.align) {
+      let alignVal = column.align;
+      if (alignVal === 'left') alignVal = 'start';
+      if (alignVal === 'right') alignVal = 'end';
+      this.editor?.input?.setAttribute('text-align', `${alignVal}`);
+    }
+
     // Save on Click Out Event
     if (['datepicker', 'timepicker'].includes(this.editor.type)) {
       this.editor.input?.onEvent('focusout', this.editor.input, () => {

--- a/src/components/ids-data-grid/ids-data-grid-cell.ts
+++ b/src/components/ids-data-grid/ids-data-grid-cell.ts
@@ -119,6 +119,7 @@ export default class IdsDataGridCell extends IdsElement {
     const template = IdsDataGridCell.template(row, column, rowIndex, this.dataGrid);
 
     this.innerHTML = template;
+    if (column.formatter) this.classList.add(`formatter-${column.formatter.name}`);
   }
 
   /**

--- a/src/components/ids-data-grid/ids-data-grid-cell.ts
+++ b/src/components/ids-data-grid/ids-data-grid-cell.ts
@@ -243,15 +243,14 @@ export default class IdsDataGridCell extends IdsElement {
   endCellEdit() {
     const column = this.column;
     const input = this.editor?.input as any;
-    const editorType = this.editor?.type;
+    const editorType = (this.editor?.type as string);
     input?.offEvent('focusout', input);
 
-    if (editorType === 'input' && input?.setDirtyTracker) {
+    if (['input', 'tree'].includes(editorType) && input?.setDirtyTracker) {
       input?.setDirtyTracker(input?.value as any);
-      (<IdsInput>input)?.checkValidation();
     }
 
-    if (editorType === 'input' && input?.checkValidation) {
+    if (['input', 'tree'].includes(editorType) && input?.checkValidation) {
       (<IdsInput>input)?.checkValidation();
     }
 

--- a/src/components/ids-data-grid/ids-data-grid-column.ts
+++ b/src/components/ids-data-grid/ids-data-grid-column.ts
@@ -223,7 +223,7 @@ export interface IdsDataGridColumn {
   cellSelectedCssPart?: string | ((rowIndex: number, cellIndex: number) => string);
   /** Setup an editor */
   editor?: {
-    type: 'input' | 'date' | 'time' | 'checkbox' | 'dropdown' | 'datepicker' | 'timepicker',
+    type: 'input' | 'date' | 'time' | 'checkbox' | 'dropdown' | 'datepicker' | 'timepicker' | 'tree',
     inline?: boolean,
     editor?: IdsDataGridEditor,
     editorSettings?: Record<string, unknown>

--- a/src/components/ids-data-grid/ids-data-grid-common.scss
+++ b/src/components/ids-data-grid/ids-data-grid-common.scss
@@ -1,0 +1,33 @@
+// ================================================
+// Generates a pseudo-element in the form of an "outline"
+// in a cell that represents the "inline, editable" state.
+@mixin ids-data-grid-inline-editable-outline($margin) {
+  position: relative;
+
+  &::after {
+    border: 1px solid var(--ids-input-color-border-default);
+    border-radius: var(--ids-border-radius-01);
+    box-sizing: border-box;
+    display: block;
+    content: '';
+    margin: #{$margin}px;
+    height: calc(100% - #{$margin * 2}px);
+    position: absolute;
+    width: calc(100% - #{$margin * 2}px);
+  }
+}
+
+// ================================================
+// Generates a pseudo-element representing the dirty tracker
+// icon in a cell that's been edited.
+@mixin ids-data-grid-cell-dirty-tracker-icon {
+  border-color: var(--ids-input-dirty-indicator-color-background-dirty) transparent transparent var(--ids-input-dirty-indicator-color-background-dirty);
+  border-style: solid;
+  border-width: 5px;
+  content: '';
+  display: inline-block;
+  margin-inline: 2px;
+  position: absolute;
+  inset-block-start: 2px;
+  z-index: 1;
+}

--- a/src/components/ids-data-grid/ids-data-grid-editors.ts
+++ b/src/components/ids-data-grid/ids-data-grid-editors.ts
@@ -12,6 +12,7 @@ import type IdsTimePickerPopup from '../ids-time-picker/ids-time-picker-popup';
 import type IdsDataGridCell from './ids-data-grid-cell';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 import { isValidDate } from '../../utils/ids-date-utils/ids-date-utils';
+import type IdsButton from '../ids-button/ids-button';
 
 export interface IdsDataGridEditorOptions {
   /** The type of editor (i.e. text, data, time, dropdown, checkbox, number ect) */
@@ -577,6 +578,49 @@ export class TimePickerEditor implements IdsDataGridEditor {
   }
 }
 
+export class TreeEditor extends InputEditor {
+  expandButton?: IdsButton;
+
+  fieldContainer?: HTMLElement;
+
+  /**
+   * Adds extra button element for mimicking the tree formatter's display
+   * @param {IdsDataGridCell} cell the cell element
+   */
+  init(cell?: IdsDataGridCell) {
+    super.init(cell);
+
+    const buttonHTML = this.#isExpandable(cell!) ? `<ids-button class="expand-button" disabled="true">
+      <ids-icon icon="plusminus-folder-${this.#isExpanded(cell!) ? 'open' : 'closed'}"></ids-icon>
+    </ids-button>` : '';
+
+    cell!.insertAdjacentHTML('afterbegin', `<span class="ids-data-grid-tree-container">
+      ${buttonHTML}
+      <span class="ids-data-grid-tree-field-container"></span>
+    </span>`);
+
+    this.expandButton = cell!.querySelector<IdsButton>('.expand-button')!;
+    this.fieldContainer = cell!.querySelector<HTMLElement>('.ids-data-grid-tree-field-container')!;
+    this.fieldContainer.appendChild(this.input!);
+  }
+
+  #isExpanded(cell: IdsDataGridCell) {
+    return cell.dataGrid.rows[cell.rowIndex].getAttribute('aria-expanded') === 'true';
+  }
+
+  #isExpandable(cell: IdsDataGridCell) {
+    return cell.dataGrid.data[cell.rowIndex].children;
+  }
+
+  destroy() {
+    super.destroy();
+    this.expandButton?.remove();
+    this.fieldContainer?.remove();
+    this.expandButton = undefined;
+    this.fieldContainer = undefined;
+  }
+}
+
 export const editors: Array<{ type: string, editor?: IdsDataGridEditor }> = [];
 
 editors.push({
@@ -602,4 +646,9 @@ editors.push({
 editors.push({
   type: 'timepicker',
   editor: new TimePickerEditor()
+});
+
+editors.push({
+  type: 'tree',
+  editor: new TreeEditor()
 });

--- a/src/components/ids-data-grid/ids-data-grid-editors.ts
+++ b/src/components/ids-data-grid/ids-data-grid-editors.ts
@@ -609,7 +609,7 @@ export class TreeEditor extends InputEditor {
   }
 
   #isExpandable(cell: IdsDataGridCell) {
-    return cell.dataGrid.data[cell.rowIndex].children;
+    return cell.dataGrid.data[cell.rowIndex].childCount;
   }
 
   destroy() {

--- a/src/components/ids-data-grid/ids-data-grid-formatters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-formatters.ts
@@ -200,7 +200,12 @@ export default class IdsDataGridFormatters {
     const button = (rowData?.children as any)?.length ? `<ids-button tabindex="-1" class="expand-button">
       <ids-icon icon="plusminus-folder-${rowData.rowExpanded === false ? 'closed' : 'open'}"></ids-icon>
     </ids-button>` : '&nbsp;';
-    return `<span class="ids-data-grid-tree-container">${button}<span class="text-ellipsis">${value}</span></span>`;
+    return `<span class="ids-data-grid-tree-container">
+      ${button}
+      <span class="ids-data-grid-tree-field-container">
+        <span class="text-ellipsis">${value}</span>
+      </span>
+    </span>`;
   }
 
   /** Shows an expander button */
@@ -209,7 +214,12 @@ export default class IdsDataGridFormatters {
     const button = `<ids-button tabindex="-1" class="expand-button">
         <ids-icon icon="plusminus-folder-${rowData.rowExpanded === true ? 'open' : 'closed'}"></ids-icon>
       </ids-button>`;
-    return `<span class="ids-data-grid-tree-container">${button}<span class="text-ellipsis">${value}</span></span>`;
+    return `<span class="ids-data-grid-tree-container">
+      ${button}
+      <span class="ids-data-grid-tree-field-container">
+        <span class="text-ellipsis">${value}</span>
+      </span>
+    </span>`;
   }
 
   /** Shows a dropdown list */

--- a/src/components/ids-data-grid/ids-data-grid-formatters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-formatters.ts
@@ -199,7 +199,7 @@ export default class IdsDataGridFormatters {
     const value = this.#extractValue(rowData, columnData.field);
     const button = (rowData?.children as any)?.length ? `<ids-button tabindex="-1" class="expand-button">
       <ids-icon icon="plusminus-folder-${rowData.rowExpanded === false ? 'closed' : 'open'}"></ids-icon>
-    </ids-button>` : '&nbsp;';
+    </ids-button>` : '';
     return `<span class="ids-data-grid-tree-container">
       ${button}
       <span class="ids-data-grid-tree-field-container">

--- a/src/components/ids-data-grid/ids-data-grid-header.scss
+++ b/src/components/ids-data-grid/ids-data-grid-header.scss
@@ -157,7 +157,7 @@
 
 .ids-data-grid-header-cell-content {
   display: flex;
-  height: 100%;
+  // height: 100%;
 }
 
 .ids-data-grid-header-text {
@@ -222,6 +222,7 @@
   max-height: 18px;
   cursor: var(--ids-cursor-pointer);
   color: var(--ids-data-grid-header-expander-color);
+  margin-inline-start: var(--ids-space-50);
 
   &:hover {
     color: var(--ids-data-grid-header-expander-color-active);
@@ -347,12 +348,6 @@ th.ids-data-grid-header-cell {
 
 // Adjust for Row Heights (large is default)
 .ids-data-grid {
-  &[data-row-height='lg'] {
-    .header-expander {
-      margin-inline-start: var(--ids-space-50);
-    }
-  }
-
   &[data-row-height='md'] {
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-md-padding);
@@ -360,10 +355,6 @@ th.ids-data-grid-header-cell {
 
     .reorderer ids-icon {
       inset-inline-start: -11px;
-    }
-
-    .header-expander {
-      margin-inline-start: var(--ids-space-50);
     }
 
     .sort-indicator {
@@ -376,10 +367,6 @@ th.ids-data-grid-header-cell {
   }
 
   &[data-row-height='sm'] {
-    .header-expander {
-      margin-inline-start: var(--ids-space-50);
-    }
-
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-sm-padding);
     }
@@ -394,10 +381,6 @@ th.ids-data-grid-header-cell {
   }
 
   &[data-row-height='xs'] {
-    .header-expander {
-      margin-inline-start: var(--ids-space-50);
-    }
-
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-xs-padding);
     }
@@ -423,10 +406,6 @@ th.ids-data-grid-header-cell {
   }
 
   &[data-row-height='xxs'] {
-    .header-expander {
-      margin-inline-start: var(--ids-space-50);
-    }
-
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-xxs-padding);
     }

--- a/src/components/ids-data-grid/ids-data-grid-header.scss
+++ b/src/components/ids-data-grid/ids-data-grid-header.scss
@@ -157,6 +157,7 @@
 
 .ids-data-grid-header-cell-content {
   display: flex;
+  height: 100%;
 }
 
 .ids-data-grid-header-text {
@@ -221,7 +222,6 @@
   max-height: 18px;
   cursor: var(--ids-cursor-pointer);
   color: var(--ids-data-grid-header-expander-color);
-  margin-inline-start: var(--ids-space-50);
 
   &:hover {
     color: var(--ids-data-grid-header-expander-color-active);
@@ -347,6 +347,12 @@ th.ids-data-grid-header-cell {
 
 // Adjust for Row Heights (large is default)
 .ids-data-grid {
+  &[data-row-height='lg'] {
+    .header-expander {
+      margin-inline-start: var(--ids-space-50);
+    }
+  }
+
   &[data-row-height='md'] {
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-md-padding);
@@ -354,6 +360,10 @@ th.ids-data-grid-header-cell {
 
     .reorderer ids-icon {
       inset-inline-start: -11px;
+    }
+
+    .header-expander {
+      margin-inline-start: var(--ids-space-50);
     }
 
     .sort-indicator {
@@ -366,6 +376,10 @@ th.ids-data-grid-header-cell {
   }
 
   &[data-row-height='sm'] {
+    .header-expander {
+      margin-inline-start: var(--ids-space-50);
+    }
+
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-sm-padding);
     }
@@ -380,6 +394,10 @@ th.ids-data-grid-header-cell {
   }
 
   &[data-row-height='xs'] {
+    .header-expander {
+      margin-inline-start: var(--ids-space-50);
+    }
+
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-xs-padding);
     }
@@ -405,6 +423,10 @@ th.ids-data-grid-header-cell {
   }
 
   &[data-row-height='xxs'] {
+    .header-expander {
+      margin-inline-start: var(--ids-space-50);
+    }
+
     .ids-data-grid-header-text {
       padding: var(--ids-data-grid-header-xxs-padding);
     }

--- a/src/components/ids-data-grid/ids-data-grid-header.scss
+++ b/src/components/ids-data-grid/ids-data-grid-header.scss
@@ -157,7 +157,6 @@
 
 .ids-data-grid-header-cell-content {
   display: flex;
-  // height: 100%;
 }
 
 .ids-data-grid-header-text {

--- a/src/components/ids-data-grid/ids-data-grid-row.scss
+++ b/src/components/ids-data-grid/ids-data-grid-row.scss
@@ -107,6 +107,15 @@
       ids-hyperlink {
         margin: var(--ids-data-grid-padding-xxs);
       }
+
+      // On 'xxs' row height, inline-editable cells have a slightly wider
+      // padding appearance to accommodate the inline display
+      &.is-inline {
+        .text-ellipsis {
+          padding-inline-start: var(--ids-data-grid-padding-xs);
+          padding-inline-end: var(--ids-data-grid-padding-xs);
+        }
+      }
     }
 
     .ids-data-grid-cell:not(.align-center) .ids-data-grid-header-cell-content:not(.vertical-align-center) .ids-data-grid-header-text {

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -458,6 +458,7 @@ export default class IdsDataGridRow extends IdsElement {
       cssClasses += `${isDirtyCell(row, column, j) ? ' is-dirty' : ''}`;
       cssClasses += `${isInvalidCell(row, column, j) ? ' is-invalid' : ''}`;
       cssClasses += `${column?.align ? ` align-${column?.align}` : ''}`;
+      cssClasses += `${column?.formatter?.name ? ` formatter-${column.formatter.name}` : ''}`;
       cssClasses += `${column?.frozen ? ` frozen frozen-${column?.frozen}${j + 1 === frozenLast ? ' frozen-last' : ''}` : ''}`;
       cssClasses += `${column?.editor && !hasReadonlyClass && !hasDisabledClass ? ` is-editable${column?.editor?.inline ? ' is-inline' : ''}` : ''}`;
       return `<ids-data-grid-cell role="gridcell" part="${cssPart(column, index, j)}" class="${cssClasses}" aria-colindex="${j + 1}">${content}</ids-data-grid-cell>`;

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -138,7 +138,6 @@
     .text-ellipsis {
       // No Ellipsis on tree columns, let links be focusable
       overflow: initial;
-      padding-inline-start: 0;
 
       ids-hyperlink {
         margin-inline-start: 0;

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use '../../themes/mixins/ids-core-mixins' as mixins;
 @import './ids-data-grid-filters';
 @import './ids-data-grid-header';
@@ -6,6 +7,7 @@
 @import '../../components/ids-popup-menu/ids-popup-menu';
 @import '../../themes/mixins/ids-checkbox-mixin';
 @import '../../themes/mixins/ids-radio-mixin';
+
 
 :host {
   --ids-data-grid-column-widths: repeat(1, minmax(110px, 1fr));
@@ -137,7 +139,6 @@
       // No Ellipsis on tree columns, let links be focusable
       overflow: initial;
       padding-inline-start: 0;
-      margin-inline-start: 40px;
 
       ids-hyperlink {
         margin-inline-start: 0;
@@ -151,38 +152,119 @@
     align-items: center;
   }
 
-  // Dynamically added indents and position dirty indicator
-  @for $i from 2 through 8 {
-    [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container .text-ellipsis {
-      margin-inline-start: #{(($i - 2) * 27) + 64px};
-    }
-    [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container ids-button {
-      margin-inline-start: #{(($i - 2) * 27) + 50px};
-    }
-    [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container ids-button + .text-ellipsis {
-      margin-inline-start: 0;
-    }
+  // =======================================================
+  // Maps used for altering alignments of editable grid cells in different scenarios.
+  // These rules are based on row-height, which is defined at the `.ids-data-grid` element level.
+  // =======================================================
+  $row-height-inline-tree-grid-button-widths: (
+    'xxs': 30,
+    'xs': 32,
+    'sm': 34,
+    'md': 40,
+    'lg': 40
+  );
 
-    [aria-level='#{$i}'] {
-      .ids-data-grid-cell.is-inline.is-dirty {
-        .ids-data-grid-tree-field-container::before {
-          margin-inline-start: #{(($i - 2) * 27) + 70px};
-        }
-        ids-button + .ids-data-grid-tree-field-container::before {
-          margin-inline-start: 6px;
+  $row-height-padding-offsets: (
+    'xxs': 12,
+    'xs': 10,
+    'sm': 8,
+    'md': 3,
+    'lg': 3
+  );
+
+  $row-height-dirty-indicator-offsets: (
+    'xxs': 1,
+    'xs': 1,
+    'sm': 1,
+    'md': 2,
+    'lg': 2
+  );
+
+  $row-height-inline-dirty-indicator-offsets: (
+    'xxs': 3,
+    'xs': 4,
+    'sm': 5,
+    'md': 6,
+    'lg': 6
+  );
+
+  $row-height-indents: (
+    'xxs': 12,
+    'xs': 13,
+    'sm': 15,
+    'md': 17,
+    'lg': 17
+  );
+
+  @each $rowHeight, $offset in $row-height-padding-offsets {
+    // These values are different for each Row Height
+    $button-width: map.get($row-height-inline-tree-grid-button-widths, $rowHeight);
+    $indent: map.get($row-height-indents, $rowHeight);
+    $dirty-indicator-offset: map.get($row-height-dirty-indicator-offsets, $rowHeight);
+    $inline-dirty-indicator-offset: map.get($row-height-inline-dirty-indicator-offsets, $rowHeight);
+
+    &[data-row-height='#{$rowHeight}'] {
+      // ================================================
+      // Top-level grid alignments that depend solely on row height
+      .ids-data-grid-cell {
+        &.is-dirty {
+          &:not(.is-inline) {
+            &.formatter-text {
+              &:before {
+                inset-block-start: #{$dirty-indicator-offset}px;
+                margin-inline-start: #{$dirty-indicator-offset}px;
+              }
+            }
+          }
+
+          &.is-inline {
+            &.formatter-text {
+              &:before {
+                inset-block-start: #{$inline-dirty-indicator-offset}px;
+                margin-inline-start: #{$inline-dirty-indicator-offset}px;
+              }
+            }
+          }
         }
       }
-    }
-  }
 
-  // Level 1 has slightly-different dirty values
-  [aria-level='1'] {
-    .ids-data-grid-cell.is-inline.is-dirty {
-      .ids-data-grid-tree-field-container::before {
-        margin-inline-start: 46px;
-      }
-      ids-button + .ids-data-grid-tree-field-container::before {
-        margin-inline-start: 6px;
+      // ================================================
+      // Expandable grid/tree grid nested alignment rules
+      @for $i from 1 through 8 {
+        [aria-level='#{$i}'] .ids-data-grid-cell {
+          @if $i == 1 {
+            .ids-data-grid-tree-field-container {
+              margin-inline-start: #{$button-width}px;
+            }
+            ids-button {
+              margin-inline-start: 0;
+            }
+            ids-button + .ids-data-grid-tree-field-container {
+              margin-inline-start: 0;
+            }
+          } @else {
+            .ids-data-grid-tree-field-container {
+              margin-inline-start: #{$button-width + $indent + $offset}px;
+            }
+            ids-button {
+              margin-inline-start: #{$button-width + $offset}px;
+            }
+            ids-button + .ids-data-grid-tree-field-container {
+              margin-inline-start: 0;
+            }
+          }
+
+          // ================================================
+          // Dirty-tracker rules dependent on `aria-level` nesting
+          &.is-dirty {
+            &.is-inline {
+              .ids-data-grid-tree-field-container::before {
+                inset-block-start: #{$inline-dirty-indicator-offset}px;
+                margin-inline-start: #{$inline-dirty-indicator-offset}px;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -232,8 +232,7 @@
       @for $i from 1 through 8 {
         [aria-level='#{$i}'] .ids-data-grid-cell {
           @if $i == 1 {
-            .ids-data-grid-tree-field-container,
-            ids-input {
+            .ids-data-grid-tree-field-container {
               margin-inline-start: #{$button-width}px;
             }
 
@@ -245,8 +244,7 @@
               margin-inline-start: 0;
             }
           } @else {
-            .ids-data-grid-tree-field-container,
-            ids-input {
+            .ids-data-grid-tree-field-container {
               margin-inline-start: #{$button-width + ($indent * ($i - 1)) + ($offset)}px;
             }
 

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -210,7 +210,7 @@
         &.is-dirty {
           &:not(.is-inline) {
             &.formatter-text {
-              &:before {
+              &::before {
                 inset-block-start: #{$dirty-indicator-offset}px;
                 margin-inline-start: #{$dirty-indicator-offset}px;
               }
@@ -219,7 +219,7 @@
 
           &.is-inline {
             &.formatter-text {
-              &:before {
+              &::before {
                 inset-block-start: #{$inline-dirty-indicator-offset}px;
                 margin-inline-start: #{$inline-dirty-indicator-offset}px;
               }
@@ -236,9 +236,11 @@
             .ids-data-grid-tree-field-container {
               margin-inline-start: #{$button-width}px;
             }
+
             ids-button {
               margin-inline-start: 0;
             }
+
             ids-button + .ids-data-grid-tree-field-container {
               margin-inline-start: 0;
             }
@@ -246,9 +248,11 @@
             .ids-data-grid-tree-field-container {
               margin-inline-start: #{$button-width + ($indent * ($i - 1)) + ($offset)}px;
             }
+
             ids-button {
               margin-inline-start: #{($indent * ($i - 1)) + $offset}px;
             }
+
             ids-button + .ids-data-grid-tree-field-container {
               margin-inline-start: 0;
             }

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -232,7 +232,8 @@
       @for $i from 1 through 8 {
         [aria-level='#{$i}'] .ids-data-grid-cell {
           @if $i == 1 {
-            .ids-data-grid-tree-field-container {
+            .ids-data-grid-tree-field-container,
+            ids-input {
               margin-inline-start: #{$button-width}px;
             }
 
@@ -244,7 +245,8 @@
               margin-inline-start: 0;
             }
           } @else {
-            .ids-data-grid-tree-field-container {
+            .ids-data-grid-tree-field-container,
+            ids-input {
               margin-inline-start: #{$button-width + ($indent * ($i - 1)) + ($offset)}px;
             }
 

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use '../../themes/mixins/ids-core-mixins' as mixins;
+@import './ids-data-grid-common';
 @import './ids-data-grid-filters';
 @import './ids-data-grid-header';
 @import './ids-data-grid-row';
@@ -195,12 +196,30 @@
     'lg': 17
   );
 
+  $row-height-outline-padding: (
+    'xxs': 2,
+    'xs': 2,
+    'sm': 3,
+    'md': 4,
+    'lg': 4
+  );
+
+  $row-height-outline-offsets: (
+    'xxs': 4,
+    'xs': 2,
+    'sm': 5,
+    'md': 8,
+    'lg': 12
+  );
+
   @each $rowHeight, $offset in $row-height-padding-offsets {
     // These values are different for each Row Height
     $button-width: map.get($row-height-inline-tree-grid-button-widths, $rowHeight);
     $indent: map.get($row-height-indents, $rowHeight);
     $dirty-indicator-offset: map.get($row-height-dirty-indicator-offsets, $rowHeight);
     $inline-dirty-indicator-offset: map.get($row-height-inline-dirty-indicator-offsets, $rowHeight);
+    $outline-offset: map.get($row-height-outline-offsets, $rowHeight);
+    $outline-padding: map.get($row-height-outline-padding, $rowHeight);
 
     &[data-row-height='#{$rowHeight}'] {
       // ================================================
@@ -221,6 +240,23 @@
               &::before {
                 inset-block-start: #{$inline-dirty-indicator-offset}px;
                 margin-inline-start: #{$inline-dirty-indicator-offset}px;
+              }
+            }
+          }
+        }
+
+        // Defines the position of the "inline-edit" style's outline
+        &.is-editable.is-inline {
+          &:not(.formatter-tree) {
+            @include ids-data-grid-inline-editable-outline($outline-padding);
+          }
+
+          &.formatter-tree {
+            .text-ellipsis {
+              @include ids-data-grid-inline-editable-outline($outline-padding);
+
+              &::after {
+                margin-inline-end: -#{$outline-offset}px;
               }
             }
           }

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -227,6 +227,11 @@
         }
       }
 
+      // Remove start padding from tree-grid-contained `.text-ellipsis` elements
+      .ids-data-grid-tree-field-container .text-ellipsis {
+        padding-inline-start: 0;
+      }
+
       // ================================================
       // Expandable grid/tree grid nested alignment rules
       @for $i from 1 through 8 {

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -124,18 +124,20 @@
     flex-direction: row;
     align-items: center;
 
-    ids-button + .text-ellipsis {
-      padding-inline-start: 0;
+    ids-button + .ids-data-grid-tree-field-container .text-ellipsis {
+      margin-inline-start: 0;
     }
 
     ids-button {
-      padding-inline: 4px;
+      padding-inline-start: 4px;
+      padding-inline-end: 3px;
     }
 
     .text-ellipsis {
       // No Ellipsis on tree columns, let links be focusable
       overflow: initial;
-      padding-inline-start: 40px;
+      padding-inline-start: 0;
+      margin-inline-start: 40px;
 
       ids-hyperlink {
         margin-inline-start: 0;
@@ -143,16 +145,22 @@
     }
   }
 
+  .ids-data-grid-cell .ids-data-grid-tree-field-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
   // Dynamically added indents
   @for $i from 2 through 8 {
     [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container .text-ellipsis {
-      padding-inline-start: #{(($i - 2) * 27) + 64px};
+      margin-inline-start: #{(($i - 2) * 27) + 64px};
     }
     [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container ids-button {
-      padding-inline-start: #{(($i - 2) * 27) + 55px};
+      margin-inline-start: #{(($i - 2) * 27) + 50px};
     }
     [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container ids-button + .text-ellipsis {
-      padding-inline-start: 0;
+      margin-inline-start: 0;
     }
   }
 

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -244,10 +244,10 @@
             }
           } @else {
             .ids-data-grid-tree-field-container {
-              margin-inline-start: #{$button-width + $indent + $offset}px;
+              margin-inline-start: #{$button-width + ($indent * ($i - 1)) + ($offset)}px;
             }
             ids-button {
-              margin-inline-start: #{$button-width + $offset}px;
+              margin-inline-start: #{($indent * ($i - 1)) + $offset}px;
             }
             ids-button + .ids-data-grid-tree-field-container {
               margin-inline-start: 0;

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -130,7 +130,7 @@
 
     ids-button {
       padding-inline-start: 4px;
-      padding-inline-end: 3px;
+      padding-inline-end: 0;
     }
 
     .text-ellipsis {
@@ -151,7 +151,7 @@
     align-items: center;
   }
 
-  // Dynamically added indents
+  // Dynamically added indents and position dirty indicator
   @for $i from 2 through 8 {
     [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container .text-ellipsis {
       margin-inline-start: #{(($i - 2) * 27) + 64px};
@@ -161,6 +161,29 @@
     }
     [aria-level='#{$i}'] .ids-data-grid-cell .ids-data-grid-tree-container ids-button + .text-ellipsis {
       margin-inline-start: 0;
+    }
+
+    [aria-level='#{$i}'] {
+      .ids-data-grid-cell.is-inline.is-dirty {
+        .ids-data-grid-tree-field-container::before {
+          margin-inline-start: #{(($i - 2) * 27) + 70px};
+        }
+        ids-button + .ids-data-grid-tree-field-container::before {
+          margin-inline-start: 6px;
+        }
+      }
+    }
+  }
+
+  // Level 1 has slightly-different dirty values
+  [aria-level='1'] {
+    .ids-data-grid-cell.is-inline.is-dirty {
+      .ids-data-grid-tree-field-container::before {
+        margin-inline-start: 46px;
+      }
+      ids-button + .ids-data-grid-tree-field-container::before {
+        margin-inline-start: 6px;
+      }
     }
   }
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -1930,7 +1930,7 @@ export default class IdsDataGrid extends Base {
       // eslint-disable-next-line eqeqeq
       if (index === 0) childRow = data.find((row: Record<string, any>) => row[this.idColumn] == r);
       // eslint-disable-next-line eqeqeq
-      else childRow = childRow.children.find((cRow: Record<string, any>) => cRow.id == r);
+      else childRow = childRow?.children.find((cRow: Record<string, any>) => cRow.id == r);
     });
     return childRow;
   }

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -526,6 +526,10 @@ $input-size-full: 100%;
       font-size: var(--ids-font-size-40);
     }
 
+    .validation-message {
+      display: none;
+    }
+
     &.ids-input.field-height-lg .ids-input-field {
       padding-inline: 11px;
       height: 40px;

--- a/src/core/ids-data-source.ts
+++ b/src/core/ids-data-source.ts
@@ -169,6 +169,7 @@ class IdsDataSource {
         newData.push(row);
 
         if (row.children) {
+          row.childCount = row.children.length;
           if (this.pageNumber > 1) {
             index += ((this.pageNumber - 1) * this.pageSize);
           }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR re-works the "inline editable" style used in some IdsDataGrid cell formatters to provide a better visual display of "nested" fields alongside expand/collapse buttons.  In addition, this PR allows the "align" property provided in column config to be passed into a cell's editor, to retain the proper text alignment during editing.

**Related github/jira issue (required)**:
Closes #1229

**Steps necessary to review your pull request (required)**:
Pull/build/run, then test the following scenarios:

_New Inline Edit + Expander:_
- Open http://localhost:4300/ids-data-grid/tree-grid-inline.html
- Observe the new style in the "Id" column.  Test the different levels of nesting to ensure they make sense.
- Test expand/collapse still works
- Try editing any cell in the "Id" column.  When the editor is opened, the text should be right aligned per the column config to match the cell formatters.
- Commit new values to different levels of nesting and make sure the dirty indicator appears in the correct place.
- Use the "More Actions" menu to select different data grid row heights.  Try them all and make sure indentation/nesting/dirty indicator placement all make sense.

_Smoke test old examples:_
- Open http://localhost:4300/ids-data-grid/tree-grid-expand-collapse.html and make sure nesting/expansions appear correct on all row heights
- Open http://localhost:4300/ids-data-grid/editable-inline.html and make sure dirty indicator/row heights work on the original inline-edit style on text-formatted cells
- Open http://localhost:4300/ids-data-grid/editable.html and make sure dirty indicator/row heights work on all editable cell types.

**Included in this Pull Request**:
- [x] A note to the change log.