### PR TITLE
1505 - fix Angular form input values when using ngModel

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[DataGrid]` Fixed runtime-error on tree-grid when `IdsDataGrid.expandAll()` is executed. ([#1485](https://github.com/infor-design/enterprise-wc/issues/1485))
 - `[DataGrid]` Fixed blank rows on tree-grid after `IdsDataGrid.collapseAll()` is executed. ([#1486](https://github.com/infor-design/enterprise-wc/issues/1486))
 - `[General]` Update side by side examples to latest enterprise version for bug fixes. ([#1549](https://github.com/infor-design/enterprise-wc/issues/1549))
+- `[Input]` Fixed input elements (checkbox, radio-group, switch) so values are properly reflected in Angular Forms when using ngModel directive. ([#1505](https://github.com/infor-design/enterprise-wc/issues/1505))
 - `[Icons]` Fixed how icon sizes are applied to correct a bug where icons in safari are the wrong size. ([#1519](https://github.com/infor-design/enterprise-wc/issues/1519))
 - `[Message]` Fixed missing status icon in safari. ([#1541](https://github.com/infor-design/enterprise-wc/issues/1541))
 - `[Modal]` Removed overflow constraint on modal content area to enable proper display of lists/popups attached to inner components. ([#1436](https://github.com/infor-design/enterprise-wc/issues/1436))

--- a/src/components/ids-checkbox-group/ids-checkbox-group.ts
+++ b/src/components/ids-checkbox-group/ids-checkbox-group.ts
@@ -2,7 +2,7 @@ import { customElement, scss } from '../../core/ids-decorators';
 import { attributes } from '../../core/ids-attributes';
 import IdsEventsMixin from '../../mixins/ids-events-mixin/ids-events-mixin';
 import IdsElement from '../../core/ids-element';
-import '../ids-checkbox/ids-checkbox';
+import type IdsCheckbox from '../ids-checkbox/ids-checkbox';
 
 import styles from './ids-checkbox-group.scss';
 
@@ -63,5 +63,21 @@ export default class IdsCheckboxGroup extends IdsEventsMixin(IdsElement) {
 
     const textElem = this.container?.querySelector('ids-text');
     if (textElem) textElem.innerHTML = value;
+  }
+
+  /**
+   * Get child ids-checkbox inputs in this group
+   * @returns {IdsCheckbox[]} list of checkboxes
+   */
+  get checkboxes(): IdsCheckbox[] {
+    return [...this.querySelectorAll<IdsCheckbox>('ids-checkbox')];
+  }
+
+  /**
+   * Get the selected ids-checkbox inputs in this group
+   * @returns {IdsCheckbox[]} list of selected checkboxes
+   */
+  get checkboxesSelected(): IdsCheckbox[] {
+    return [...this.querySelectorAll<IdsCheckbox>('ids-checkbox[checked]')];
   }
 }

--- a/src/components/ids-radio/ids-radio-group.ts
+++ b/src/components/ids-radio/ids-radio-group.ts
@@ -103,7 +103,7 @@ export default class IdsRadioGroup extends Base {
 
   /**
    * Get the selected child ids-radio button in this group
-   * @returns {IdsRadio[]} the currently selected ids-radio
+   * @returns {IdsRadio[]} list of selected radios
    */
   get radiosSelected(): IdsRadio[] {
     return [...this.querySelectorAll<IdsRadio>('ids-radio[checked]')];

--- a/src/components/ids-radio/ids-radio-group.ts
+++ b/src/components/ids-radio/ids-radio-group.ts
@@ -247,23 +247,23 @@ export default class IdsRadioGroup extends Base {
    * @returns {void}
    */
   attachRadioGroupKeydown(): void {
-    const radioArr = [...this.querySelectorAll<IdsRadio>('ids-radio:not([disabled="true"])')];
-    const len = radioArr.length;
-    radioArr.forEach((r, i) => {
-      this.offEvent('keydown', r);
-      this.onEvent('keydown', r, (e: KeyboardEvent) => {
-        const allow = ['ArrowDown', 'ArrowRight', 'ArrowUp', 'ArrowLeft', 'Space'];
-        const key = e.code;
-        if (allow.indexOf(key) > -1) {
-          let idx = i;
+    const activeRadios = [...this.querySelectorAll<IdsRadio>('ids-radio:not([disabled="true"])')];
+    const numActive = activeRadios.length;
+    activeRadios.forEach((radio, index) => {
+      this.offEvent('keydown', radio);
+      this.onEvent('keydown', radio, (evt: KeyboardEvent) => {
+        const allowedKeys = ['ArrowDown', 'ArrowRight', 'ArrowUp', 'ArrowLeft', 'Space'];
+        const key = evt.code;
+        if (allowedKeys.includes(key)) {
+          let nextIndex = index;
           if (key === 'ArrowDown' || key === 'ArrowRight') {
-            idx = (i >= (len - 1)) ? 0 : (idx + 1);
+            nextIndex = (index >= (numActive - 1)) ? 0 : (nextIndex + 1);
           } else if (key === 'ArrowUp' || key === 'ArrowLeft') {
-            idx = (i <= 0) ? (len - 1) : (idx - 1);
+            nextIndex = (index <= 0) ? (numActive - 1) : (nextIndex - 1);
           }
-          this.makeChecked(radioArr[idx]);
-          radioArr[idx].focus();
-          e.preventDefault();
+          this.makeChecked(activeRadios[nextIndex]);
+          activeRadios[nextIndex].focus();
+          evt.preventDefault();
         }
       });
     });

--- a/src/components/ids-radio/ids-radio-group.ts
+++ b/src/components/ids-radio/ids-radio-group.ts
@@ -147,7 +147,7 @@ export default class IdsRadioGroup extends Base {
     }
 
     const lastSelected = radiosSelected?.at(-1);
-    const currentSelected = radios.find((radio) => radio.value === defaultValue) || lastSelected;
+    const currentSelected = radios.find((radio) => (defaultValue && radio.value === defaultValue)) || lastSelected;
 
     radios.forEach((radio: IdsRadio) => {
       if (radio === currentSelected) {

--- a/src/components/ids-radio/ids-radio-group.ts
+++ b/src/components/ids-radio/ids-radio-group.ts
@@ -204,31 +204,16 @@ export default class IdsRadioGroup extends Base {
    * Make given radio as checked.
    * @private
    * @param {object} radio to make checked
-   * @param {boolean} isFocus if true will set focus
    * @returns {void}
    */
-  makeChecked(radio: any, isFocus: boolean): void {
-    const radioArr = this.radios;
-    const targetEl = radioArr.filter((r) => r !== radio);
-    targetEl.forEach((r: any) => r.removeAttribute(attributes.CHECKED));
-    this.checked = radio;
-    const val = radio.value;
-    if (val) {
-      this.value = val;
-    }
-    if (isFocus) {
-      radio.shadowRoot?.querySelector('input[type="radio"]')?.focus();
-    }
+  makeChecked(radio: IdsRadio): void {
+    const value = radio?.value ?? '';
+    this.value = value;
 
-    // Mark if first radio checked in group, use for css style
-    const className = 'first-item-checked';
-    if (radio === radioArr[0]) {
-      this.input?.classList.add(className);
-    } else {
-      this.input?.classList.remove(className);
-    }
+    this.checked = radio ?? false;
+    if (radio) radio.checked = true;
 
-    const args = { detail: { value: val, checked: radio } };
+    const args = { detail: { value, checked: radio ?? false } };
     this.triggerEvent('change', this.input, args);
     this.triggerEvent('change', this, args);
   }
@@ -241,9 +226,9 @@ export default class IdsRadioGroup extends Base {
   attachRadioGroupChangeEvent(): void {
     const radioArr = this.radios;
 
-    radioArr.forEach((r) => {
-      this.onEvent('change', r, () => {
-        this.makeChecked(r, false);
+    radioArr.forEach((radio) => {
+      this.onEvent('change', radio, () => {
+        this.makeChecked(radio);
       });
     });
   }
@@ -254,7 +239,7 @@ export default class IdsRadioGroup extends Base {
    * @returns {void}
    */
   attachRadioGroupKeydown(): void {
-    const radioArr = [...this.querySelectorAll('ids-radio:not([disabled="true"])')];
+    const radioArr = [...this.querySelectorAll<IdsRadio>('ids-radio:not([disabled="true"])')];
     const len = radioArr.length;
     radioArr.forEach((r, i) => {
       this.onEvent('keydown', r, (e: KeyboardEvent) => {
@@ -267,7 +252,8 @@ export default class IdsRadioGroup extends Base {
           } else if (key === 'ArrowUp' || key === 'ArrowLeft') {
             idx = (i <= 0) ? (len - 1) : (idx - 1);
           }
-          this.makeChecked(radioArr[idx], true);
+          this.makeChecked(radioArr[idx]);
+          radioArr[idx].focus();
           e.preventDefault();
         }
       });

--- a/src/components/ids-radio/ids-radio.ts
+++ b/src/components/ids-radio/ids-radio.ts
@@ -29,25 +29,13 @@ const Base = IdsLocaleMixin(
 @customElement('ids-radio')
 @scss(styles)
 export default class IdsRadio extends Base {
-  input?: HTMLInputElement | null;
-
-  labelEl?: HTMLLabelElement | null;
-
-  rootEl?: HTMLElement | null;
-
-  /**
-   * Call the constructor and then initialize
-   */
-  constructor() {
-    super();
-  }
-
   /**
    * Return the attributes we handle as getters/setters
    * @returns {Array} The attributes in an array
    */
   static get attributes(): Array<string> {
     return [
+      ...super.attributes,
       attributes.CHECKED,
       attributes.COLOR,
       attributes.DISABLED,
@@ -60,15 +48,24 @@ export default class IdsRadio extends Base {
     ];
   }
 
+  get input(): HTMLInputElement | null {
+    return this.shadowRoot?.querySelector<HTMLInputElement>('input[type="radio"]') ?? null;
+  }
+
+  get labelEl(): HTMLLabelElement | null {
+    return this.shadowRoot?.querySelector<HTMLLabelElement>('label') ?? null;
+  }
+
+  get rootEl(): HTMLElement | null {
+    return this.shadowRoot?.querySelector<HTMLElement>('.ids-radio') ?? null;
+  }
+
   /**
    * Custom Element `connectedCallback` implementation
    * @returns {void}
    */
   connectedCallback(): void {
     super.connectedCallback();
-    this.input = this.shadowRoot?.querySelector('input[type="radio"]');
-    this.labelEl = this.shadowRoot?.querySelector('label');
-    this.rootEl = this.shadowRoot?.querySelector('.ids-radio');
 
     if (this.checked && !this.input?.getAttribute(attributes.CHECKED)) {
       this.checked = true;
@@ -82,7 +79,6 @@ export default class IdsRadio extends Base {
    * @returns {string} The template
    */
   template(): string {
-    // Checkbox
     const isDisabled = stringToBool(this.groupDisabled) || stringToBool(this.disabled);
     const disabled = isDisabled ? ' disabled' : '';
     const disabledAria = isDisabled ? ' aria-disabled="true"' : '';
@@ -91,11 +87,12 @@ export default class IdsRadio extends Base {
     const checked = stringToBool(this.checked) ? ' checked' : '';
     const rootClass = ` class="ids-radio${disabled}${horizontal}"`;
     const radioClass = ' class="radio-button"';
+    const value = ` value="${this.value ?? ''}"`;
 
     return `
       <div${rootClass}${color}>
         <label>
-          <input type="radio" part="radio" tabindex="-1"${radioClass}${disabled}${checked}>
+          <input type="radio" part="radio" tabindex="-1"${radioClass}${value}${disabled}${checked}>
           <span class="circle${checked}" part="circle"></span>
           <ids-text class="label-text"${disabledAria} part="label">${this.label}</ids-text>
         </label>
@@ -215,13 +212,14 @@ export default class IdsRadio extends Base {
    * @param {boolean|string} value If true will set `disabled` attribute
    */
   set disabled(value: boolean | string) {
-    const labelText = this.shadowRoot?.querySelector('.label-text');
     const val = stringToBool(value);
+    const labelText = this.shadowRoot?.querySelector('.label-text');
+    const rootEl = this.rootEl;
     if (val) {
       this.setAttribute(attributes.DISABLED, val.toString());
       this.input?.setAttribute(attributes.DISABLED, val.toString());
-      this.rootEl?.classList.add(attributes.DISABLED);
-      this.rootEl?.setAttribute('tabindex', '-1');
+      rootEl?.classList.add(attributes.DISABLED);
+      rootEl?.setAttribute('tabindex', '-1');
       labelText?.setAttribute('aria-disabled', 'true');
       labelText?.setAttribute(attributes.DISABLED, 'true');
     } else {
@@ -229,7 +227,7 @@ export default class IdsRadio extends Base {
       this.input?.removeAttribute(attributes.DISABLED);
       labelText?.removeAttribute('aria-disabled');
       labelText?.removeAttribute(attributes.DISABLED);
-      this.rootEl?.classList.remove(attributes.DISABLED);
+      rootEl?.classList.remove(attributes.DISABLED);
     }
   }
 

--- a/src/components/ids-switch/ids-switch.ts
+++ b/src/components/ids-switch/ids-switch.ts
@@ -191,7 +191,9 @@ export default class IdsSwitch extends Base {
     }
   }
 
-  get checked(): boolean { return stringToBool(this.input?.checked); }
+  get checked(): boolean {
+    return stringToBool(this.input ? this.input.checked : this.getAttribute(attributes.CHECKED));
+  }
 
   /**
    * @readonly

--- a/src/components/ids-switch/ids-switch.ts
+++ b/src/components/ids-switch/ids-switch.ts
@@ -176,16 +176,22 @@ export default class IdsSwitch extends Base {
 
     if (val) {
       this.setAttribute(attributes.CHECKED, val.toString());
-      this.input?.setAttribute(attributes.CHECKED, val.toString());
       slider?.classList.add(attributes.CHECKED);
+      if (this.input) {
+        this.input.setAttribute(attributes.CHECKED, val.toString());
+        this.input.checked = true;
+      }
     } else {
       this.removeAttribute(attributes.CHECKED);
-      this.input?.removeAttribute(attributes.CHECKED);
       slider?.classList.remove(attributes.CHECKED);
+      if (this.input) {
+        this.input.removeAttribute(attributes.CHECKED);
+        this.input.checked = false;
+      }
     }
   }
 
-  get checked(): boolean { return stringToBool(this.getAttribute(attributes.CHECKED)); }
+  get checked(): boolean { return stringToBool(this.input?.checked); }
 
   /**
    * @readonly

--- a/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
+++ b/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
@@ -42,6 +42,14 @@ const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extend
   }
 
   /**
+   * @readonly
+   * @returns {HTMLInputElement} the inner `input` element
+   */
+  get formInput(): HTMLInputElement | HTMLTextAreaElement | null {
+    return this.shadowRoot?.querySelector<HTMLInputElement>(`input`) ?? null;
+  }
+
+  /**
    * React to attributes changing on the web-component
    * @param {string} name The property name
    * @param {string} oldValue The property old value
@@ -137,14 +145,6 @@ const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extend
         nativeEvent: e,
       }
     });
-  }
-
-  /**
-   * @readonly
-   * @returns {HTMLInputElement} the inner `input` element
-   */
-  get formInput(): HTMLInputElement | HTMLTextAreaElement | null {
-    return this.shadowRoot?.querySelector<HTMLInputElement>(`input`) ?? null;
   }
 
   get form() { return this.#internals?.form; }

--- a/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
+++ b/src/mixins/ids-form-input-mixin/ids-form-input-mixin.ts
@@ -12,7 +12,11 @@ const noop = (...params: any) => params;
  * @returns {any} The extended object
  */
 const IdsFormInputMixin = <T extends Constraints>(superclass: T) => class extends superclass {
-  // @see https://webkit.org/blog/13711/elementinternals-and-form-associated-custom-elements/
+  /**
+   * ElementInternals adds the capability for custom elements to participate in a form submission.
+   * To use this feature, we must declare that a custom element is associated with forms as follows:
+   * @see https://webkit.org/blog/13711/elementinternals-and-form-associated-custom-elements/
+   */
   static formAssociated = true;
 
   #internals: ElementInternals;

--- a/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
+++ b/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
@@ -108,8 +108,8 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
           thisAsInput.input?.setAttribute('aria-required', true);
 
           if (isRadioGroup) {
-            const radioArr = [].slice.call(this.querySelectorAll('ids-radio'));
-            radioArr.forEach((r: any) => r.input.setAttribute('required', 'required'));
+            const radios = [...this.querySelectorAll('ids-radio')];
+            radios.forEach((radio: any) => radio.input?.setAttribute('required', 'required'));
           }
           (this as any).validationElems?.editor?.setAttribute('aria-required', true);
         }

--- a/test/ids-radio/ids-radio-group-func-test.ts
+++ b/test/ids-radio/ids-radio-group-func-test.ts
@@ -47,7 +47,7 @@ describe('IdsRadioGroup Component', () => {
 
   it('should renders as disabled', () => {
     expect(rg.getAttribute('disabled')).toEqual(null);
-    let radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    let radioArr = [...rg.querySelectorAll('ids-radio')];
     radioArr.forEach((r: any) => {
       expect(r.getAttribute('group-disabled')).toEqual(null);
     });
@@ -56,7 +56,7 @@ describe('IdsRadioGroup Component', () => {
     expect(rg.disabled).toEqual(false);
     rg.disabled = true;
     expect(rg.getAttribute('disabled')).toEqual('true');
-    radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    radioArr = [...rg.querySelectorAll('ids-radio')];
     radioArr.forEach((r: any) => {
       expect(r.getAttribute('group-disabled')).toEqual('true');
     });
@@ -65,7 +65,7 @@ describe('IdsRadioGroup Component', () => {
     expect(rg.disabled).toEqual(true);
     rg.disabled = false;
     expect(rg.getAttribute('disabled')).toEqual(null);
-    radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    radioArr = [...rg.querySelectorAll('ids-radio')];
     radioArr.forEach((r: any) => {
       expect(r.getAttribute('group-disabled')).toEqual(null);
     });
@@ -184,7 +184,7 @@ describe('IdsRadioGroup Component', () => {
     rg = document.body.appendChild(elem);
     rg.template();
     rg.setValue();
-    let radioArr: any[] = [].slice.call(rg.querySelectorAll('ids-radio'));
+    let radioArr: any[] = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual(null);
     expect(radioArr[1].getAttribute('checked')).toEqual('true');
     expect(rg.getAttribute('value')).toEqual('t2');
@@ -202,7 +202,7 @@ describe('IdsRadioGroup Component', () => {
     rg.setAttribute('label-required', 'false');
     rg.template();
     rg.setValue();
-    radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    radioArr = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual(null);
     expect(radioArr[1].getAttribute('checked')).toEqual('true');
 
@@ -217,7 +217,7 @@ describe('IdsRadioGroup Component', () => {
     rg.setAttribute('label', 'test');
     rg.template();
     rg.setValue();
-    radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    radioArr = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual('true');
     expect(radioArr[1].getAttribute('checked')).toEqual(null);
 
@@ -225,7 +225,7 @@ describe('IdsRadioGroup Component', () => {
     elem = document.createElement('ids-radio-group');
     rg = document.body.appendChild(elem);
     rg.template();
-    radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    radioArr = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr.length).toEqual(0);
   });
 
@@ -241,21 +241,21 @@ describe('IdsRadioGroup Component', () => {
     rg = document.body.appendChild(elem);
     rg.template();
     rg.setValue();
-    let radioArr: any[] = [].slice.call(rg.querySelectorAll('ids-radio'));
+    let radioArr: any[] = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual(null);
     expect(radioArr[1].getAttribute('checked')).toEqual('true');
     rg.clear();
-    radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    radioArr = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual(null);
     expect(radioArr[1].getAttribute('checked')).toEqual(null);
   });
 
   it('should make checked', () => {
-    let radioArr: any[] = [].slice.call(rg.querySelectorAll('ids-radio'));
+    let radioArr: any[] = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual(null);
     expect(radioArr[1].getAttribute('checked')).toEqual(null);
     rg.makeChecked(radioArr[0], true);
-    radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    radioArr = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual('true');
     expect(radioArr[1].getAttribute('checked')).toEqual(null);
     radioArr[0].value = null;
@@ -293,7 +293,7 @@ describe('IdsRadioGroup Component', () => {
   });
 
   it('should trigger key events', () => {
-    const radioArr = [].slice.call(rg.querySelectorAll('ids-radio'));
+    const radioArr = [...rg.querySelectorAll('ids-radio')];
     const allow = ['ArrowDown', 'ArrowRight', 'ArrowUp', 'ArrowLeft', 'Space'];
     const keys = [...allow, 'DummyKey'];
     let response = null;

--- a/test/ids-radio/ids-radio-group-func-test.ts
+++ b/test/ids-radio/ids-radio-group-func-test.ts
@@ -254,7 +254,7 @@ describe('IdsRadioGroup Component', () => {
     let radioArr: any[] = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual(null);
     expect(radioArr[1].getAttribute('checked')).toEqual(null);
-    rg.makeChecked(radioArr[0], true);
+    rg.makeChecked(radioArr[0]);
     radioArr = [...rg.querySelectorAll('ids-radio')];
     expect(radioArr[0].getAttribute('checked')).toEqual('true');
     expect(radioArr[1].getAttribute('checked')).toEqual(null);
@@ -262,6 +262,9 @@ describe('IdsRadioGroup Component', () => {
     radioArr[1].value = null;
     rg.makeChecked(radioArr[0]);
     expect(radioArr[0].getAttribute('checked')).toEqual('true');
+    expect(radioArr[1].getAttribute('checked')).toEqual(null);
+    rg.makeChecked();
+    expect(radioArr[0].getAttribute('checked')).toEqual(null);
     expect(radioArr[1].getAttribute('checked')).toEqual(null);
   });
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

When using `ngModel` directive in Angular's some custom components () did not update their values properly. This PR fixes ids-checkbox, ids-checkbox-group, ids-radio, ids-radio-group, and ids-switch.

**Related github/jira issue (required)**:

Closes #1505 

**Steps necessary to review your pull request (required)**:

1. Check out this PRs' branch and run: `nvm use && npm run start`
2. Run (in another tab): `npm run publish:link`
3. Check out this PR in WC examples repository: https://github.com/infor-design/enterprise-wc-examples/pull/38
4. In the examples repository run: `npm install`
5. In the examples repository run: `npm link ids-enterprise-wc`
6. In the examples repository run: `rm -fr .angular/cache`
7. In the examples repository run: `npm run build && npm run start` 
8. Go to: http://localhost:4200/ids-forms/example
9. Open your browser's developer console to see updated values of the updated form-controls.
10. Change the values in the different field controls and see console output.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
