### PR TITLE
1465 - IdsCalendar afterrendermonth event

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # What's New with Enterprise Web Components
 
+### 1.0.0-beta.17 Fixes
+
+- `[Calendar]` Fix multiple `beforerendermonth` events. ([#1464](https://github.com/infor-design/enterprise-wc/issues/1464))
+- `[Calendar]` Add `afterrendermonth` event to calendar and month view. ([#1465](https://github.com/infor-design/enterprise-wc/issues/1465))
+
 ## 1.0.0-beta.16
 
 ### 1.0.0-beta.16 Breaking Changes

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,7 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.17
+
 ### 1.0.0-beta.17 Fixes
 
 - `[Calendar]` Fix multiple `beforerendermonth` events. ([#1464](https://github.com/infor-design/enterprise-wc/issues/1464))

--- a/src/components/ids-calendar/demos/example.ts
+++ b/src/components/ids-calendar/demos/example.ts
@@ -61,3 +61,11 @@ monthview?.addEventListener('beforeeventrendered', (e: Event) => {
 monthview?.addEventListener('aftereventrendered', (e: Event) => {
   console.info(`After Event Rendered`, (e as CustomEvent).detail);
 });
+
+monthview?.addEventListener('beforerendermonth', (e: Event) => {
+  console.info('Before Month Rendered', (e as CustomEvent).detail);
+});
+
+monthview?.addEventListener('afterrendermonth', (e: Event) => {
+  console.info('After Month Rendered', (e as CustomEvent).detail);
+});

--- a/src/components/ids-calendar/ids-calendar.ts
+++ b/src/components/ids-calendar/ids-calendar.ts
@@ -80,13 +80,14 @@ export default class IdsCalendar extends Base {
 
   constructor() {
     super();
-    if (!this.state) this.state = {};
+    this.state ??= {};
   }
 
   static get attributes() {
     return [
       ...super.attributes,
       attributes.DATE,
+      attributes.FIRST_DAY_OF_WEEK,
       attributes.SHOW_DETAILS,
       attributes.SHOW_LEGEND
     ];
@@ -205,8 +206,8 @@ export default class IdsCalendar extends Base {
    */
   connectedCallback(): void {
     super.connectedCallback();
-    this.changeView('month');
     this.#attachEventHandlers();
+    this.changeView('month');
     this.#configureResizeObserver();
     this.viewPickerConnected();
     this.onLocaleChange(this.localeAPI);
@@ -586,6 +587,32 @@ export default class IdsCalendar extends Base {
       this.#selectedEventId = elem.eventData.id;
       this.#removePopup();
       this.#insertFormPopup(elem.container, elem.eventData);
+    });
+
+    // Relay month before render event, ignore before render events from datepicker
+    this.offEvent('beforerendermonth');
+    this.onEvent('beforerendermonth', this.container, (evt: CustomEvent) => {
+      evt.stopPropagation();
+      evt.stopImmediatePropagation();
+      if (evt.detail.elem.parentElement?.classList?.contains('calendar-view-pane')) {
+        this.triggerEvent('beforerendermonth', this, {
+          bubbles: true,
+          detail: { ...evt.detail }
+        });
+      }
+    });
+
+    // Relay month after render event, ignore after render events from datepicker
+    this.offEvent('afterrendermonth');
+    this.onEvent('afterrendermonth', this.container, (evt: CustomEvent) => {
+      evt.stopPropagation();
+      evt.stopImmediatePropagation();
+      if (evt.detail.elem.parentElement?.classList?.contains('calendar-view-pane')) {
+        this.triggerEvent('afterrendermonth', this, {
+          bubbles: true,
+          detail: { ...evt.detail }
+        });
+      }
     });
 
     if (this.viewPicker) this.attachViewPickerEvents('month');
@@ -996,13 +1023,16 @@ export default class IdsCalendar extends Base {
    */
   #createMonthTemplate(): string {
     const date = this.date;
+    const firstDayOfWeek = this.firstDayOfWeek
+      ? `first-day-of-week="${this.firstDayOfWeek}"`
+      : '';
 
     return `
       <ids-month-view
         month="${date.getMonth()}"
         day="${date.getDate()}"
         year="${date.getFullYear()}"
-        first-day-of-week="${this.firstDayOfWeek || 0}">
+        ${firstDayOfWeek}>
         <slot name="MonthViewCalendarEventTemplate" slot="customCalendarEvent"></slot>
       </ids-month-view>
     `;
@@ -1225,6 +1255,8 @@ export default class IdsCalendar extends Base {
     return this.container?.querySelector<IdsMonthView>('ids-month-view') || this.container?.querySelector<IdsWeekView>('ids-week-view');
   }
 
+  #lastMonthLegendData: Array<any> | null = null;
+
   /**
    * Toggle Month View Legend
    * @param {CalendarEventTypeData[]} eventTypes calendar event types data
@@ -1247,7 +1279,10 @@ export default class IdsCalendar extends Base {
       }));
     }
 
-    component.legend = legendData;
+    if (this.#lastMonthLegendData !== legendData) {
+      this.#lastMonthLegendData = legendData;
+      component.legend = legendData;
+    }
   }
 
   /**

--- a/src/components/ids-month-view/ids-month-view.ts
+++ b/src/components/ids-month-view/ids-month-view.ts
@@ -95,6 +95,14 @@ const Base = IdsMonthViewAttributeMixin(
 @customElement('ids-month-view')
 @scss(styles)
 class IdsMonthView extends Base implements IdsRangeSettingsInterface {
+  #lastRenderedYear = NaN;
+
+  #lastRenderedDay = NaN;
+
+  #lastRenderedMonth = NaN;
+
+  #lastRenderedFirstDayOfWeek = NaN;
+
   constructor() {
     super();
   }
@@ -980,7 +988,10 @@ class IdsMonthView extends Base implements IdsRangeSettingsInterface {
     const weeksCount = this.#isDisplayRange()
       ? weeksInRange(this.startDate, this.endDate, this.firstDayOfWeek)
       : weeksInMonth(this.year, this.month, this.day, this.firstDayOfWeek, this.localeAPI?.isIslamic());
-    this.triggerEvent('beforerendermonth', this, { bubbles: true, composed: true });
+    this.triggerEvent('beforerendermonth', this, {
+      bubbles: true,
+      detail: { elem: this }
+    });
 
     const rowsTemplate = Array.from({ length: weeksCount }).map((_, weekIndex) => `<tr>${this.#getCellTemplate(weekIndex)}</tr>`).join('');
 
@@ -995,6 +1006,16 @@ class IdsMonthView extends Base implements IdsRangeSettingsInterface {
     if (!this.compact && !this.isDatePicker) {
       this.renderEventsData();
     }
+
+    this.#lastRenderedYear = this.year;
+    this.#lastRenderedMonth = this.month;
+    this.#lastRenderedDay = this.day;
+    this.#lastRenderedFirstDayOfWeek = this.firstDayOfWeek;
+
+    this.triggerEvent('afterrendermonth', this, {
+      bubbles: true,
+      detail: { elem: this }
+    });
   }
 
   /**
@@ -1159,7 +1180,9 @@ class IdsMonthView extends Base implements IdsRangeSettingsInterface {
    * @returns {void}
    */
   onFirstDayOfWeekChange() {
-    if (this.container) this.#renderMonth();
+    if (this.container && this.firstDayOfWeek !== this.#lastRenderedFirstDayOfWeek) {
+      this.#renderMonth();
+    }
   }
 
   /**
@@ -1172,7 +1195,7 @@ class IdsMonthView extends Base implements IdsRangeSettingsInterface {
     // Month change in range calendar doesn't trigger a rerender, just selects a day
     if (this.#isDisplayRange()) {
       this.selectDay(this.year, this.month, this.day);
-    } else {
+    } else if (this.month !== this.#lastRenderedMonth) {
       this.#renderMonth();
       this.#renderRangeSelection();
     }
@@ -1188,7 +1211,7 @@ class IdsMonthView extends Base implements IdsRangeSettingsInterface {
     // Year change in range calendar doesn't trigger a rerender, just selects a day
     if (this.#isDisplayRange()) {
       this.selectDay(this.year, this.month, this.day);
-    } else {
+    } else if (this.year !== this.#lastRenderedYear) {
       this.#renderMonth();
       this.#renderRangeSelection();
     }
@@ -1201,7 +1224,7 @@ class IdsMonthView extends Base implements IdsRangeSettingsInterface {
    * @returns {void}
    */
   onDayChange(numberVal: number, validates: boolean) {
-    if (!this.container) return;
+    if (!this.container || this.day === this.#lastRenderedDay) return;
 
     if (!(this.rangeSettings.start || this.useRange) && !this.isDatePicker) {
       this.selectDay(this.year, this.month, validates ? numberVal : this.day);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Adds `afterrendermonth` event to IdsCalendar.
Also fixed issue in #1464 where `beforerendermonth` was triggered multiple times on init.

**Related github/jira issue (required)**:
Fixes #1465 
Fixes #1464 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-calendar/example.html
3. Check that `beforemonthrender` and `aftermonthrender` event handlers are console.logged
4. Check that they each are only console.logged once

![Screenshot 2023-10-23 145855](https://github.com/infor-design/enterprise-wc/assets/98347152/651363ed-cb2c-4200-9d58-cdbbc11d0f22)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
