### PR TITLE
1494 - Added a ticks setting to axis charts

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 1.0.0-beta.16 Features
 
+- `[AxisCharts]` Added a `ticks` setting to control the number of ticks on the y axis. ([#1494](https://github.com/infor-design/enterprise-wc/issues/1494))
 - `[Themes]` For theme switching added logic to check for a `<base href="">` tag. ([#1498](https://github.com/infor-design/enterprise-wc/issues/1498))
 
 ### 1.0.0-beta.16 Fixes
@@ -15,8 +16,8 @@
 - `[AxisChart]` Fixed responsive axis charts `inherit` setting value. ([#1458](https://github.com/infor-design/enterprise-wc/issues/1458))
 - `[Calendar]` Fixed calendar `firstDayOfWeek` setting. ([#1467](https://github.com/infor-design/enterprise-wc/issues/1467))
 - `[Calendar]` Allow propagation of `dayselected` event from calendar. ([#1470](https://github.com/infor-design/enterprise-wc/issues/1470))
-- `[DataGrid]` Added `wrap` attribute to `IdsMenuGroup` so large contextmenu menu-items can be wrapped into a column view. ([#1410](https://github.com/infor-design/enterprise-wc/issues/1410))
-- `[DataGrid]` Fixed contextmenu focused menu item in datagrid. ([#1453](https://github.com/infor-design/enterprise-wc/issues/1453))
+- `[DataGrid]` Added `wrap` attribute to `IdsMenuGroup` so large `contextmenu` menu-items can be wrapped into a column view. ([#1410](https://github.com/infor-design/enterprise-wc/issues/1410))
+- `[DataGrid]` Fixed `contextmenu` focused menu item in datagrid. ([#1453](https://github.com/infor-design/enterprise-wc/issues/1453))
 - `[DataGrid]` Add alignment rules and row-height specific padding to checkbox formatters. ([#1481](https://github.com/infor-design/enterprise-wc/issues/1481))
 - `[DataGrid]` Fixed a bug on the size of the `xxs` filter row inputs. ([#1456](https://github.com/infor-design/enterprise-wc/issues/1456))
 - `[DataGrid]` Fixed runtime-error on tree-grid when `IdsDataGrid.expandAll()` is executed. ([#1485](https://github.com/infor-design/enterprise-wc/issues/1485))

--- a/src/components/ids-axis-chart/README.md
+++ b/src/components/ids-axis-chart/README.md
@@ -178,6 +178,7 @@ The following data attributes can be used on the data passed to a chart.
 - `axisLabelTop` {string} Option to add top axis label.
 - `axisLabelMargin` {string|number} Axis label margin value.
 - `rotateNameLabels` {string|number} Sets the rotation of the labels on the name axis (style guide recommends -60 but you may want to tweak it based on labels. The `shortName` and `abbreviatedName` labels do not work with this setting.
+- `ticks` {number} Sets the number of ticks to show, to either reduce or show more ticks on the axis. This is an approximation based on the shape of the data and height of the chart the exact number of ticks specified might be altered to fit the algorithm.
 
 ## Events
 

--- a/src/components/ids-axis-chart/demos/index.yaml
+++ b/src/components/ids-axis-chart/demos/index.yaml
@@ -26,3 +26,6 @@
   - link: responsive.html
     type: Example
     description: Shows responsive example
+  - link: ticks.html
+    type: Example
+    description: Shows controling the ticks with a setting

--- a/src/components/ids-axis-chart/demos/ticks.html
+++ b/src/components/ids-axis-chart/demos/ticks.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Axis Chart</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-axis-chart title="A line chart showing component usage" ticks="5" width="700" height="400" id="index-example"></ids-axis-chart>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-axis-chart/demos/ticks.ts
+++ b/src/components/ids-axis-chart/demos/ticks.ts
@@ -1,0 +1,13 @@
+import componentsJSON from '../../../assets/data/components.json';
+import type IdsAxisChart from '../ids-axis-chart';
+
+const setData = async () => {
+  const res = await fetch(componentsJSON as any);
+  const data = await res.json();
+  const chart = document.querySelector<IdsAxisChart>('#index-example');
+  if (chart) {
+    chart.data = data;
+  }
+};
+
+setData();

--- a/src/components/ids-axis-chart/ids-axis-chart.ts
+++ b/src/components/ids-axis-chart/ids-axis-chart.ts
@@ -227,6 +227,7 @@ export default class IdsAxisChart extends Base implements ChartSelectionHandler 
       attributes.HEIGHT,
       attributes.HORIZONTAL,
       attributes.MARGINS,
+      attributes.TICKS,
       attributes.SHOW_HORIZONTAL_GRID_LINES,
       attributes.SHOW_VERTICAL_GRID_LINES,
       attributes.ROTATE_NAME_LABELS,
@@ -484,7 +485,11 @@ export default class IdsAxisChart extends Base implements ChartSelectionHandler 
 
     // Calculate a Nice Scale
     const groupMax = Math.max(...this.markerData.groupTotals);
-    const scale: NiceScale = new NiceScale(this.yAxisMin, this.stacked ? groupMax : this.markerData.max);
+    const scale: NiceScale = new NiceScale(
+      this.yAxisMin,
+      this.stacked ? groupMax : this.markerData.max,
+      { maxTicks: this.ticks }
+    );
     this.markerData.scale = scale;
     this.markerData.scaleValues = [];
     for (let i = (scale.niceMin || 0); i <= (scale.niceMax); i += (Number(scale.tickSpacing))) {
@@ -1347,6 +1352,21 @@ export default class IdsAxisChart extends Base implements ChartSelectionHandler 
 
   get yAxisMin(): number {
     return parseInt(this.getAttribute(attributes.Y_AXIS_MIN) ?? '') || 0;
+  }
+
+  /**
+   * Set the number of ticks to show
+   * @param {number} value The value to use
+   */
+  set ticks(value: number | undefined) {
+    this.setAttribute(attributes.TICKS, String(value));
+    this.redraw();
+  }
+
+  get ticks(): number | undefined {
+    const value = this.getAttribute(attributes.TICKS);
+    if (value) return Number(value);
+    return undefined;
   }
 
   /**

--- a/src/components/ids-bar-chart/demos/index.yaml
+++ b/src/components/ids-bar-chart/demos/index.yaml
@@ -44,3 +44,6 @@
   - link: horizontal-rotate-name-labels.html
     type: Example
     description: Shows a horizontal rotating name labels bar chart
+  - link: ticks.html
+    type: Example
+    description: Shows controling the ticks with a setting

--- a/src/components/ids-bar-chart/demos/ticks.html
+++ b/src/components/ids-bar-chart/demos/ticks.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Bar Chart</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-bar-chart id="index-example" title="Bar Chart - Component Adoption" ticks="18" width="700" height="500"></ids-bar-chart>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-bar-chart/demos/ticks.ts
+++ b/src/components/ids-bar-chart/demos/ticks.ts
@@ -1,0 +1,14 @@
+import componentsJSON from '../../../assets/data/components-single.json';
+
+const url = componentsJSON;
+const setData = async () => {
+  const res = await fetch(url as any);
+  const data = await res.json();
+
+  const chart: any = document.querySelector('#index-example');
+  if (chart) {
+    chart.data = data;
+  }
+};
+
+setData();

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -472,6 +472,7 @@ export const attributes = {
   TEXT_OFF: 'text-off',
   TEXT_ON: 'text-on',
   THEME: 'theme',
+  TICKS: 'ticks',
   TIMELINE_INTERVAL: 'timeline-interval',
   TIMEOUT: 'timeout',
   TITLE: 'title',


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Added a ticks setting to axis charts, that lets you control how many ticks are shown. Not when increasing the ticks the data can effect the number so the value might not be exact.

**Related github/jira issue (required)**:
Closes #1494 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-axis-chart/ticks.html and note it has 5 ticks compared to http://localhost:4300/ids-axis-chart/example.html
- go to http://localhost:4300/ids-bar-chart/ticks.html and note it has more ticks compared to http://localhost:4300/ids-bar-chart/example.html
- go to http://localhost:4300/ids-bar-chart/ticks.html  and edit the dom value for `ticks` on `ids-bar-chart` setting it to 5, observe it updates

**Included in this Pull Request**:
- [x ] A note to the change log.