### PR TITLE
1527 - IdsModal showCloseButton setting

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.17 Fixes
 
 - `[Calendar]` Add `disableSettings` property to calendar. ([#1471](https://github.com/infor-design/enterprise-wc/issues/1471))
+- `[Modal]` Add `showCloseButton` setting to modal. ([#1527](https://github.com/infor-design/enterprise-wc/issues/1527))
 
 ## 1.0.0-beta.16
 

--- a/src/components/ids-about/ids-about.ts
+++ b/src/components/ids-about/ids-about.ts
@@ -40,6 +40,7 @@ export default class IdsAbout extends Base {
 
   connectedCallback() {
     super.connectedCallback();
+    this.showCloseButton = this.getAttribute(attributes.SHOW_CLOSE_BUTTON) || 'right';
   }
 
   /**
@@ -73,7 +74,6 @@ export default class IdsAbout extends Base {
   attachEventHandlers(): object {
     super.attachEventHandlers();
     this.#refreshProduct();
-    this.#attachCloseButton();
     this.#refreshDeviceSpecs();
     this.#refreshCopyright();
 
@@ -88,19 +88,6 @@ export default class IdsAbout extends Base {
       this.#refreshCopyright();
     };
     return this;
-  }
-
-  /**
-   * Add button with icon to the modal
-   * Reusing ids-modal-button component with cancel attribute and extra css class to change appearance
-   */
-  #attachCloseButton() {
-    const element = `<ids-modal-button cancel slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
-      <span class="audible">Close modal</span>
-      <ids-icon icon="close"></ids-icon>
-    </ids-modal-button>`;
-
-    this.insertAdjacentHTML('beforeend', element);
   }
 
   /**

--- a/src/components/ids-button/ids-button.ts
+++ b/src/components/ids-button/ids-button.ts
@@ -105,6 +105,9 @@ export default class IdsButton extends Base {
     if (this.hasAttribute(attributes.CONTENT_ALIGN)) this.setContentAlignClass(this.getAttribute(attributes.CONTENT_ALIGN));
     this.setIconAlignment();
     this.refreshProtoClasses();
+
+    // set initial direction
+    this.localeAPI.updateDirectionAttribute(this, this.localeAPI.language.name);
   }
 
   /**

--- a/src/components/ids-modal/README.md
+++ b/src/components/ids-modal/README.md
@@ -20,6 +20,7 @@ The IDS Modal Component builds on top of the [Ids Popup](../ids-popup/README.md)
 - `visible` can be used to make the Modal show or hide
 - `buttons` (readonly) contains a list of references to any Modal Buttons present
 - `messageTitle` The text present at the very top of the Modal to indicate its purpose
+- `showCloseButton` used to show and position close button in modal. Can be set to values `left` or `right`.
 
 ## Themeable Parts
 

--- a/src/components/ids-modal/ids-modal.scss
+++ b/src/components/ids-modal/ids-modal.scss
@@ -69,6 +69,31 @@
   display: flex;
 }
 
+.modal-control-close {
+  position: absolute;
+  top: 4px;
+
+  &:not([dir='rtl']) {
+    &.right {
+      right: 4px;
+    }
+
+    &.left {
+      left: 4px;
+    }
+  }
+
+  &[dir='rtl'] {
+    &.right {
+      left: 4px;
+    }
+
+    &.left {
+      right: 4px;
+    }
+  }
+}
+
 // =====================================================
 // Alter the rules in this block to affect the border
 // between buttons inside the Modal Footer

--- a/src/components/ids-modal/ids-modal.ts
+++ b/src/components/ids-modal/ids-modal.ts
@@ -25,6 +25,8 @@ import styles from './ids-modal.scss';
 
 type IdsModalFullsizeAttributeValue = null | 'null' | '' | keyof Breakpoints | 'always';
 
+const VALID_POSITIONS = ['left', 'right'];
+
 const Base = IdsXssMixin(
   IdsBreakpointMixin(
     IdsFocusCaptureMixin(
@@ -92,6 +94,7 @@ export default class IdsModal extends Base {
       ...super.attributes,
       attributes.FULLSIZE,
       attributes.MESSAGE_TITLE,
+      attributes.SHOW_CLOSE_BUTTON,
       attributes.VISIBLE
     ];
   }
@@ -260,6 +263,31 @@ export default class IdsModal extends Base {
           break;
       }
     }
+  }
+
+  set showCloseButton(position: string | null) {
+    if (typeof position === 'string') {
+      position = VALID_POSITIONS.includes(position) ? position : 'right';
+      this.setAttribute(attributes.SHOW_CLOSE_BUTTON, position);
+      this.#attachCloseButton();
+    } else {
+      this.removeAttribute(attributes.SHOW_CLOSE_BUTTON);
+      this.#removeCloseButton();
+    }
+  }
+
+  get showCloseButton(): string | null {
+    const attrValue = this.getAttribute(attributes.SHOW_CLOSE_BUTTON);
+
+    if (typeof attrValue === 'string') {
+      return VALID_POSITIONS.includes(attrValue) ? attrValue : 'right';
+    }
+
+    return null;
+  }
+
+  get closeButton(): HTMLElement | null {
+    return this.container?.querySelector<HTMLElement>('.modal-control-close') ?? null;
   }
 
   /**
@@ -690,5 +718,35 @@ export default class IdsModal extends Base {
       return;
     }
     this.hide();
+  }
+
+  /**
+   * Add button with icon to the modal
+   * Reusing ids-modal-button component with cancel attribute and extra css class to change appearance
+   */
+  #attachCloseButton() {
+    this.#removeCloseButton();
+    const position = this.showCloseButton || 'right';
+
+    const element = `<ids-modal-button
+      class="modal-control-close ${position}"
+      slot="buttons"
+      appearance="tertiary"
+      css-class="ids-icon-button ids-modal-icon-button"
+      cancel>
+      <span class="audible">Close modal</span>
+      <ids-icon icon="close"></ids-icon>
+    </ids-modal-button>`;
+
+    this.container?.querySelector('.ids-modal-container')?.insertAdjacentHTML('afterbegin', element);
+
+    // attach close button handler
+    this.onEvent('click.modal-close', this.closeButton, () => this.hide());
+  }
+
+  #removeCloseButton() {
+    const closeButton = this.closeButton;
+    this.offEvent('click.modal-close', closeButton);
+    closeButton?.remove();
   }
 }

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -408,6 +408,7 @@ export const attributes = {
   SHOW_BROWSE_LINK: 'show-browse-link',
   SHOW_CANCEL: 'show-cancel',
   SHOW_CLEAR: 'show-clear',
+  SHOW_CLOSE_BUTTON: 'show-close-button',
   SHOW_DETAILS: 'show-details',
   SHOW_HEADER_EXPANDER: 'show-header-expander',
   SHOW_HORIZONTAL_GRID_LINES: 'show-horizontal-grid-lines',

--- a/test/ids-about/ids-about-func-test.ts.snap
+++ b/test/ids-about/ids-about-func-test.ts.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IdsAbout Component (using properties) should render 1`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
-      <span class="audible">Close modal</span>
-      <ids-icon icon="close"></ids-icon>
-    </ids-modal-button><ids-text slot="device" type="p">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" show-close-button="right"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-text slot="device" type="p">
         <span>Platform : </span><br>
         <span>Mobile : false</span><br>
         <span>Browser :  jsdom (20.0.0)</span><br>
@@ -16,10 +13,7 @@ exports[`IdsAbout Component (using properties) should render 1`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 2`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" visible="" style="z-index: 1021;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
-      <span class="audible">Close modal</span>
-      <ids-icon icon="close"></ids-icon>
-    </ids-modal-button><ids-text slot="device" type="p">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" show-close-button="right" visible="" style="z-index: 1021;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-text slot="device" type="p">
         <span>Platform : </span><br>
         <span>Mobile : false</span><br>
         <span>Browser :  jsdom (20.0.0)</span><br>
@@ -31,10 +25,7 @@ exports[`IdsAbout Component (using properties) should render 2`] = `
 `;
 
 exports[`IdsAbout Component (using properties) should render 3`] = `
-"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" style="z-index: 1021;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-modal-button cancel="" slot="buttons" appearance="tertiary" css-class="ids-icon-button ids-modal-icon-button">
-      <span class="audible">Close modal</span>
-      <ids-icon icon="close"></ids-icon>
-    </ids-modal-button><ids-text slot="device" type="p">
+"<ids-about id="test-about-component" product-version="4.0.0" product-name="Controls" copyright-year="2022" device-specs="true" use-default-copyright="true" aria-label=" Controls 4.0.0" role="dialog" fullsize="sm" respond-down="sm" show-close-button="right" style="z-index: 1021;"><ids-text slot="product" type="p">Controls 4.0.0</ids-text><ids-text slot="device" type="p">
         <span>Platform : </span><br>
         <span>Mobile : false</span><br>
         <span>Browser :  jsdom (20.0.0)</span><br>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Moved close button templating/logic to IdsModal via `showCloseButton` setting.
`showCloseButton` can be set to `left` or `right` to position the close button.

**Related github/jira issue (required)**:
Closes #1527 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-about/example.html
3. Check that close button is shown by default for ids-about
4. Run `$('ids-about').showCloseButton = 'left'` to change close btn position
5. Switch to an RTL language
6. Set `showCloseButton` to both `right` then `left` to test both positions in RTL

**Test `showCloseButton` in Modal examples**
1. Go to http://localhost:4300/ids-modal/contains-components.html
2. Run `$('ids-modal').showCloseButton = 'right'` to show close button on the top right of modal

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

