### PR TITLE
1507 - IdsPager dropdown empty label

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 - `[Modal]` Removed overflow constraint on modal content area to enable proper display of lists/popups attached to inner components. ([#1436](https://github.com/infor-design/enterprise-wc/issues/1436))
 - `[Modal]` Changed the way z-index counting works to prevent a TypeScript/Angular compiler bug. ([#1476](https://github.com/infor-design/enterprise-wc/issues/1476))
+- `[Pager]` Fix ability to set empty label to pager dropdowns. ([#1507](https://github.com/infor-design/enterprise-wc/issues/1507))
 - `[Themes]` Fixed duplicate requests for theme files. ([#1491](https://github.com/infor-design/enterprise-wc/issues/1491))
 
 ## 1.0.0-beta.15

--- a/src/components/ids-pager/demos/index.yaml
+++ b/src/components/ids-pager/demos/index.yaml
@@ -14,6 +14,9 @@
   - link: pager-size-dropdown.html
     type: Example
     description: Showing an example page-size dropdown
+  - link: pager-size-dropdown-label.html
+    type: Example
+    description: Showing an example page-size dropdown label
   - link: list.html
     type: Example
     description: Showing a list style Pager example

--- a/src/components/ids-pager/demos/pager-size-dropdown-label.html
+++ b/src/components/ids-pager/demos/pager-size-dropdown-label.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+    <ids-layout-grid cols="3" gap="md" padding="md">
+      <ids-text font-size="12" type="h1">Ids Pager</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid cols="1" gap="md" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-pager page-number="1" page-size="20" total="200" id="ids-pager-example">
+          <ids-pager-dropdown slot="start" label="Products per page"></ids-pager-dropdown>
+          <ids-pager-button first></ids-pager-button>
+          <ids-pager-button previous></ids-pager-button>
+          <ids-pager-input></ids-pager-input>
+          <ids-pager-button next></ids-pager-button>
+          <ids-pager-button last></ids-pager-button>
+          <ids-pager-dropdown slot="end" label=""></ids-pager-dropdown>
+        </ids-pager>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-pager/ids-pager-dropdown.ts
+++ b/src/components/ids-pager/ids-pager-dropdown.ts
@@ -105,7 +105,7 @@ export default class IdsPagerDropdown extends IdsEventsMixin(IdsElement) {
    */
   get label(): string {
     const labelText = this.pageSize > 1 ? 'Records per page' : 'Record per page';
-    return this.getAttribute(attributes.LABEL) || labelText;
+    return this.getAttribute(attributes.LABEL) ?? labelText;
   }
 
   /**
@@ -183,7 +183,6 @@ export default class IdsPagerDropdown extends IdsEventsMixin(IdsElement) {
 
     const popupMenuGroup = popupMenu?.querySelector('ids-menu-group');
     if (popupMenuGroup) {
-      popupMenuGroup.style.minWidth = '175px';
       popupMenuGroup.style.textAlign = 'left';
       const sel = stringToNumber(popupMenu?.getSelectedValues?.()?.[0]);
       if (!Number.isNaN(sel) && sel !== pageSize) {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Removes label from `ids-pager-dropdown` by allowing `label` setting to accept an empty string as a value

**Related github/jira issue (required)**:
Fixes #1507 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-pager/pager-size-dropdown-label.html
3. Check both ids-pager-dropdowns
4. Left dropdown has custom `Products per page` as label
5. Right dropdown has "" as a label, so it should appear as if there's no label

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

