### PR TITLE
1467 - IdsCalendar first day of week setting

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 1.0.0-beta.16 Fixes
 
+- `[Calendar]` Fixed calendar `firstDayOfWeek` setting. ([#1467](https://github.com/infor-design/enterprise-wc/issues/1467))
 - `[DataGrid]` Fixed a bug on the size of the `xxs` filter row inputs. ([#1456](https://github.com/infor-design/enterprise-wc/issues/1456))
 - `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 - `[Modal]` Removed overflow constraint on modal content area to enable proper display of lists/popups attached to inner components. ([#1436](https://github.com/infor-design/enterprise-wc/issues/1436))

--- a/src/components/ids-calendar/demos/first-day-of-week.html
+++ b/src/components/ids-calendar/demos/first-day-of-week.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-toolbar>
+      <ids-toolbar-section align="end" type="fluid">
+        <ids-menu-button menu="add-event" value="${view}">
+          <ids-icon icon="add"></ids-icon>
+          <span class="audible">Add Event</span>
+        </ids-menu-button>
+        <ids-popup-menu id="add-event" trigger="click">
+          <ids-menu-group>
+            <ids-menu-item value="add-api">
+              <ids-text>Add Event (API)</ids-text>
+            </ids-menu-item>
+            <ids-menu-item value="add-modal">
+              <ids-text>Add Event (Modal)</ids-text>
+            </ids-menu-item>
+            <ids-menu-item value="clear">
+              <ids-text>Clear Events</ids-text>
+            </ids-menu-item>
+          </ids-menu-group>
+        </ids-popup-menu>
+
+        <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+      </ids-toolbar-section>
+    </ids-toolbar>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Calendar View</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-calendar date="10/22/2019" view-picker first-day-of-week="6"></ids-calendar>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-calendar/demos/first-day-of-week.ts
+++ b/src/components/ids-calendar/demos/first-day-of-week.ts
@@ -1,0 +1,29 @@
+import eventsJSON from '../../../assets/data/events.json';
+import eventTypesJSON from '../../../assets/data/event-types.json';
+
+const eventsURL: any = eventsJSON;
+const eventTypesURL: any = eventTypesJSON;
+
+/**
+ * Fetch events.json
+ * @returns {Promise} events.json content
+ */
+function getCalendarEvents(): Promise<any> {
+  return fetch(eventsURL).then((res) => res.json());
+}
+
+/**
+ * Fetch event-types.json
+ * @returns {Promise} event-types.json content
+ */
+function getEventTypes(): Promise<any> {
+  return fetch(eventTypesURL).then((res) => res.json());
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const calendar: any = document.querySelector('ids-calendar');
+
+  // Set event types
+  calendar.eventTypesData = await getEventTypes();
+  calendar.eventsData = await getCalendarEvents();
+});

--- a/src/components/ids-calendar/demos/index.yaml
+++ b/src/components/ids-calendar/demos/index.yaml
@@ -11,3 +11,6 @@
   - link: example-custom.html
     type: Example
     description: Custom Calendar View
+  - link: first-day-of-week.html
+    type: Example
+    description: Custom calendar first day of week

--- a/src/mixins/ids-date-attribute-mixin/ids-date-attribute-mixin.ts
+++ b/src/mixins/ids-date-attribute-mixin/ids-date-attribute-mixin.ts
@@ -12,7 +12,7 @@ export type IdsDateAttributeChangeCallback = undefined | ((newValue: number, isV
 export interface DateAttributeInterface {
   // as instance functions
   onDayChange?(newValue: number, isValid: boolean): void;
-  onFirstDayOfWeekChange?(newValue: number | null): void;
+  onFirstDayOfWeekChange?(newValue: number): void;
   onFormatChange?(newValue: string | null): void;
   onMonthChange?(newValue: number, isValid: boolean): void;
   onYearChange?(newValue: number, isValid: boolean): void;
@@ -113,11 +113,17 @@ const IdsDateAttributeMixin = <T extends Constraints>(superclass: T) => class ex
 
   /**
    * Set month view first day of the week
-   * @param {string|number|null} val fist-day-of-week attribute value
+   * @param {string|number} val fist-day-of-week attribute value
    */
-  set firstDayOfWeek(val: string | number | null) {
-    this.setAttribute(attributes.FIRST_DAY_OF_WEEK, String(val));
-    if (typeof this.onFirstDayOfWeekChange === 'function') this.onFirstDayOfWeekChange(Number(val));
+  set firstDayOfWeek(val: string | number) {
+    let dayOfWeek = Number(val);
+    dayOfWeek = Math.max(dayOfWeek, 0);
+    dayOfWeek = Math.min(dayOfWeek, 6);
+
+    this.setAttribute(attributes.FIRST_DAY_OF_WEEK, String(dayOfWeek));
+    if (typeof this.onFirstDayOfWeekChange === 'function') {
+      this.onFirstDayOfWeekChange(dayOfWeek);
+    }
   }
 
   /**

--- a/src/utils/ids-date-utils/ids-date-utils.ts
+++ b/src/utils/ids-date-utils/ids-date-utils.ts
@@ -24,7 +24,7 @@ export function isTodaysDate(date: Date) {
 export function firstDayOfWeekDate(date: Date, startsOn = 0, showRange = false): Date {
   const dayOfWeek = date.getDay();
   const firstDay = new Date(date);
-  const diff = dayOfWeek >= startsOn || showRange ? dayOfWeek - startsOn : 6 - dayOfWeek;
+  const diff = dayOfWeek >= startsOn || showRange ? dayOfWeek - startsOn : 7 - (startsOn - dayOfWeek);
 
   firstDay.setDate(date.getDate() - diff);
   firstDay.setHours(0, 0, 0, 0);

--- a/test/core/ids-date-utils-func-test.ts
+++ b/test/core/ids-date-utils-func-test.ts
@@ -43,7 +43,7 @@ describe('IdsDateUtils Tests', () => {
     // Monday
     expect(firstDayOfWeekDate(date, 1, true).getDay()).toEqual(1);
     // Thursday
-    expect(firstDayOfWeekDate(date, 6, false).getDay()).toEqual(4);
+    expect(firstDayOfWeekDate(date, 4, false).getDay()).toEqual(4);
   });
 
   it('should get the last day of the week', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed IdsCalendar to respond to `firstDayOfWeek` setting

Fixed related bug with IdsMonthView's calculation of `firstDayOfWeek`
Go to https://main.wc.design.infor.com/ids-month-view/example.html
`November 15 2021` is a Monday
Run `$('ids-month-view').firstDayOfWeek = 2`
IdsMonthView incorrectly displays the 15th as a Sunday

**Related github/jira issue (required)**:
Fixes #1467 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-calendar/first-day-of-week.html
3. Check that ids-calendar's `first-day-of-week` attribute is set to `6` (Saturday)
4. Check  that Month/Week views correctly reflects `firstDayOfWeek` setting
5. Check that datepicker popup also correctly reflects `firstDayOfWeek` setting
6. Compare to a real calendar to ensure that dates are correct and in their proper day columns

**Dynamic**
1. Try setting `firstDayOfWeek` value via dev console -> `$('ids-calendar').firstDayOfWeek = 1;`
2. Try values `0-6` (Sun - Sat)
3. Check that Month/Week views and datepicker popup correctly reflect firstDayOfWeek setting


**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

