### PR TITLE
1441 - Add migration guide

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -88,3 +88,6 @@ lg
 IntelliSense
 Mada
 flexbox
+viz
+jsbin
+github

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Most popular editors support custom code completion with different configuration
 
 ## Documentation
 
-- See the [Documentation](doc/DOC-INDEX.md) for each component in markdown format. In addition to this index you will see a `.md` file in each [component folder](https://github.com/infor-design/enterprise-wc/tree/main/src/components) if browsing the source and examples.
+- See the [Documentation](doc/DOCUMENTATION.md) for each component in markdown format. In addition to this index you will see a `.md` file in each [component folder](https://github.com/infor-design/enterprise-wc/tree/main/src/components) if browsing the source and examples.
 - See the [Migration Guide](doc/MIGRATION-GUIDE.md)
 - See the [Change Log](doc/CHANGELOG.md) for info and breaking changes by version
 - See the [Examples in popular frameworks](https://github.com/infor-design/enterprise-wc-examples) for examples and notes on using these in several frameworks

--- a/README.md
+++ b/README.md
@@ -10,23 +10,32 @@ Infor Design System Enterprise Web Components Library is a framework independent
 ## Key Features
 
 - Three themes, including a WCAG 2.0 AAA compatible high-contrast theme and ability to theme anything
-- Responsive components, patterns and layouts
+- Responsive components
 - Touch-friendly interactions
 - SVG-based iconography for high DPI screens and scaling
 - Built-in, extendible localization system
 - Built-in mitigation of XSS exploits
-- 85-100% Functional Test Coverage
-- Passes all code security scans and is fully CSP compliant
+- Excellent test coverage
 - Well documented in `.md` format
 - Contains an extensive [Change log](./doc/CHANGELOG.md) which lists any and all breaking changes
 - [Fully linted code](./doc/LINTING.md)
-- Follows [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard-interaction-12) with a focus on accessibility
-- Fully Namespaced with an `ids-` namespace
-- We Follow the [Gold Standard For Making Web Components](https://github.com/webcomponents/gold-standard/wiki)
+- Follows [WAI-ARIA authoring practices](https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard-interaction-12) with a focus on accessibility
+- Fully namespaced with an `ids-` namespace
+- We follow the [Gold standard for making web components](https://github.com/webcomponents/gold-standard/wiki)
 - Includes types for typescript users
-- Every component has the CSS and DOM Encapsulation
+- Every component has the CSS and DOM Encapsulation for css collision avoidance
 - 100+ Components
-- Includes Visual Code and [standard schemas](https://github.com/webcomponents/custom-elements-manifest)
+- Includes Visual Code intellisense with [standard schemas](https://github.com/webcomponents/custom-elements-manifest)
+- Typescript types
+- We now support Es Modules
+- Bundle size in npm is 33% smaller (with code splitting enabled)
+- Supports [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) including css and js CSP
+- The newest designs will be added here
+- Removed a lot of older less commonly used features and misused patterns
+- New scroll view component to replace circle pager
+- New chart components
+- Data Grid virtual DOM
+- Flexible Flex Grid and responsive grid
 
 ## Browser Support
 
@@ -57,13 +66,7 @@ npm i
 npm run start
 ```
 
-## Documentation
-
-- For each component see the `.md` file in the relevant [component folder](https://github.com/infor-design/enterprise-wc/tree/main/src)
-- See the [Change Log](doc/CHANGELOG.md) for info on breaking changes as well more info in each individual component
-- See the [Examples in popular frameworks](https://github.com/infor-design/enterprise-wc-examples) for examples and notes on using these in several frameworks
-
-## Usage for Code Hinting
+## Using Code Hinting
 
 The npm package ships with a file called `vscode.html-custom-data.json`. The file describes the custom elements and their settings for use in Visual Studio Code to provide “IntelliSense”. To enable it, you just need to tell VS Code where the file is.
 
@@ -82,13 +85,21 @@ You may need to restart VS Code for the changes to take affect.
 
 Most popular editors support custom code completion with different configurations. Please [submit a feature request and/or pull request](https://github.com/infor-design/enterprise-wc/issues/new/choose) if you want to add your editor.
 
-## Contributing
+## Documentation
 
+- See the [Documentation](doc/DOC-INDEX.md) for each component in markdown format. In addition to this index you will see a `.md` file in each [component folder](https://github.com/infor-design/enterprise-wc/tree/main/src/components) if browsing the source and examples.
+- See the [Migration Guide](doc/MIGRATION-GUIDE.md)
+- See the [Change Log](doc/CHANGELOG.md) for info and breaking changes by version
+- See the [Examples in popular frameworks](https://github.com/infor-design/enterprise-wc-examples) for examples and notes on using these in several frameworks
+
+## Other Documentation
+
+- [Contributors Guide](doc/CONTRIBUTING.md)
 - [Articles about Web Components](doc/ARTICLES.md)
 - [Things to consider for each component](doc/CHECKLIST.md)
-- [How to Make a new Component](doc/COMPONENTS.md)
+- [How to make a new component](doc/COMPONENTS.md)
 - [Info on which linters we use](doc/LINTING.md)
-- [Info on Running and Debugging Tests](doc/TESTING.md)
-- Use [Github Issues](https://github.com/infor-design/enterprise-wc/issues) to report all requests, bugs, questions, and feature requests
+- [Info on running and debugging tests](doc/TESTING.md)
+- Use [Github Issues](https://github.com/infor-design/enterprise-wc/issues) to report enhancements, bugs, questions, and feature requests
 - [Review source code changes](https://github.com/infor-design/enterprise-wc/pulls)
 - [Roadmap and Sprint Board](https://github.com/orgs/infor-design/projects)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.17
+
+### 1.0.0-beta.17 Features
+
+- `[General]` Added an initial migration guide. ([#1561](https://github.com/infor-design/enterprise-wc/issues/1561))
+
 ## 1.0.0-beta.16
 
 ### 1.0.0-beta.16 Breaking Changes

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -48,7 +48,7 @@ We have found [the MacOS app](https://getkap.co), and [the Chrome plugin Screenc
 Feature requests are welcome. Before you submit one be sure to have:
 
 1. Does your idea fit within the general scope of the project? Would it be better served as an app/plugin/extension?
-1. Would anyone else but you want this feature?
+1. Could this feature be adopted and used by other Infor teams?
 1. Remember, it's up to you to make a strong case to convince the merits of this feature.
 
 ## Submitting Pull Requests

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -47,7 +47,7 @@ We have found [the MacOS app](https://getkap.co), and [the Chrome plugin Screenc
 
 Feature requests are welcome. Before you submit one be sure to have:
 
-1. Does your idea fits with the our general scope of the project? Might better fit being an app/plugin/extension?
+1. Does your idea fit within the general scope of the project? Would it be better served as an app/plugin/extension?
 1. Would anyone else but you want this feature?
 1. Remember, it's up to you to make a strong case to convince the merits of this feature.
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing Guidelines
+
+So you're interested in giving us a hand? That's awesome! We've put together some brief guidelines that should help you get started quickly and easily.
+
+There are several ways to get involved, this document covers:
+
+- [Raising Issues/Requests](#reporting-an-issue)
+  - :beetle: [bug reports](#bug-reports)
+  - :bulb: [feature requests](#feature-requests)
+- [Contributing to the codebase](#submitting-pull-requests)
+  - :repeat: [submitting pull requests](#pull-requests)
+- [testing and quality assurance](#testing-and-quality-assurance)
+
+## Reporting An Issue
+
+<https://github.com/infor-design/enterprise-wc/issues/new/choose>
+
+### Bug Reports
+
+A bug is a **demonstrable problem** that is caused by the code in the repository. Good bug reports are extremely helpful - thank you!
+
+Guidelines for bug reports:
+
+1. **Git issue search** - check if the issue has already been
+reported.
+2. **Check if the issue has been fixed** - try to reproduce it using the latest `main`.
+3. **Isolate the problem** - create a [reduced test case](https://www.browserstack.com/guide/test-case-reduction-and-techniques) and a live example.
+
+Examples of reduced test cases are:
+
+- Try to plug the example in a small project like our [plain html example](https://github.com/infor-design/enterprise-wc-examples/tree/main/plain-html)
+- Take an existing example and modify it to resemble the issue, this is ideal as we can include this in our test suite to avoid future breakages
+- Create an example using a tool like [stackblitz](https://stackblitz.com/) or [jsbin](https://jsbin.com/)
+- Any Other runnable code
+
+Also if you spend a little time in recreating and isolating the issue and you might learn and discover the solution.
+
+**:no_entry: Do not :no_entry:**
+- Send a video in place of a reduced test case
+- Send a link to your application
+- Just send an image of the source code
+
+If a video is useful to show the problem please use a cross platform format such as `.npm4`, `.gif` or `.webm` for the video.
+We have found [the MacOS app](https://getkap.co), and [the Chrome plugin Screencastify](https://chrome.google.com/webstore/detail/screencastify-screen-vide/mmeijimgabbpbgpdklnllpncmdofkcpn?hl=en) for video recording to be useful. Keep the video short or it gets confusing to follow, and always include the steps to reproduce in writing.
+
+### Feature Requests
+
+Feature requests are welcome. Before you submit one be sure to have:
+
+1. Does your idea fits with the our general scope of the project? Might better fit being an app/plugin/extension?
+1. Would anyone else but you want this feature?
+1. Remember, it's up to you to make a strong case to convince the merits of this feature.
+
+## Submitting Pull Requests
+
+Pull requests are awesome. If you're looking to raise a PR for something which doesn't have an open issue,
+please first [raise an issue](#raising-issues) which your PR can close, especially if you're fixing a bug.
+
+If you'd like to submit a pull request you'll need to do the following:
+
+1. **[Forking the repo](https://help.github.com/articles/fork-a-repo/)**. Navigate to [Github Repository](https://github.com/infor-design/enterprise-wc) and click the "Fork" button in the top right corner of your browser.
+1. **[Clone the Repository](https://help.github.com/articles/cloning-a-repository/)** to your machine.
+1. **Make your changes** to your local fork for the proper branch.
+  - Almost all development will be done on branches from `main`.
+  - If you are unsure, just ask someone on the team so you don't have to redo your branch.
+1. Remember to make an **e2e test** for your case.
+1. Remember to add a **note to the [Change Log](CHANGELOG.md)** and keep it in alphanumeric format
+1. **Commit your changes locally.**  Try to follow the standards for your commit message outlined below.
+  - Try to follow
+    - [Github's commit message standards](https://github.com/erlang/otp/wiki/Writing-good-commit-messagesMore)
+    - [Closing issues using keywords with commits and PRs](https://help.github.com/articles/closing-issues-using-keywords/)
+   - For Example:
+    ```bash
+      Closes #00 - Changed modal to implement the new design
+      Closes #00 - Changed header markup to implement arrow keys treating it as a toolbar
+    ```
+  - Repeat Steps 3 and 4 as many times as necessary to refine your code. Please try to stick to our coding standards and patterns that already exist in the code.
+1. **[Pull & Rebase](https://help.github.com/articles/about-pull-request-merges/#rebase-and-merge-your-pull-request-commits) to the latest version of the controls before you submit.**
+  - If enough time passes between your original clone and the completion of your changes, the main repository may have changed and some files you've edited may be out of sync.
+  - To re-sync your remote branch and clone, use the following after committing your changes:
+
+    ```bash
+    git pull --rebase {remote}/{branch}
+    ```
+
+    Note: You may need to merge some files or fix some conflicts.
+1. **Push your changes to your remote repository.**  Use `git push {remote} {branch}` to push your changes to your branch on the remote repository.
+1. **[Create a pull request](https://help.github.com/articles/creating-a-pull-request/)**
+  1. Request to the proper branch
+    - Normal changes get merged into `main`
+    - Version specific changes need to go into that specific version branch
+  1. The pull request title should follow this format:
+    - `{Issue Number} - Brief description of fix`
+    - e.g. `100 - Fixed a typo for such and such`
+  1. If you are doing a patch and requesting into a version branch, the title should look like
+    - `{Issue Number} - Brief description of fix`
+    - e.g. `100 - Fixed a type for such and such`
+
+See [help.github.com](https://help.github.com/) for further information on github.
+
+### Testing and Quality Assurance
+
+Never underestimate just how useful quality assurance is. If you're looking to get involved with the code base and don't know where to start, start by checking out and testing a pull request.
+
+Essentially though, check out the latest main, take it for a spin, and if you find anything odd, please follow the [bug report guidelines](#bug-reports) and let us know!

--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1,0 +1,125 @@
+# Documentation Main Index
+
+## Form Input Components
+
+- [Alert](../src/components/ids-alert/README.md) Alert indicator/icon
+- [Checkbox](../src/components/ids-checkbox/README.md) Checkbox Input element
+- [Checkbox Group](../src/components/ids-checkbox-group/README.md) Group of checkboxes with label
+- [Color Picker](../src/components/ids-color-picker/TODO.md) Input field for colors
+- [Data Label](../src/components/ids-data-label/README.md) Readonly data/label component
+- [Date Picker](../src/components/ids-date-picker/README.md) Input field for a date
+- [Dropdown](../src/components/ids-radio/README.md) Select from a list of items
+- [Editor](../src/components/ids-editor/README.MD) An input for multi line rich text
+- [Form](../src/components/ids-form/README.md) Form Controller Component
+- [Input](../src/components/ids-input/README.md) Input element and features
+- [Lookup](../src/components/ids-lookup/README.md) Select from a data grid list
+- [Mask](../src/components/ids-mask/README.md) Util for masking input
+- [Multiselect](../src/components/ids-multiselect/README.md) Select multiple values from a list
+- [Radio](../src/components/ids-radio/README.md) Input Radio element
+- [Search Field](../src/components/ids-search-field/README.md) Interactive input for typing in to search
+- [Spinbox](../src/components/ids-spinbox/README.md) Input element for numbers
+- [Switch](../src/components/ids-switch/README.md) Input element with on off capabilities
+- [Text Area](../src/components/ids-textarea/README.md) An input for multi line text
+- [Time Picker](../src/components/ids-time-picker/README.md) Input field for time and dates
+- [Trigger Field](../src/components/ids-trigger-field/README.md) An input field with an icon
+- [File Upload](../src/components/ids-upload/README.md) Upload a single file in a field
+- [File Upload Advanced](../src/components/ids-upload-advanced/README.md) Upload multiple files
+
+## Navigation and Interaction
+
+- [Action Sheet](../src/components/ids-action-sheet/README.md) Displays a menu at the bottom of your screen on mobile devices
+- [App Menu](../src/components/ids-app-menu/README.md) Application Nav
+- [BreadCrumb](../src/components/ids-breadcrumb/README.md) Navigational Way finding
+- [Button](../src/components/ids-button/README.md) Simple HTMLButtonElement
+- [Action Panel](../src/components/ids-action-panel/README.md) A modal component containing complicated forms
+- [Loading Indicator](../src/components/ids-loading-indicator/README.md) Animation for loading
+- [Menu](../src/components/ids-menu/README.md) A static UI menu
+- [Menu Button](../src/components/ids-menu-button/README.md) A button with a popup menu
+- [Modal](../src/components/ids-modal/README.md) Displays a Modal Dialog
+- [Pager](../src/components/ids-pager/README.md) Displays a Pager for lists
+- [Popup Menu](../src/components/ids-popup-menu/README.md) Displays a context menu
+- [Scroll View](../src/components/ids-scroll-view/README.md) Swipe / Scroll Container
+- [Skip Link](../src/components/ids-skip-link/README.md) Accessible Navigation
+- [Tabs](../src/components/ids-tabs/README.md) Segment different areas
+- [Tag](../src/components/ids-tag/README.md) UI Classification
+- [Theme Switcher](../src/components/ids-theme-switcher/README.md) Set and control themes
+- [Toggle Button](../src/components/ids-toggle-button/README.md) An on/off toggle button
+- [Tree](../src/components/ids-tree/README.md) Hierarchical view of items and subitems
+- [Virtual Scroll](../src/components/ids-virtual-scroll/README.md) Fast scrolling for lots of data
+- [Wizard](../src/components/ids-wizard/README.md) A clickable 4 step wizard
+
+## Messages and Alerts
+
+- [About](../src/components/ids-about/README.md) Displays info about a product with copyright and browser specs
+- [Empty Message](../src/components/ids-empty-message/README.md) Format for empty message alert
+- [Error Page](../src/components/ids-error-page/README.md) Displays error message
+- [Icons](../src/components/ids-icon/README.md) SVG icons
+- [Message](../src/components/ids-message/README.md) Displays a Message Dialog
+- [Notification Banner](../src/components/ids-notification-banner/README.MD) Displays a Top Level Application Message
+- [Progress Bar](../src/components/ids-progress-bar/README.md) Displays feedback on a process
+- [Tooltip](../src/components/ids-tooltip/README.MD) An message tooltip that shows on click/hover/focus
+- [Toast](../src/components/ids-toast/README.MD)Provides feedback after an action has taken place
+
+## Lists
+
+- [Data Grid](../src/components/ids-data-grid/README.MD) Tabular Data
+- [Draggable](../src/components/ids-draggable/README.MD) Drag API
+- [List Builder](../src/components/ids-list-builder/README.MD) Displays List Builder component
+- [List View](../src/components/ids-list-view/README.MD) Use to display a list of records
+- [SwapList](../src/components/ids-swaplist/README.md) Select from two lists
+
+## Layouts
+
+- [Accordion](../src/components/ids-accordion/README.md) Vertically Stacked Sections
+- [Block Grid](../src/components/ids-block-grid/README.md) Box/Block Grid Layout
+- [Box](../src/components/ids-box/README.md) Basic layout box for contents
+- [Calendar](../src/components/ids-calendar/README.md) Displays month, week, day views
+- [Card](../src/components/ids-card/README.md) Card layouts
+- [Container](../src/components/ids-container/README.md) Main container for themes / page body
+- [Expandable Area](../src/components/ids-expandable-area/README.md) Collapsible form sections
+- [Fieldset](../src/components/ids-fieldset/README.md) Divide Form Areas
+- [Header](../src/components/ids-header/README.md) Layout header component
+- [Hidden](../src/components/ids-hidden/README.md) Hide and Show content on values / breakpoints
+- [Hierarchy](../src/components/ids-hierarchy/README.md) Hierarchical view of items and subitems
+- [Home Page](../src/components/ids-home-page/README.md) Home Page / Widget Layout
+- [Image](../src/components/ids-image/README.md) Images, placeholders and thumbnails
+- [Layout Flex](../src/components/ids-layout-flex/README.md) Responsive Flex
+- [Layout Grid](../src/components/ids-layout-grid/README.md) Responsive Grid
+- [List Box](../src/components/ids-list-box/README.md) List Item Markup
+- [Masthead](../src/components/ids-masthead/README.md) Top level masthead component
+- [Month View](../src/components/ids-month-view/README.md) Displays month view calendar
+- [Popup](../src/components/ids-popup/README.md) Displays a Popup Container
+- [Separator](../src/components/ids-separator/README.md) Visual separator for separating components
+- [Splitter](../src/components/ids-splitter/README.md) Split Content panes
+- [Swipe Action](../src/components/ids-swipe-action/README.md) Container for swipe actions
+- [Toolbar](../src/components/ids-toolbar/README.md) A container for buttons
+- [Widget](../src/components/ids-widget/README.md) Widget container in home pages
+- [Week View](../src/components/ids-week-view/README.md) Displays weeks and days with navigation
+
+## Patterns
+
+- [Locale](../src/components/ids-locale/README.md) Extendible localization system
+- [Personalization](../src/components/ids-locale/README.md) Set a personalization color
+- [Swappable](../src/components/ids-locale/README.md) Swappable list items
+
+## Charts and Visualizations
+
+- [Badge](../src/components/ids-badge/README.md) Ui Text decoration
+- [Area Chart](../src/components/ids-area-chart/README.md) Chart used to compare trends with solid colored areas
+- [Axis Chart](../src/components/ids-axis-chart/README.md) Configurable chart with x and y axis
+- [Bar Chart](../src/components/ids-bar-chart/README.md) Chart used to convey relational quantity information
+- [Color](../src/components/ids-color/README.md) Color Swatches and scales
+- [Counts](../src/components/ids-counts/README.md) Informational Counts
+- [Line Chart](../src/components/ids-line-chart/README.md) Chart used to track changes over time with lines
+- [Pie Chart](../src/components/ids-pie-chart/README.md) Configurable circle chart divided into sectors
+- [Process Indicator](../src/components/ids-process-indicator/README.md) Progress Chart
+- [Rating](../src/components/ids-rating/README.md) Show a star rating
+- [Slider](../src/components/ids-slider/README.md) Allows a user to drag/click an input value between a min and m
+- [Stats](../src/components/ids-stats/README.md) how KPI's and trends
+- [Step Chart](../src/components/ids-step-chart/README.md) Displays steps in a process
+- [Treemap](../src/components/ids-step-chart/README.md) Hierarchical data viz component
+
+## Text and Typography
+
+- [Hyperlink](../src/components/ids-hyperlink/README.MD)
+- [Text](../src/components/ids-text/README.MD)

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -96,7 +96,7 @@ We added a seperate section on ways you can [customize a component](./DOCUMENTAT
 
 ## Component specific changes
 
-When migrating a component, review the documentation for the component your migrating. Note that each component doc contains a section called `Converting from Previous Versions (Breaking Changes)` which lists specific notes for each component. Again if we missed anything [make an issue](https://github.com/infor-design/enterprise-wc/issues/new/choose).
+When migrating a component, closely review that component's documentation. Note that each component doc contains a section called `Converting from Previous Versions (Breaking Changes)` which lists specific notes for upgrading. If we missed anything, [please raise a Github issue](https://github.com/infor-design/enterprise-wc/issues/new/choose).
 
 ## Getting Help
 

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -1,0 +1,118 @@
+#  Migration Guide
+
+While everyone's path and and needs may vary, this guide is meant to provide a list of common questions and answers and notes that may be helpful while migrating from previous versions of IDS or using it for the first. This is meant to be a live guide. If you have suggestions please [make an issue](https://github.com/infor-design/enterprise-wc/issues) and even better [a pull request](./CONTRIBUTING.md).
+
+## What is a Web Component
+
+One of the best guides on web components can be found on [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). We use the following concepts heavily and as a developer you should probably be aware of the following.
+
+- [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements)
+- [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM)
+- [HTML Templates and slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
+- [Lifecycle Callbacks](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#custom_element_lifecycle_callbacks)
+- [`:host`](https://developer.mozilla.org/en-US/docs/Web/CSS/:host)
+- [`:part`](https://developer.mozilla.org/en-US/docs/Web/CSS/::part)
+
+The advantage of the components being a web component is we can now use custom elements and have encapsulation in the css which protects you from css conflicts.
+
+## Whats is good and whats new
+
+See our [key features](../README.md#key-features) section for info on what we see as the key features in IDS Web Components.
+
+## Browser Support
+
+See the [browser support](../README.md#browser-support) section for this information.
+
+## Dependencies
+
+The ids-enterprise-wc web components no longer have any (dev) dependencies.
+
+- We dropped jQuery as a dependency, its no longer needed unless running old components side by side
+- We dropped d3 as a dependency, its no longer needed unless running old components side by side.
+
+## Installing into your framework
+
+The components are available via npm/yarn:
+
+```bash
+npm install --save ids-enterprise-wc@latest
+```
+
+After that the files can be seen in `node_modules/ids-enterprise-wc`. Then just import the components as needed. You can either import all component in one import via the `enterprise-wc.js` file. A better method is to import each and only each component you actually use, if doing a side by side approach this is especially important.
+
+```js
+// ALL
+import 'ids-enterprise-wc/enterprise-wc.js';
+
+// OR
+import 'ids-enterprise-wc/components/ids-tag/ids-tag';
+import 'ids-enterprise-wc/components/ids-alert/ids-alert';
+```
+
+If you just need the type you can import the types for each component like so:
+
+```js
+import type IdsAlert 'ids-enterprise-wc/components/ids-alert/ids-alert';
+```
+
+Once you import the script the custom element will self-register and then you can just use like the markup shown in the [docs for each component](./DOCUMENTATION.md).
+
+## Documentation
+
+Each component has an `md` file for documentation. See the index for a full listing of [docs for each component](./DOCUMENTATION.md)
+
+## Side By Side Migration Approach
+
+Side by Side migration to us means you can the older version of components with this version of the components. Then swap out components side by side as both can run together in the same page. Note: that not all possibilities have been tested, but if you run into an issue we can possibly fix it, just raise an issue.
+
+Start Slow: Consider areas of the application that need improvement, or new areas or maybe an admin page that needs rework and has lower impact.
+
+Get New Features: Try to migrate to components that have new features that wont be added to the old component library. Like much cleaner way to use icons with `<ids-icon>` and a future icon font, or components like a new `scroll-view`, `data grid` virtual scroll, `stats`, new `ids-charts`, `ids-action-sheet`, new `ids-loading-indicator` styles and a much cleaner and better stand alone `ids-pager` to name a few.
+
+Go Component By Component: Most components have a side-by-side example to test it you can review on the demo site https://main.wc.design.infor.com/ then click each component and see if there is a side by side page that show cases the two components can work side by side. But also you might want to work component by component and replace all uses of it, for example all old IDS buttons to `<ids-button>`.
+
+## What are settings / attributes / properties
+
+To clarify we use these terms in the following way:
+
+- `settings` In general everything is a setting as a generic term. For example `minute interval` is a setting on date picker for the time minutes picker. Almost every component has an array of settings mentioned in the docs. In case we missed one in the docs note that they can always been seen in each component source in a `attributes` section like [this component](https://github.com/infor-design/enterprise-wc/blob/main/src/components/ids-alert/ids-alert.ts#L49).
+- `attributes` Refer to either the html attribute name. Or the fact that the [web component spec](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#responding_to_attribute_changes) calls the attributes. So all settings can also be referred to as attributes. When used in markup they are done with kebab case as is the html spec. For example `<ids-date-picker minute-interval="15"`. Note that primitive types can have html attribute style settings, any object settings must be done with Js.
+- `properties` Refer to [js properties](https://developer.mozilla.org/en-US/docs/Glossary/Property/JavaScript). So all settings can also be referred to as properties. When used in Js they are done with camel case as is the js naming convention.  Note that any types can be used here and Typescript types should show in the intellisense if installed property. For example:
+
+```js
+const myDatePicker = document.querySelector<IdsDatePicker>('ids-date-picker');
+myDatePicker.minuteInterval = 15;
+```
+
+## Where is my feature XYX
+
+All the features should be in the docs for each component. See the index for a full listing of [docs for each component](./DOCUMENTATION.md). If a setting is missing in the docs you can also consult the [source for the components](https://github.com/infor-design/enterprise-wc/tree/main/src/components). And [let us know](https://github.com/infor-design/enterprise-wc/issues/new/choose) or give us a pull request.
+
+Note that we did not add every feature from the previous version. We tried to select the most common / used features. We also wanted to deprecate some things that were confusing / wrong or badly done. If we missed one that you find important and need [let us know](https://github.com/infor-design/enterprise-wc/issues/new/choose) or give us a pull request.
+
+## Customizing and Themes
+
+We added a seperate section on ways you can [customize a component](./DOCUMENTATION.md). These include using themes, css parts, extending ect.
+
+## Component specific changes
+
+When migrating a component, review the documentation for the component your migrating. Note that each component doc contains a section called `Converting from Previous Versions (Breaking Changes)` which lists specific notes for each component. Again if we missed anything [make an issue](https://github.com/infor-design/enterprise-wc/issues/new/choose).
+
+## Getting Help
+
+We :heart: working with developers and we have a few channels for questions or support:
+
+- [Contributing](./CONTRIBUTING.md) with bug reports and pull requests and suggestions
+- For asking general questions or searching for other questions use or [Ms Teams Channel](https://teams.microsoft.com/l/team/19%3A2b0c9ce520b0481a9ce115f0ca4a326f%40thread.skype/conversations?groupId=4f50ef7d-e88d-4ccb-98ca-65f26e57fe35&tenantId=457d5685-0467-4d05-b23b-8f817adda47c)
+
+## Example Projects
+
+We dont recommend any particular framework but we try to test with the most common ones and provide guidance on how to use the components. If we missed anything or you want to see a pattern example in a framework [make an issue](https://github.com/infor-design/enterprise-wc/issues/new/choose). As of now we have examples for the following frameworks click the link for guidance on each one. The example project can be found on [this repo](https://github.com/infor-design/enterprise-wc-examples), each example is in various levels of maturity.
+
+- **[Angular](https://github.com/infor-design/enterprise-wc-examples/tree/main/angular-ids-wc)**
+- **[React](https://github.com/infor-design/enterprise-wc-examples/tree/main/react-ids-wc)**
+- **[React Typescript](https://github.com/infor-design/enterprise-wc-examples/tree/main/react-ts-ids-wc)**
+- **[Vue JS](https://github.com/infor-design/enterprise-wc-examples/tree/main/vue-ids-wc)**
+- **[Svelte Kit](https://github.com/infor-design/enterprise-wc-examples/tree/main/sveltekit-ids-wc)**
+- **[Plain Html](https://github.com/infor-design/enterprise-wc-examples/tree/main/plain-html)**
+- **[Typescript](https://github.com/infor-design/enterprise-wc-examples/tree/main/typescript-ids-wc)**

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -88,7 +88,7 @@ myDatePicker.minuteInterval = 15;
 
 All the features should be in the docs for each component. See the index for a full listing of [docs for each component](./DOCUMENTATION.md). If a setting is missing in the docs you can also consult the [source for the components](https://github.com/infor-design/enterprise-wc/tree/main/src/components). And [let us know](https://github.com/infor-design/enterprise-wc/issues/new/choose) or give us a pull request.
 
-Note that we did not add every feature from the previous version. We tried to select the most common / used features. We also wanted to deprecate some things that were confusing / wrong or badly done. If we missed one that you find important and need [let us know](https://github.com/infor-design/enterprise-wc/issues/new/choose) or give us a pull request.
+Note that we did not add every feature from the previous version. We selected the most common / used features. We also wanted to deprecate some things that were confusing, incorrect, or did not provide an adequate user experience. If we missed a feature that you find important, let us know or [contribute it with a pull request](https://github.com/infor-design/enterprise-wc/issues/new/choose).
 
 ## Customizing and Themes
 

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -107,7 +107,7 @@ We :heart: working with developers and we have a few channels for questions or s
 
 ## Example Projects
 
-We dont recommend any particular framework but we try to test with the most common ones and provide guidance on how to use the components. If we missed anything or you want to see a pattern example in a framework [make an issue](https://github.com/infor-design/enterprise-wc/issues/new/choose). As of now we have examples for the following frameworks click the link for guidance on each one. The example project can be found on [this repo](https://github.com/infor-design/enterprise-wc-examples), each example is in various levels of maturity.
+We don't recommend any particular framework, but we try to test with the most common ones and provide guidance on how to integrate. If we missed anything, or you want to see a pattern example in a framework, [please raise a Github issue](https://github.com/infor-design/enterprise-wc/issues/new/choose).  See the links below for guidance and integration examples of the frameworks we currently support. The example project can be found on [this repo](https://github.com/infor-design/enterprise-wc-examples), each example is in various levels of maturity.
 
 - **[Angular](https://github.com/infor-design/enterprise-wc-examples/tree/main/angular-ids-wc)**
 - **[React](https://github.com/infor-design/enterprise-wc-examples/tree/main/react-ids-wc)**

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -73,7 +73,7 @@ Go Component By Component: Most components have a side-by-side example to test i
 
 ## What are settings / attributes / properties
 
-To clarify we use these terms in the following way:
+Not all properties will correspond to attributes, but all attributes are represented by properties.  To clarify, IDS uses these terms as described below:
 
 - `settings` In general everything is a setting as a generic term. For example `minute interval` is a setting on date picker for the time minutes picker. Almost every component has an array of settings mentioned in the docs. In case we missed one in the docs note that they can always been seen in each component source in a `attributes` section like [this component](https://github.com/infor-design/enterprise-wc/blob/main/src/components/ids-alert/ids-alert.ts#L49).
 - `attributes` Refer to either the html attribute name. Or the fact that the [web component spec](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#responding_to_attribute_changes) calls the attributes. So all settings can also be referred to as attributes. When used in markup they are done with kebab case as is the html spec. For example `<ids-date-picker minute-interval="15"`. Note that primitive types can have html attribute style settings, any object settings must be done with Js.

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -92,7 +92,7 @@ Note that we did not add every feature from the previous version. We selected th
 
 ## Customizing and Themes
 
-We added a seperate section on ways you can [customize a component](./DOCUMENTATION.md). These include using themes, css parts, extending ect.
+We added a separate section on ways you can [customize a component](./DOCUMENTATION.md). These include using themes, css parts, extending etc.
 
 ## Component specific changes
 

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -30,7 +30,7 @@ The ids-enterprise-wc web components no longer have any (dev) dependencies.
 - We dropped jQuery as a dependency, its no longer needed unless running old components side by side
 - We dropped d3 as a dependency, its no longer needed unless running old components side by side.
 
-## Installing into your framework
+## Installation
 
 The components are available via npm/yarn:
 

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -2,7 +2,7 @@
 
 While everyone's path and and needs may vary, this guide is meant to provide a list of common questions and answers and notes that may be helpful while migrating from previous versions of IDS or using it for the first. This is meant to be a live guide. If you have suggestions please [make an issue](https://github.com/infor-design/enterprise-wc/issues) and even better [a pull request](./CONTRIBUTING.md).
 
-## What is a Web Component
+## What is a Web Component?
 
 One of the best guides on web components can be found on [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). We use the following concepts heavily and as a developer you should probably be aware of the following.
 

--- a/doc/MIGRATION-GUIDE.md
+++ b/doc/MIGRATION-GUIDE.md
@@ -1,6 +1,6 @@
 #  Migration Guide
 
-While everyone's path and and needs may vary, this guide is meant to provide a list of common questions and answers and notes that may be helpful while migrating from previous versions of IDS or using it for the first. This is meant to be a live guide. If you have suggestions please [make an issue](https://github.com/infor-design/enterprise-wc/issues) and even better [a pull request](./CONTRIBUTING.md).
+While everyone's path and and needs may vary, this guide is meant to provide a list of common questions and answers and notes that may be helpful while migrating from previous versions of IDS, or using it for the first time. This is meant to be a live guide. If you have suggestions please [raise an issue on Github](https://github.com/infor-design/enterprise-wc/issues) or even better [a pull request with your contribution](./CONTRIBUTING.md).
 
 ## What is a Web Component?
 

--- a/src/components/ids-badge/demos/index.yaml
+++ b/src/components/ids-badge/demos/index.yaml
@@ -2,7 +2,7 @@
  component: Badge
  link: ids-badge
  description: Ui Text decoration
- category: Navigation and Interaction
+ category: Charts and Visualizations
  keywords: badge, decoration
  examples:
   - link: example.html

--- a/src/components/ids-bar-chart/demos/index.yaml
+++ b/src/components/ids-bar-chart/demos/index.yaml
@@ -1,9 +1,9 @@
 ---
  component: Bar Chart
  link: ids-bar-chart
- description: Chart used to convey relational quanity information
+ description: Chart used to convey relational quantity information
  category: Charts and Visualizations
- keywords: bar chart, column, chart, visualization, quanity, relational information, trends
+ keywords: bar chart, column, chart, visualization, quantity, relational information, trends
  examples:
   - link: example.html
     type: Main Example

--- a/src/components/ids-container/demos/index.yaml
+++ b/src/components/ids-container/demos/index.yaml
@@ -1,7 +1,7 @@
 ---
  component: Container
  link: ids-container
- description: Main container for themes / locale
+ description: Main container for themes / page body
  category: Layouts
  keywords: layout, container, locale, theme
  examples:

--- a/src/components/ids-skip-link/demos/index.yaml
+++ b/src/components/ids-skip-link/demos/index.yaml
@@ -1,7 +1,7 @@
 ---
  component: Skip Link
  link: ids-skip-link
- description: Accessibile Navigation
+ description: Accessible Navigation
  category: Navigation and Interaction
  keywords: number, spinbox, spinner, input, form
  examples:

--- a/src/components/ids-splitter/demos/index.yaml
+++ b/src/components/ids-splitter/demos/index.yaml
@@ -1,7 +1,7 @@
 ---
  component: Splitter
  link: ids-splitter
- description: IDS Splitter
+ description: Split Content panes
  category: Layouts
  keywords: splitter, pane, resize, grid
  examples:

--- a/src/components/ids-swaplist/demos/index.yaml
+++ b/src/components/ids-swaplist/demos/index.yaml
@@ -1,7 +1,7 @@
 ---
  component: SwapList
  link: ids-swaplist
- description: Displays SwapList component
+ description: Select from two lists
  category: Lists
  keywords: ids-swaplist, SwapList
  examples:


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds more root docs, a doc index page, contribution guide and a migration guide. The main stratgey in the guide is to map out intelligent sections with useful info and link to it. Rather than repeat info in various places

**Related github/jira issue (required)**:
Fixes #1441

**Steps necessary to review your pull request (required)**:
- make any comments or additons at any time and make PR comments
- browse the readme https://github.com/infor-design/enterprise-wc/tree/1441-migration-guide
- browse the migration  https://github.com/infor-design/enterprise-wc/blob/1441-migration-guide/doc/MIGRATION-GUIDE.md
- browse the contribution guide https://github.com/infor-design/enterprise-wc/blob/1441-migration-guide/doc/CONTRIBUTING.md

**Included in this Pull Request**:
- [x] A note to the change log.
