### PR TITLE
1050 - Sync IdsTabs and related components with 4.x Alabaster theme changes

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Calendar]` Fix multiple `beforerendermonth` events. ([#1464](https://github.com/infor-design/enterprise-wc/issues/1464))
 - `[Calendar]` Add `afterrendermonth` event to calendar and month view. ([#1465](https://github.com/infor-design/enterprise-wc/issues/1465))
 - `[Calendar]` Add `disableSettings` property to calendar. ([#1471](https://github.com/infor-design/enterprise-wc/issues/1471))
+- `[Tabs]` Sync component with Figma design changes related to Alabaster default theme. ([#1050](https://github.com/infor-design/enterprise-wc/issues/1050))
 
 ## 1.0.0-beta.16
 

--- a/src/components/ids-menu/ids-menu-item.scss
+++ b/src/components/ids-menu/ids-menu-item.scss
@@ -27,9 +27,11 @@
   pointer-events: none;
 }
 
+/*
 ::slotted(ids-icon) {
   pointer-events: none;
 }
+*/
 
 // Resets position rules for nested menus
 ::slotted(ids-popup-menu) {

--- a/src/components/ids-popup-menu/ids-popup-menu.ts
+++ b/src/components/ids-popup-menu/ids-popup-menu.ts
@@ -545,7 +545,9 @@ export default class IdsPopupMenu extends Base {
         this.hide();
         if (mouseLeaveNode?.tagName === 'IDS-MENU-ITEM') {
           mouseLeaveNode.highlight();
-          if (mouseLeaveNode.menu) mouseLeaveNode.menu.hideSubmenus(mouseLeaveNode);
+          if (mouseLeaveNode.menu && typeof mouseLeaveNode.menu.hideSubmenus === 'function') {
+            mouseLeaveNode.menu.hideSubmenus(mouseLeaveNode);
+          }
         }
       }
     }

--- a/src/components/ids-tabs/demos/header-tabs.html
+++ b/src/components/ids-tabs/demos/header-tabs.html
@@ -24,6 +24,15 @@
           <ids-tab value="opportunities">Opportunities</ids-tab>
           <ids-tab value="attachments" disabled>Attachments</ids-tab>
           <ids-tab value="notes">Notes</ids-tab>
+          <ids-tab slot="fixed" value="add" actionable>
+            <ids-icon icon="add"></ids-icon>
+            <ids-text type="span" audible>Add New Tab</ids-text>
+          </ids-tab>
+          <ids-tab slot="fixed" value="reset" actionable>
+            <ids-icon icon="reset"></ids-icon>
+            <ids-text type="span" audible>Remove User-added Tabs</ids-text>
+          </ids-tab>
+          <ids-tab-more overflow></ids-tab-more>
         </ids-tabs>
       </ids-header>
       <div class="ids-tabs-content">

--- a/src/components/ids-tabs/demos/header-tabs.ts
+++ b/src/components/ids-tabs/demos/header-tabs.ts
@@ -14,4 +14,40 @@ document.addEventListener('DOMContentLoaded', () => {
   tabElements.forEach((el) => el.addEventListener('change', (e: Event | CustomEvent | any) => {
     console.info(`ids-tabs.on('change') =>`, e.target.value);
   }));
+
+  const tabList: any = document.querySelector('ids-tabs');
+  const tabContentContainer: any = document.querySelector('div.ids-tabs-content');
+  let newTabCount = 0;
+
+  // If an "Add Tab" button is present, configures it to add a tab and panel
+  const addTab: any = document.querySelector('ids-tab[value="add"]');
+  if (addTab) {
+    addTab.onAction = () => {
+      addTab.insertAdjacentHTML('beforebegin', `<ids-tab color-variant="header" value="new-tab-${newTabCount}" dismissible>New Tab ${newTabCount}</ids-tab>`);
+      tabContentContainer.insertAdjacentHTML('beforeend', `<ids-tab-content value="new-tab-${newTabCount}">
+        <ids-layout-grid auto-fit="true" padding="md">
+          <ids-layout-grid-cell>
+            <ids-text font-size="20" type="h2">New Tab #${newTabCount}</ids-text>
+            <br />
+            <ids-text type="p">Generated ${new Date()}</ids-text>
+          </ids-layout-grid-cell>
+        </ids-layout-grid>
+      </ids-tab-content>`);
+      newTabCount += 1;
+    };
+  }
+
+  // If a "Reset Tab" button is present, configures it to remove the tab and panel
+  const resetTab: any = document.querySelector('ids-tab[value="reset"]');
+  if (resetTab) {
+    resetTab.onAction = () => {
+      [...tabList.querySelectorAll('ids-tab[value*="new-tab-"]')].forEach((tab) => {
+        tab.remove();
+      });
+      [...tabContentContainer.querySelectorAll('ids-tab-content[value*="new-tab-"]')].forEach((panel) => {
+        panel.remove();
+      });
+      newTabCount = 0;
+    };
+  }
 });

--- a/src/components/ids-tabs/demos/module.ts
+++ b/src/components/ids-tabs/demos/module.ts
@@ -7,29 +7,35 @@ document.addEventListener('DOMContentLoaded', () => {
   const tabContentContainer: any = document.querySelector('div.ids-tabs-content');
   let newTabCount = 0;
 
+  // If an "Add Tab" button is present, configures it to add a tab and panel
   const addTab: any = document.querySelector('ids-tab[value="add"]');
-  addTab.onAction = () => {
-    addTab.insertAdjacentHTML('beforebegin', `<ids-tab color-variant="module" value="new-tab-${newTabCount}" dismissible>New Tab ${newTabCount}</ids-tab>`);
-    tabContentContainer.insertAdjacentHTML('beforeend', `<ids-tab-content value="new-tab-${newTabCount}">
-      <ids-layout-grid auto-fit="true" padding-x="md">
-        <ids-layout-grid-cell>
-          <ids-text font-size="20" type="h2">New Tab #${newTabCount}</ids-text>
-          <br />
-          <ids-text type="p">Generated ${new Date()}</ids-text>
-        </ids-layout-grid-cell>
-      </ids-layout-grid>
-    </ids-tab-content>`);
-    newTabCount += 1;
-  };
+  if (addTab) {
+    addTab.onAction = () => {
+      addTab.insertAdjacentHTML('beforebegin', `<ids-tab color-variant="module" value="new-tab-${newTabCount}" dismissible>New Tab ${newTabCount}</ids-tab>`);
+      tabContentContainer.insertAdjacentHTML('beforeend', `<ids-tab-content value="new-tab-${newTabCount}">
+        <ids-layout-grid auto-fit="true" padding="md">
+          <ids-layout-grid-cell>
+            <ids-text font-size="20" type="h2">New Tab #${newTabCount}</ids-text>
+            <br />
+            <ids-text type="p">Generated ${new Date()}</ids-text>
+          </ids-layout-grid-cell>
+        </ids-layout-grid>
+      </ids-tab-content>`);
+      newTabCount += 1;
+    };
+  }
 
+  // If a "Reset Tab" button is present, configures it to remove the tab and panel
   const resetTab: any = document.querySelector('ids-tab[value="reset"]');
-  resetTab.onAction = () => {
-    [...tabList.querySelectorAll('ids-tab[value*="new-tab-"]')].forEach((tab) => {
-      tab.remove();
-    });
-    [...tabContentContainer.querySelectorAll('ids-tab-content[value*="new-tab-"]')].forEach((panel) => {
-      panel.remove();
-    });
-    newTabCount = 0;
-  };
+  if (resetTab) {
+    resetTab.onAction = () => {
+      [...tabList.querySelectorAll('ids-tab[value*="new-tab-"]')].forEach((tab) => {
+        tab.remove();
+      });
+      [...tabContentContainer.querySelectorAll('ids-tab-content[value*="new-tab-"]')].forEach((panel) => {
+        panel.remove();
+      });
+      newTabCount = 0;
+    };
+  }
 });

--- a/src/components/ids-tabs/demos/vertical.html
+++ b/src/components/ids-tabs/demos/vertical.html
@@ -5,14 +5,46 @@
   <%= htmlWebpackPlugin.options.font %>
 </head>
 <body>
-  <ids-container role="main" padding="8" hidden>
-    <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-tabs value="notes" orientation="vertical" id="ids-tabs-vertical">
-      <ids-tab value="contracts">Contracts</ids-tab>
-      <ids-tab value="opportunities">Opportunities</ids-tab>
-      <ids-tab value="attachments" disabled>Attachments</ids-tab>
-      <ids-tab value="notes">Notes</ids-tab>
-    </ids-tabs>
+  <ids-container role="main" padding="0" hidden>
+    <ids-tabs-context orientation="vertical" auto-fit>
+      <ids-tabs value="notes" id="ids-tabs-vertical">
+        <ids-tab value="contracts">Contracts</ids-tab>
+        <ids-tab value="opportunities">Opportunities</ids-tab>
+        <ids-tab value="attachments" disabled>Attachments</ids-tab>
+        <ids-tab value="notes">Notes</ids-tab>
+      </ids-tabs>
+      <div class="ids-tabs-content">
+        <ids-theme-switcher mode="light"></ids-theme-switcher>
+        <ids-tab-content value="contracts">
+          <ids-layout-grid auto-fit="true" padding="sm">
+            <ids-text font-size="16" type="p">Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+        <ids-tab-content value="opportunities">
+          <div class="tab-content">
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+              </ids-text>
+            </ids-layout-grid>
+          </div>
+        </ids-tab-content>
+        <ids-tab-content value="attachments">
+          <ids-layout-grid auto-fit="true" padding="sm">
+            <ids-text font-size="16" type="p">
+              Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.
+            </ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+        <ids-tab-content value="notes">
+          <ids-layout-grid auto-fit="true" padding="sm">
+            <ids-text font-size="16" type="p">
+              Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+            </ids-text>
+          </ids-layout-grid>
+        </ids-tab-content>
+      </div>
+    </ids-tabs-context>
   </ids-container>
 </body>
 </html>

--- a/src/components/ids-tabs/ids-tab-more.ts
+++ b/src/components/ids-tabs/ids-tab-more.ts
@@ -8,6 +8,7 @@ import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import '../ids-popup-menu/ids-popup-menu';
 import '../ids-text/ids-text';
 import type IdsTabs from './ids-tabs';
+import { getClosest } from '../../utils/ids-dom-utils/ids-dom-utils';
 
 const MORE_ACTIONS_SELECTOR = `[${attributes.MORE_ACTIONS}]`;
 
@@ -346,7 +347,8 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
     this.menu.width = '100%';
     this.menu.popup.align = 'bottom, left';
     this.menu.popup.y = -10;
-    this.menu.popup.alignTarget = this.container;
+    this.menu.target = this;
+    this.menu.triggerType = 'click';
   }
 
   #attachMoreMenuEvents(): void {
@@ -365,6 +367,19 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
         this.menu.show();
       } else {
         this.menu.hide();
+      }
+    });
+
+    this.onEvent('click', this.menu, (e: MouseEvent) => {
+      const target = (e.target as HTMLElement);
+      if (target) {
+        // If the icon inside the menu item is a "close" icon, dismiss the tab.
+        if (target.tagName === 'IDS-ICON' && target.getAttribute('icon') === 'close') {
+          const menuItem = getClosest(target, 'ids-menu-item');
+          if (menuItem) {
+            (menuItem.overflowTarget as IdsTab).dismiss();
+          }
+        }
       }
     });
 

--- a/src/components/ids-tabs/ids-tab-more.ts
+++ b/src/components/ids-tabs/ids-tab-more.ts
@@ -74,6 +74,10 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
     return this.shadowRoot?.querySelector('ids-popup-menu');
   }
 
+  /**
+   * @readonly
+   * @returns {HTMLElement} More Actions menu group
+   */
   get moreActionsGroup(): any {
     return this.querySelector(MORE_ACTIONS_SELECTOR);
   }
@@ -107,6 +111,14 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
   }
 
   /**
+   * @readonly
+   * @returns {HTMLElement} the "dropdown arrow" IdsIcon element
+   */
+  get dropdownIcon() {
+    return this.shadowRoot?.querySelector('ids-icon[icon="dropdown"]');
+  }
+
+  /**
    * @private
    * @returns {string} the template for the More Actions Menu Group
    */
@@ -115,7 +127,7 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
     const renderedTabItems = childTabs?.map((i: HTMLElement) => this.#moreActionsItemTemplate(i)).join('') || '';
 
     // Cycle through tabs, if present, and render a menu item that represents them
-    return `<ids-menu-group ${attributes.MORE_ACTIONS}>
+    return `<ids-menu-group ${attributes.MORE_ACTIONS} select="single">
       ${renderedTabItems}
     </ids-menu-group>`;
   }
@@ -139,6 +151,8 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
       overflowed = this.isOverflowed(item) ? '' : ' hidden';
     }
 
+    const iconTemplate = (iconDef: string) => `<ids-icon slot="icon" icon="${iconDef}"></ids-icon>`;
+
     // Handles regular tabs
     const handleTab = (thisItem: any) => {
       text = thisItem.textContent;
@@ -147,7 +161,7 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
 
       const tabIcon = thisItem.querySelector('ids-icon');
       if (tabIcon) {
-        icon = ` icon="${tabIcon.icon}"`;
+        icon = iconTemplate(tabIcon.icon);
       }
     };
 
@@ -166,7 +180,7 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
     // These represent menu items in Dropdown Tabs, which can be hidden.
     const handleMenuItem = (thisItem: any) => {
       if (thisItem.disabled) disabled = ' disabled';
-      if (thisItem.icon) icon = ` icon="${thisItem.icon}"`;
+      if (thisItem.icon) icon = iconTemplate(thisItem.icon);
       if (thisItem.hidden) hidden = ` hidden`;
       text = thisItem.text;
 
@@ -192,10 +206,11 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
     }
 
     // Sanitize text from Tabs to fit menu items
-    text = removeNewLines(text)?.trim();
+    text = `<span class="ids-tab-more-menu-item-text">${removeNewLines(text)?.trim()}</span>`;
 
-    return `<ids-menu-item${disabled}${icon}${hidden || overflowed}${value}>
+    return `<ids-menu-item${disabled}${hidden || overflowed}${value}>
       ${text}
+      ${icon}
       ${submenu}
     </ids-menu-item>`;
   }
@@ -344,11 +359,19 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
   }
 
   #configureMenu() {
-    this.menu.width = '100%';
-    this.menu.popup.align = 'bottom, left';
-    this.menu.popup.y = -10;
     this.menu.target = this;
     this.menu.triggerType = 'click';
+
+    if (this.colorVariant !== 'module') {
+      this.menu.popup.arrow = 'bottom';
+      this.menu.popup.arrowTarget = this.dropdownIcon || this;
+      this.menu.popup.align = 'bottom, right';
+      this.menu.popup.y = 4;
+    } else {
+      this.menu.popup.align = 'bottom, left';
+      this.menu.width = '100%';
+      this.menu.popup.y = -10;
+    }
   }
 
   #attachMoreMenuEvents(): void {

--- a/src/components/ids-tabs/ids-tab-more.ts
+++ b/src/components/ids-tabs/ids-tab-more.ts
@@ -151,7 +151,7 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
       overflowed = this.isOverflowed(item) ? '' : ' hidden';
     }
 
-    const iconTemplate = (iconDef: string) => `<ids-icon slot="icon" icon="${iconDef}"></ids-icon>`;
+    const iconTemplate = (iconDef: string) => `<ids-icon slot="icon" icon="${iconDef}" size="xsmall"></ids-icon>`;
 
     // Handles regular tabs
     const handleTab = (thisItem: any) => {

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -21,12 +21,12 @@ $ids-tab-vertical-height: 42px;
 // without shadowDOM scope so need .selection-underline div
 // as workaround
 @mixin ids-tabs-selected-underline() {
-  border-bottom: 2px solid;
+  border-bottom: 1px solid transparent;
 
   &::after,
   & .selection-underline {
     position: absolute;
-    bottom: 0;
+    bottom: -1px;
     height: 1px;
     left: -1px;
     width: calc(100% + 2px);
@@ -113,7 +113,8 @@ $ids-tab-vertical-height: 42px;
       font-weight: 700;
     }
 
-    &::after {
+    &::after,
+    & .selection-underline {
       background-color: var(--ids-tab-color-text-selected);
     }
   }
@@ -159,10 +160,6 @@ $ids-tab-vertical-height: 42px;
       &.selected,
       &:hover {
         @include ids-tabs-selected-underline();
-
-        &::after {
-          background-color: var(--ids-tab-color-text-selected);
-        }
       }
 
       // Hide the underline on disabled
@@ -245,13 +242,13 @@ $ids-tab-vertical-height: 42px;
 
       border-style: none;
 
-      &::before {
-        border-color: var(--ids-tab-vertical-color-border-selected);
+      &::after,
+      & .selection-underline {
+        background-color: var(--ids-tab-vertical-color-border-selected);
       }
     }
   }
 }
-
 
 // =================================================
 // Module Color Variant
@@ -372,6 +369,11 @@ $ids-tab-vertical-height: 42px;
 
     &.selected {
       color: var(--ids-tab-alternate-color-text-disabled);
+
+      &::after,
+      & .selection-underline {
+        background-color: var(--ids-tab-alternate-color-text-disabled);
+      }
     }
   }
 
@@ -390,6 +392,15 @@ $ids-tab-vertical-height: 42px;
 .ids-tab.color-variant-header {
   &:hover {
     background-color: var(--ids-tab-header-color-background-hover);
+  }
+
+  &.selected {
+    color: var(--ids-tab-header-color-text-selected);
+
+    &::after,
+    & .selection-underline {
+      background-color: var(--ids-tab-header-color-text-selected);
+    }
   }
 }
 

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -3,16 +3,20 @@ $ids-tab-min-width: 135px;
 $ids-tab-actionable-min-width: 44px;
 $ids-tab-vertical-height: 42px;
 
-@mixin ids-tabs-focus-border() {
-  &::before {
-    border: 1px solid;
-    position: absolute;
-    top: 1px;
-    left: 1px;
-    width: calc(100% - 4px);
-    height: calc(100% - 4px);
-    content: '';
-    pointer-events: none;
+@mixin ids-tabs-focus-border($inset-x-distance: 4, $inset-y-distance: 4, $offset-x-distance: -1, $offset-y-distance: 0) {
+  outline: none;
+
+  &:not(.hide-focus) {
+    &::before {
+      border: 1px solid;
+      position: absolute;
+      inset-block-start: #{$offset-x-distance}px;
+      inset-inline-start: #{$offset-y-distance}px;
+      width: calc(100% - #{$inset-x-distance}px);
+      height: calc(100% - #{$inset-y-distance}px);
+      content: '';
+      pointer-events: none;
+    }
   }
 }
 
@@ -26,13 +30,28 @@ $ids-tab-vertical-height: 42px;
   &::after,
   & .selection-underline {
     position: absolute;
-    bottom: -1px;
     height: 1px;
-    left: -1px;
-    width: calc(100% + 2px);
+    inset-block-end: -1px;
+    inset-inline: 0;
     z-index: 1;
     pointer-events: none;
     content: '';
+  }
+}
+
+@mixin display-data-text-as-bold() {
+  &::after {
+    content: attr(data-text);
+    content: attr(data-text) / '';
+    font-weight: 700;
+    visibility: hidden;
+    height: 0;
+    user-select: none;
+    pointer-events: none;
+
+    @media speech {
+      display: none;
+    }
   }
 }
 
@@ -77,7 +96,6 @@ $ids-tab-vertical-height: 42px;
   display: flex;
   position: relative;
   color: var(--ids-tab-color-text-default);
-  border: 1px solid transparent;
   box-sizing: border-box;
   height: 100%;
   padding-inline: 4px;
@@ -134,12 +152,8 @@ $ids-tab-vertical-height: 42px;
     }
   }
 
-  // Focus state
-  &:focus-visible:not(.hide-focus) {
-    border-color: var(--ids-tab-color-border-focus);
-    border-style: solid;
+  &:focus-visible {
     outline: none;
-    box-shadow: var(--ids-tab-shadow-focus);
   }
 
   // Trigger Button Slot
@@ -154,12 +168,17 @@ $ids-tab-vertical-height: 42px;
       padding-top: 8px;
     }
 
-    // Round borders on regular horizontal tabs
+    // In-page and Header Tabs only
     &:not(.color-variant-module) {
-      // Show the underline on hover
+      border-bottom: 1px solid transparent;
+
+      &:focus-visible {
+        @include ids-tabs-focus-border(0, 2, 0, -1);
+      }
+
       &.selected,
       &:hover {
-        @include ids-tabs-selected-underline();
+        @include ids-tabs-selected-underline;
       }
 
       // Hide the underline on disabled
@@ -182,18 +201,10 @@ $ids-tab-vertical-height: 42px;
     justify-content: space-between;
   }
 
-  & ids-text::part(text)::after,
-  &.ids-tab.ids-text::after {
-    font-weight: 700;
-    content: attr(data-text);
-    content: attr(data-text) / '';
-    visibility: hidden;
-    height: 0;
-    user-select: none;
-    pointer-events: none;
-
-    @media speech {
-      display: none;
+  &:not(.orientation-vertical) {
+    ids-text::part(text),
+    .ids-tab.ids-text {
+      @include display-data-text-as-bold;
     }
   }
 
@@ -231,17 +242,17 @@ $ids-tab-vertical-height: 42px;
     color: var(--ids-tab-vertical-color-text-disabled);
   }
 
+  &:focus-visible {
+    @include ids-tabs-focus-border(4, 4, 1, 1);
+  }
+
   // vertical selected state
   &.selected {
     border-style: none;
     background-color: var(--ids-tab-vertical-color-background-selected);
     color: var(--ids-tab-vertical-color-text-selected);
 
-    &:not(.hide-focus):focus {
-      @include ids-tabs-focus-border();
-
-      border-style: none;
-
+    &:focus-visible:not(.hide-focus) {
       &::after,
       & .selection-underline {
         background-color: var(--ids-tab-vertical-color-border-selected);
@@ -286,8 +297,7 @@ $ids-tab-vertical-height: 42px;
 
   // Module - Focus state
   &:focus-visible {
-    border-color: var(--ids-tab-color-border-focus);
-    box-shadow: var(--ids-tab-shadow-focus);
+    @include ids-tabs-focus-border(4, 4, 1, 1);
   }
 
   // Module - Disabled state

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -433,3 +433,8 @@ ids-popup-menu,
   margin-inline-end: var(--ids-tab-dismiss-button-offset);
   place-self: center;
 }
+
+::slotted(.ids-tab-more-menu-item-text) {
+  display: inline-block;
+  margin-inline-start: 4px;
+}

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -417,9 +417,11 @@ ids-popup-menu,
 }
 
 // "More Tabs" tab flex rules
-::slotted(ids-icon) {
-  color: currentColor;
-  pointer-events: none;
+.ids-tab:not(.more) {
+  ::slotted(ids-icon) {
+    color: currentColor;
+    pointer-events: none;
+  }
 }
 
 ::slotted(ids-trigger-button) {

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -423,7 +423,11 @@ ids-popup-menu,
 }
 
 ::slotted(ids-trigger-button) {
+  align-items: center;
   color: currentColor;
-  height: fit-content;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  margin-inline-end: var(--ids-tab-dismiss-button-offset);
   place-self: center;
 }

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -400,8 +400,11 @@ $ids-tab-vertical-height: 42px;
 // Header Color Variant
 // =================================================
 .ids-tab.color-variant-header {
+  color: var(--ids-tab-header-color-text-default);
+
   &:hover {
     background-color: var(--ids-tab-header-color-background-hover);
+    color: var(--ids-tab-header-color-text-hover);
   }
 
   &.selected {
@@ -410,6 +413,19 @@ $ids-tab-vertical-height: 42px;
     &::after,
     & .selection-underline {
       background-color: var(--ids-tab-header-color-text-selected);
+    }
+  }
+
+  &.disabled {
+    color: var(--ids-tab-header-color-text-disabled);
+  }
+
+  // Alternate - Focus state
+  &:not(.hide-focus) {
+    &:focus-visible,
+    &:focus,
+    &:focus-within {
+      border-color: var(--ids-tab-header-color-border-focus);
     }
   }
 }

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -123,7 +123,7 @@ export default class IdsTab extends Base {
     const inheritColor = this.colorVariant === 'module' ? '' : 'inherit-color';
 
     return `<ids-trigger-button slot="close" label="Close" ${colorVariant} ${inheritColor}>
-      <ids-icon icon="close" size="xsmall"></ids-icon>
+      <ids-icon icon="close" size="small"></ids-icon>
     </ids-trigger-button>`;
   }
 

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -86,7 +86,7 @@ export default class IdsTab extends Base {
     const cssClassAttr = buildClassAttrib(
       'ids-tab',
       this.selected,
-      this.orientation,
+      `orientation-${this.orientation}`,
       this.count
     );
     const selectedAttr = this.selected ? ' font-weight="semi-bold"' : '';
@@ -123,7 +123,7 @@ export default class IdsTab extends Base {
     const inheritColor = this.colorVariant === 'module' ? '' : 'inherit-color';
 
     return `<ids-trigger-button slot="close" label="Close" ${colorVariant} ${inheritColor}>
-      <ids-icon icon="close" size="small"></ids-icon>
+      <ids-icon icon="close" size="xsmall"></ids-icon>
     </ids-trigger-button>`;
   }
 

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -254,7 +254,7 @@ export default class IdsTab extends Base {
         this.container?.setAttribute(htmlAttributes.TABINDEX, '-1');
       } else {
         this.setAttribute(attributes.SELECTED, '');
-        this.container?.children?.[0]?.setAttribute?.(attributes.FONT_WEIGHT, 'bold');
+        this.container?.children?.[0]?.setAttribute?.(attributes.FONT_WEIGHT, 'semi-bold');
         this.container?.classList.add(attributes.SELECTED);
         this.setAttribute(htmlAttributes.TABINDEX, '0');
         this.container?.setAttribute(htmlAttributes.TABINDEX, '0');

--- a/src/components/ids-tabs/ids-tabs-context.scss
+++ b/src/components/ids-tabs/ids-tabs-context.scss
@@ -1,0 +1,16 @@
+
+:host([auto-fit]) {
+  height: 100%;
+}
+
+:host([auto-fit]) ::slotted(.ids-tabs-content) {
+  height: 100%;
+}
+
+.orientation-vertical {
+  display: flex;
+}
+
+.auto-fit {
+  height: 100%;
+}

--- a/src/components/ids-tabs/ids-tabs-context.ts
+++ b/src/components/ids-tabs/ids-tabs-context.ts
@@ -1,13 +1,24 @@
 import { customElement, scss } from '../../core/ids-decorators';
 import { attributes } from '../../core/ids-attributes';
+import { setBooleanAttr } from '../../utils/ids-attribute-utils/ids-attribute-utils';
 
 import IdsEventsMixin from '../../mixins/ids-events-mixin/ids-events-mixin';
+import IdsOrientationMixin from '../../mixins/ids-orientation-mixin/ids-orientation-mixin';
 import IdsElement from '../../core/ids-element';
 
 import './ids-tab-content';
 
-import styles from './ids-tabs.scss';
+import styles from './ids-tabs-context.scss';
+
 import type IdsTabContent from './ids-tab-content';
+import type IdsTabs from './ids-tabs';
+import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
+
+const Base = IdsOrientationMixin(
+  IdsEventsMixin(
+    IdsElement
+  )
+);
 
 /**
  * IDS Tabs Context Component
@@ -18,7 +29,7 @@ import type IdsTabContent from './ids-tab-content';
  */
 @customElement('ids-tabs-context')
 @scss(styles)
-export default class IdsTabsContext extends IdsEventsMixin(IdsElement) {
+export default class IdsTabsContext extends Base {
   constructor() {
     super();
   }
@@ -51,12 +62,33 @@ export default class IdsTabsContext extends IdsEventsMixin(IdsElement) {
   static get attributes() {
     return [
       ...super.attributes,
+      attributes.AUTO_FIT,
       attributes.VALUE
     ];
   }
 
   template() {
     return '<slot></slot>';
+  }
+
+  /**
+   * @readonly
+   * @returns {IdsTabs} reference to the internal IdsTabs list
+   */
+  get tabList() {
+    return this.querySelector<IdsTabs>('ids-tabs');
+  }
+
+  /**
+   * Set the tabs context element to auto fit to its parent container's size
+   * @param {boolean|string|null} value The auto fit
+   */
+  set autoFit(value) {
+    setBooleanAttr(attributes.AUTO_FIT, this, stringToBool(value));
+  }
+
+  get autoFit(): boolean | string | null {
+    return this.hasAttribute(attributes.AUTO_FIT);
   }
 
   /** @param {string} value The value representing a currently selected tab */
@@ -83,5 +115,12 @@ export default class IdsTabsContext extends IdsEventsMixin(IdsElement) {
     const targetPane = contentPanes.find((el) => el.value === newValue);
     if (currentPane) currentPane.active = false;
     if (targetPane) targetPane.active = true;
+  }
+
+  /**
+   * Inherited from IdsOrientationMixin
+   */
+  onOrientationRefresh(): void {
+    if (this.orientation) this.tabList?.setAttribute(attributes.ORIENTATION, this.orientation);
   }
 }

--- a/src/components/ids-tabs/ids-tabs.scss
+++ b/src/components/ids-tabs/ids-tabs.scss
@@ -1,19 +1,24 @@
-// :host(ids-tabs),
 .ids-tabs-container {
   --tab-width: 100%;
+  --vertical-container-width: 250px;
 
   display: flex;
 
   // Horizontal Tabs
   &:not(.orientation-vertical) {
     .ids-tabs-list {
-      width: 100%;
+      width: var(--tab-width);
     }
   }
 
   // Vertical Tabs
   &.orientation-vertical {
-    .ids-tabs-list {
+    flex-direction: column;
+    height: 100%;
+    width: var(--vertical-container-width);
+
+    .ids-tabs-list,
+    .ids-tabs-list-more {
       flex-direction: column;
     }
   }
@@ -45,7 +50,7 @@
 }
 
 .ids-tabs-container:not(.orientation-vertical):not([class*='color-variant-']) {
-  border-bottom: 1px solid var(--ids-tab-color-border-bottom);
+  border-bottom: 1px solid var(--ids-tab-divider-color-background);
 }
 
 // Module Tabs
@@ -55,7 +60,14 @@
 
   &.has-more-actions {
     .ids-tabs-list-more {
-      border-left: 1px solid var(--ids-tab-module-color-border-right);
+      border-inline-start: 1px solid var(--ids-tab-module-color-border-right);
     }
   }
+}
+
+// Vertical Tabs
+
+.ids-tabs-container.orientation-vertical {
+  background-color: var(--ids-tab-vertical-color-background-default);
+  border-inline-end: 1px solid var(--ids-tab-vertical-color-border-default);
 }

--- a/src/components/ids-tabs/ids-tabs.ts
+++ b/src/components/ids-tabs/ids-tabs.ts
@@ -286,7 +286,7 @@ export default class IdsTabs extends Base {
             this.#selectTab(elem);
           }
         }
-        if (elem.tagName === 'IDS-TRIGGER-BUTTON') {
+        if (elem.tagName === 'IDS-TRIGGER-BUTTON' || getClosest(elem, 'ids-trigger-button')) {
           e.stopPropagation();
           const tab = getClosest(elem, 'ids-tab');
           this.#dismissTab(tab);

--- a/src/mixins/ids-orientation-mixin/ids-orientation-mixin.ts
+++ b/src/mixins/ids-orientation-mixin/ids-orientation-mixin.ts
@@ -13,6 +13,8 @@ type Constraints = IdsConstructor<OrientationHandler>;
  * @returns {any} The extended object
  */
 const IdsOrientationMixin = <T extends Constraints>(superclass: T) => class extends superclass {
+  #orientation: string | null = 'horizontal';
+
   constructor(...args: any[]) {
     super(...args);
 
@@ -20,14 +22,13 @@ const IdsOrientationMixin = <T extends Constraints>(superclass: T) => class exte
     // to color variant styling after it runs, keeping the visual state in-sync.
     this.render = () => {
       super.render();
-      this.#refreshOrientation();
+      this.#refreshOrientation('horizontal', this.orientation);
       return this;
     };
   }
 
   connectedCallback() {
     super.connectedCallback?.();
-    this.#refreshOrientation('horizontal', this.orientation);
   }
 
   static get attributes() {
@@ -43,10 +44,10 @@ const IdsOrientationMixin = <T extends Constraints>(superclass: T) => class exte
   orientations = ['horizontal', 'vertical'];
 
   /**
-   * @returns {string} the name of the orientation currently applied
+   * @returns {string | null} the name of the orientation currently applied
    */
-  get orientation(): string {
-    return this.getAttribute(attributes.ORIENTATION) ?? 'horizontal';
+  get orientation(): string | null {
+    return this.#orientation;
   }
 
   /**
@@ -55,7 +56,7 @@ const IdsOrientationMixin = <T extends Constraints>(superclass: T) => class exte
   set orientation(val: string | null) {
     val ??= 'horizontal';
     const safeValue = String(stripTags(val, ''));
-    const currentValue = this.orientation;
+    const currentValue = this.#orientation;
 
     if (currentValue !== safeValue) {
       if (this.orientations.includes(safeValue)) {
@@ -64,6 +65,7 @@ const IdsOrientationMixin = <T extends Constraints>(superclass: T) => class exte
         this.removeAttribute(attributes.ORIENTATION);
       }
 
+      this.#orientation = safeValue;
       this.#refreshOrientation(currentValue, safeValue);
     }
   }
@@ -71,11 +73,11 @@ const IdsOrientationMixin = <T extends Constraints>(superclass: T) => class exte
   /**
    * Refreshes the component's orientation state, driven by
    * a CSS class on the WebComponent's `container` element
-   * @param {string} oldVariantName the orientation variant name to "remove" from the style
-   * @param {string} newVariantName the orientation variant name to "add" to the style
+   * @param {string | null} oldVariantName the orientation variant name to "remove" from the style
+   * @param {string | null} newVariantName the orientation variant name to "add" to the style
    * @returns {void}
    */
-  #refreshOrientation(oldVariantName?: string, newVariantName?: string) {
+  #refreshOrientation(oldVariantName: string | null, newVariantName: string | null) {
     if (!this.container) return;
     const cl = this.container.classList;
 

--- a/src/themes/default/ids-theme-default-contrast.scss
+++ b/src/themes/default/ids-theme-default-contrast.scss
@@ -475,8 +475,9 @@
   --ids-tab-color-text-selected: var(--ids-color-primary-80);
 
   // Tab (Module Variant)
-  --ids-tab-module-color-background-default: var(--ids-color-neutral-20);
-  --ids-tab-module-color-background-selected: var(--ids-color-neutral-00);
+  --ids-tab-module-color-background-default: var(--ids-color-slate-10);
+  --ids-tab-module-color-background-selected: var(--ids-color-slate-00);
+  --ids-tab-module-color-background-hover: var(--ids-color-slate-20);
 
   // Tag
   --ids-tag-color-background-default: var(--ids-input-color-background-readonly);

--- a/src/themes/default/ids-theme-default-contrast.scss
+++ b/src/themes/default/ids-theme-default-contrast.scss
@@ -470,9 +470,9 @@
   // Tab
   --ids-tab-divider-color-background: var(--ids-color-neutral-40);
   --ids-tab-color-background-hover: var(--ids-color-primary-10);
-  --ids-tab-color-text-hover: var(--ids-color-primary-50);
+  --ids-tab-color-text-hover: var(--ids-color-slate-60);
   --ids-tab-color-border-focus: var(--ids-color-primary-80);
-  --ids-tab-color-text-selected: var(--ids-color-primary-80);
+  --ids-tab-color-text-selected: var(--ids-color-slate-100);
 
   // Tab (Module Variant)
   --ids-tab-module-color-background-default: var(--ids-color-slate-10);

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -1350,6 +1350,8 @@
   --ids-tab-color-border-bottom: var(--ids-color-neutral-60);
   --ids-tab-color-text-disabled: var(--ids-color-neutral-40);
   --ids-tab-color-text-selected: var(--ids-color-primary-60);
+  --ids-tab-dismiss-button-size: 24px;
+  --ids-tab-dismiss-button-offset: 4px;
 
   // Tab (Header Variant)
   --ids-tab-header-color-background-hover: var(--ids-color-neutral-20);
@@ -1375,13 +1377,13 @@
   --ids-tab-alternate-horizontal-color-background: var(--ids-color-neutral-00);
 
   // Tab (Module Variant)
-  --ids-tab-module-color-background-default: var(--ids-color-neutral-20);
-  --ids-tab-module-color-border-right: var(--ids-color-neutral-50);
+  --ids-tab-module-color-background-default: var(--ids-color-slate-10);
+  --ids-tab-module-color-border-right: var(--ids-color-slate-30);
   --ids-tab-module-color-text-default: var(--ids-color-text-default);
-  --ids-tab-module-color-background-hover: var(--ids-color-neutral-30);
+  --ids-tab-module-color-background-hover: var(--ids-color-slate-20);
   --ids-tab-module-color-text-hover: var(--ids-color-neutral-80);
   --ids-tab-module-color-background-selected: var(--ids-color-neutral-00);
-  --ids-tab-module-color-text-selected: var(--ids-color-neutral-100);
+  --ids-tab-module-color-text-selected: var(--ids-color-slate-100);
   --ids-tab-module-color-background-disabled: var(--ids-color-neutral-20);
   --ids-tab-module-color-text-disabled: var(--ids-color-neutral-50);
 

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -1354,8 +1354,12 @@
   --ids-tab-dismiss-button-offset: 4px;
 
   // Tab (Header Variant)
+  --ids-tab-header-color-text-default: var(--ids-color-slate-60);
+  --ids-tab-header-color-text-disabled: var(--ids-color-neutral-40);
+  --ids-tab-header-color-text-hover: var(--ids-color-slate-100);
   --ids-tab-header-color-text-selected: var(--ids-color-slate-100);
   --ids-tab-header-color-background-hover: var(--ids-color-neutral-20);
+  --ids-tab-header-color-border-focus: var(--ids-color-slate-100);
 
   // Tab (Vertical Orientation)
   --ids-tab-vertical-color-background-default: var(--ids-color-slate-10);

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -1358,7 +1358,8 @@
   --ids-tab-header-color-background-hover: var(--ids-color-neutral-20);
 
   // Tab (Vertical Orientation)
-  --ids-tab-vertical-color-background-default: var(--ids-color-neutral-20);
+  --ids-tab-vertical-color-background-default: var(--ids-color-slate-10);
+  --ids-tab-vertical-color-border-default: var(--ids-color-slate-30);
   --ids-tab-vertical-color-text-default: var(--ids-color-text-default);
   --ids-tab-vertical-color-background-hover: var(--ids-color-neutral-30);
   --ids-tab-vertical-color-text-hover: var(--ids-color-neutral-80);

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -1341,10 +1341,10 @@
 
   // Tab
   --ids-tab-content-color-text: var(--ids-color-text);
-  --ids-tab-color-text-default: var(--ids-color-text-default);
+  --ids-tab-color-text-default: var(--ids-color-slate-60);
   --ids-tab-divider-color-background: var(--ids-color-neutral-30);
   --ids-tab-color-background-hover: var(--ids-color-primary-10);
-  --ids-tab-color-text-hover: var(--ids-color-primary-60);
+  --ids-tab-color-text-hover: var(--ids-color-slate-100);
   --ids-tab-color-border-focus: var(--ids-color-primary-60);
   --ids-tab-shadow-focus: var(--ids-shadow-30);
   --ids-tab-color-border-bottom: var(--ids-color-neutral-60);
@@ -1354,6 +1354,7 @@
   --ids-tab-dismiss-button-offset: 4px;
 
   // Tab (Header Variant)
+  --ids-tab-header-color-text-selected: var(--ids-color-slate-100);
   --ids-tab-header-color-background-hover: var(--ids-color-neutral-20);
 
   // Tab (Vertical Orientation)

--- a/src/themes/default/ids-theme-default-dark.scss
+++ b/src/themes/default/ids-theme-default-dark.scss
@@ -593,7 +593,12 @@
   --ids-tab-color-border-bottom: var(--ids-color-neutral-70);
 
   // Tab (Header Variant)
+  --ids-tab-header-color-text-default: var(--ids-color-slate-30);
+  --ids-tab-header-color-text-disabled: var(--ids-color-neutral-60);
+  --ids-tab-header-color-text-hover: var(--ids-color-neutral-00);
+  --ids-tab-header-color-text-selected: var(--ids-color-neutral-00);
   --ids-tab-header-color-background-hover: var(--ids-color-neutral-90);
+  --ids-tab-header-color-border-focus: var(--ids-color-neutral-00);
 
   // Tab (Vertical Variant)
   --ids-tab-vertical-color-background-default: var(--ids-color-neutral-70);
@@ -604,6 +609,7 @@
   --ids-tab-vertical-color-text-hover: var(--ids-color-neutral-00);
   --ids-tab-vertical-color-background-disabled: var(--ids-color-neutral-60);
   --ids-tab-vertical-color-text-disabled: var(--ids-color-neutral-50);
+  --ids-tab-vertical-color-border-default: var(--ids-color-slate-60);
 
   // Tab (Module Variant)
   --ids-tab-module-color-background-default: var(--ids-color-slate-80);

--- a/src/themes/default/ids-theme-default-dark.scss
+++ b/src/themes/default/ids-theme-default-dark.scss
@@ -297,8 +297,8 @@
   --ids-empty-message-color-icon-fill: transparent;
 
   // Headers
-  --ids-header-color-border-bottom: var(--ids-color-neutral-80);
-  --ids-header-color-background: var(--ids-color-neutral-90);
+  --ids-header-color-border-bottom: var(--ids-color-slate-100);
+  --ids-header-color-background: var(--ids-color-slate-70);
   --ids-header-gradient-opacity-none: rgb(0 114 237 / 1);
   --ids-header-gradient-opacity-full: rgb(0 114 237 / 0);
 
@@ -606,15 +606,15 @@
   --ids-tab-vertical-color-text-disabled: var(--ids-color-neutral-50);
 
   // Tab (Module Variant)
-  --ids-tab-module-color-background-default: var(--ids-color-neutral-60);
-  --ids-tab-module-color-border-right: var(--ids-color-neutral-80);
-  --ids-tab-module-color-text-default: var(--ids-color-neutral-10);
-  --ids-tab-module-color-background-hover: var(--ids-color-neutral-90);
+  --ids-tab-module-color-background-default: var(--ids-color-slate-80);
+  --ids-tab-module-color-border-right: var(--ids-color-slate-100);
+  --ids-tab-module-color-text-default: var(--ids-color-neutral-00);
+  --ids-tab-module-color-background-hover: var(--ids-color-slate-90);
   --ids-tab-module-color-text-hover: var(--ids-color-neutral-00);
-  --ids-tab-module-color-background-selected: var(--ids-color-neutral-70);
+  --ids-tab-module-color-background-selected: var(--ids-color-slate-70);
   --ids-tab-module-color-text-selected: var(--ids-color-neutral-00);
-  --ids-tab-module-color-background-disabled: var(--ids-color-neutral-60);
-  --ids-tab-module-color-text-disabled: var(--ids-color-neutral-40);
+  --ids-tab-module-color-background-disabled: var(--ids-color-slate-90);
+  --ids-tab-module-color-text-disabled: var(--ids-color-slate-40);
 
   // Tag
   --ids-tag-color-background-default: var(--ids-input-color-background-readonly);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR syncs Header/Vertical/Module tabs styles with changes that were made to accommodate the Alabaster color scheme in the Enterprise components, making them the default in the Web Components.

In addition, some features were added and some bugs fixed in related components:
- Fixed a bug where it was no longer possible to dismiss tabs (specifically in Module Tabs).
- Added an "Add Tab" and "Reset" button to the header tabs example.
- Added "auto-fit" setting to `IdsTabsContext` in order to allow Vertical Tabs components to stretch the full height of their parent containers.
- Added "orientation" setting to `IdsTabsContext` component for easier configuration of Vertical Tabs.

**Related github/jira issue (required)**:
Closes #1050

**Steps necessary to review your pull request (required)**:
Pull/build/run, then test the following using the [latest Figma design changes as a reference](https://www.figma.com/file/gRpli2TgQ3scLE6GF4e2Hz/Alabaster-Clean-up?type=design&node-id=127-38899&mode=design&t=Y4Ezgh4EqqHuedJg-0):

_Alabaster Design Sync:_
Make sure the following sample pages match the provided designs.  Test all theme modes (light/dark/contrast):
- http://localhost:4300/ids-tabs/example.html
- http://localhost:4300/ids-tabs/vertical.html
- http://localhost:4300/ids-tabs/header-tabs.html
- http://localhost:4300/ids-tabs/module.html
- http://localhost:4300/ids-header/example.html

_Dismissible Tabs bug:_
- Open http://localhost:4300/ids-tabs/module.html
- Use the Add Tab "+" button to add enough tabs that the "More Tabs" menu appears
- Try dismissing tabs from both the tabs themselves, and the popup menu, using the "x" button.  Both should cause their tabs and panels to be dismissed.

_Auto fit/Orientation:_
- Open http://localhost:4300/ids-tabs/vertical.html
- See that the Vertical Tabs and the content panels should stretch their entire page height.
- Additionally the whole thing should be "vertical" (the setting is now being passed down from IdsTabsContext)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
