### PR TITLE
1411 - multiselect fix rerender logic to fix ngFor directive in Angular

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))
 - `[Inputs]` Fixed removing `readonly` and `disabled` not working after form additions. ([#1570](https://github.com/infor-design/enterprise-wc/issues/1570))
 - `[Modal]` Add `showCloseButton` setting to modal. ([#1527](https://github.com/infor-design/enterprise-wc/issues/1527))
+- `[Multiselect]` Fix rerender logic so that state is maintained while using ngFor directive in Angular. ([#1411](https://github.com/infor-design/enterprise-wc/issues/1411))
 
 ## 1.0.0-beta.16
 

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -328,26 +328,27 @@ export default class IdsDataGridFilters {
     this.#suppressFilteredEvent = true;
     this.resetFilters();
     const toBeRemoved: any = [];
-    conditions.forEach((c, i) => {
-      const el = this.filterWrapperById(c.columnId);
-      if (!el || hasClass(el, 'disabled') || hasClass(el, 'readonly')) return;
+    conditions.forEach((condition, i) => {
+      const headerFilterWrapper = this.filterWrapperById(condition.columnId);
+      if (!headerFilterWrapper || hasClass(headerFilterWrapper, 'disabled') || hasClass(headerFilterWrapper, 'readonly')) return;
 
-      const slot = el.querySelector('slot[name^="filter-"]');
-      const node = slot ? slot.assignedElements()[0] : el;
-      if (node) {
-        const input = node.querySelector('ids-input');
-        const btn = node.querySelector('ids-menu-button');
-        const dropdown = node.querySelector('ids-dropdown');
-        const triggerField = node.querySelector('ids-trigger-field');
-        const timePicker = node.querySelector('ids-time-picker');
-        const headerElem = node.closest('.ids-data-grid-header-cell');
-        const columnData = this.root.columnDataByHeaderElem(headerElem);
+      const headerSlot = headerFilterWrapper.querySelector('slot[name^="filter-"]');
+      const headerRoot = headerSlot ? headerSlot.assignedElements()[0] : headerFilterWrapper;
+      if (headerRoot) {
+        const input = headerRoot.querySelector('ids-input');
+        const button = headerRoot.querySelector('ids-menu-button');
+        const dropdown = headerRoot.querySelector('ids-dropdown');
+        const triggerField = headerRoot.querySelector('ids-trigger-field');
+        const timePicker = headerRoot.querySelector('ids-time-picker');
+        const headerCell = headerRoot.closest('.ids-data-grid-header-cell');
+        const columnData = this.root.columnDataByHeaderElem(headerCell);
 
-        if (input) input.value = c.value || '';
-        if (triggerField) triggerField.value = c.value || '';
-        if (timePicker) timePicker.value = c.value || '';
+        const conditionValue = condition.value || '';
+        if (input) input.value = conditionValue;
+        if (triggerField) triggerField.value = conditionValue;
+        if (timePicker) timePicker.value = conditionValue;
         if (dropdown) {
-          dropdown.value = c.value || '';
+          dropdown.value = conditionValue;
           if (dropdown.value === this.#dropdownNotFilterItem(columnData).value) toBeRemoved.push(i);
         }
         if (timePicker && !columnData.formatOptions?.dateFormat && !columnData.formatOptions?.timeStyle) {
@@ -355,16 +356,16 @@ export default class IdsDataGridFilters {
           columnData.formatOptions.dateFormat = timePicker.format;
           columnData.formatOptions.timeStyle = 'short';
         }
-        if (btn) {
-          let item = btn.menuEl.items.filter((itm: any) => itm.value === c.operator)[0];
-          if (!item) item = btn.menuEl.items[0];
-          if (item) btn.menuEl.selectItem(item);
+        if (button) {
+          let item = button.menuEl.items.filter((itm: any) => itm.value === condition.operator)[0];
+          if (!item) item = button.menuEl.items[0];
+          if (item) button.menuEl.selectItem(item);
         }
-        if (!c.filterElem) c.filterElem = timePicker || triggerField || dropdown || input;
-        this.#setDatePicker(triggerField, c.operator);
+        if (!condition.filterElem) condition.filterElem = timePicker || triggerField || dropdown || input;
+        this.#setDatePicker(triggerField, condition.operator);
       }
     });
-    if (toBeRemoved.length) conditions = conditions.filter((c, i) => !toBeRemoved.includes(i));
+    if (toBeRemoved.length) conditions = conditions.filter((condition, idx) => !toBeRemoved.includes(idx));
     this.#suppressFilteredEvent = false;
     return conditions;
   }

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -386,8 +386,7 @@ export default class IdsDropdown extends Base {
    * @returns {Array<IdsListBoxOption>} the array of options
    */
   get options() {
-    if (!this.dropdownList || !this.dropdownList.listBox) return [];
-    return [...this.dropdownList.listBox.querySelectorAll<IdsListBoxOption>('ids-list-box-option')];
+    return [...this.dropdownList?.listBox?.querySelectorAll<IdsListBoxOption>('ids-list-box-option') ?? []];
   }
 
   /**

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -310,19 +310,22 @@ export default class IdsDropdown extends Base {
     }
 
     let selector = `ids-list-box-option[value="${value}"]`;
-    if (value === ' ' || !value) selector = `ids-list-box-option:not([value])`;
-    const elem = this.dropdownList?.listBox?.querySelector<IdsListBoxOption>(selector);
-    if (!elem) return;
+    if (value === ' ' || !value) {
+      selector = `ids-list-box-option[value=""], ids-list-box-option:not([value])`;
+    }
+
+    const listBoxOption = [...this.dropdownList?.listBox?.querySelectorAll<IdsListBoxOption>(selector) ?? []].at(0);
+    if (!listBoxOption) return;
 
     // NOTE: setAttribute() must be called here, before the internal input.value is set below
     this.setAttribute(attributes.VALUE, String(value));
 
     this.clearSelected();
-    this.selectOption(elem);
-    this.selectIcon(elem);
-    this.selectTooltip(elem);
-    if (this.input) this.input.value = elem.textContent?.trim();
-    this.state.selectedIndex = [...((elem?.parentElement as any)?.children || [])].indexOf(elem);
+    this.selectOption(listBoxOption);
+    this.selectIcon(listBoxOption);
+    this.selectTooltip(listBoxOption);
+    if (this.input) this.input.value = listBoxOption.textContent?.trim();
+    this.state.selectedIndex = [...((listBoxOption?.parentElement as any)?.children || [])].indexOf(listBoxOption);
   }
 
   /**

--- a/src/components/ids-list-box/ids-list-box-option.ts
+++ b/src/components/ids-list-box/ids-list-box-option.ts
@@ -105,9 +105,11 @@ export default class IdsListBoxOption extends Base {
     if (stringToBool(val)) {
       this.setAttribute(attributes.SELECTED, 'true');
       this.container?.classList.add('is-selected');
+      this.childCheckbox?.setAttribute('checked', 'true');
     } else {
       this.removeAttribute(attributes.SELECTED);
       this.container?.classList.remove('is-selected');
+      this.childCheckbox?.removeAttribute('checked');
     }
   }
 

--- a/src/components/ids-list-box/ids-list-box-option.ts
+++ b/src/components/ids-list-box/ids-list-box-option.ts
@@ -5,6 +5,13 @@ import IdsTooltipMixin from '../../mixins/ids-tooltip-mixin/ids-tooltip-mixin';
 import IdsElement from '../../core/ids-element';
 
 import styles from './ids-list-box-option.scss';
+import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
+
+import '../ids-checkbox/ids-checkbox';
+import '../ids-icon/ids-icon';
+
+import type IdsCheckbox from '../ids-checkbox/ids-checkbox';
+import type IdsIcon from '../ids-icon/ids-icon';
 
 const Base = IdsTooltipMixin(
   IdsEventsMixin(
@@ -35,6 +42,8 @@ export default class IdsListBoxOption extends Base {
     return [
       ...super.attributes,
       attributes.GROUP_LABEL,
+      attributes.ROW_INDEX,
+      attributes.SELECTED,
       attributes.TOOLTIP,
       attributes.VALUE
     ];
@@ -42,24 +51,85 @@ export default class IdsListBoxOption extends Base {
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute('role', this.hasAttribute(attributes.GROUP_LABEL) ? 'none' : 'option');
+    this.setAttribute('role', this.groupLabel ? 'none' : 'option');
     this.setAttribute('tabindex', '-1');
+    this.#hideEmptyGroupOption();
+  }
+
+  #hideEmptyGroupOption() {
+    const nextOption = this.nextElementSibling as IdsListBoxOption;
+    this.hidden = this.groupLabel && (!nextOption || nextOption.groupLabel);
   }
 
   /**
-   * Create the Template for the contents
+   * Create the template for the contents
    * @returns {string} The template
    */
   template(): string {
     return `<slot></slot>`;
   }
 
-  set value(val: string | null) {
-    if (val) this.setAttribute(attributes.VALUE, `${val}`);
-    else this.removeAttribute(attributes.VALUE);
+  /**
+   * Get nested ids-checkbox child
+   * @returns {IdsCheckbox | undefined} - nested ids-checkbox child
+   */
+  get childCheckbox(): IdsCheckbox | undefined {
+    return this?.querySelector<IdsCheckbox>('ids-checkbox') ?? undefined;
   }
 
-  get value(): string | null {
-    return this.getAttribute(attributes.VALUE);
+  get childIcon(): IdsIcon | undefined {
+    return this.querySelector<IdsIcon>('ids-icon') ?? undefined;
   }
+
+  get label(): string { return this.textContent?.trim() || this.childCheckbox?.label || ''; }
+
+  get groupLabel(): boolean { return this.hasAttribute(attributes.GROUP_LABEL); }
+
+  set groupLabel(value) {
+    if (stringToBool(value)) {
+      this.setAttribute(attributes.GROUP_LABEL, 'true');
+    } else {
+      this.removeAttribute(attributes.GROUP_LABEL);
+    }
+  }
+
+  set value(value: string | null) { this.setAttribute(attributes.VALUE, `${value ?? ''}`); }
+
+  get value(): string { return this.getAttribute(attributes.VALUE) ?? ''; }
+
+  /**
+   * Set the selected state on the list-box-option
+   * @param {boolean} val true if this option should appear "selected"
+   */
+  set selected(val) {
+    if (stringToBool(val)) {
+      this.setAttribute(attributes.SELECTED, 'true');
+      this.container?.classList.add('is-selected');
+    } else {
+      this.removeAttribute(attributes.SELECTED);
+      this.container?.classList.remove('is-selected');
+    }
+  }
+
+  get selected() {
+    return stringToBool(this.getAttribute(attributes.SELECTED));
+  }
+
+  /**
+   * Set the row index. This index will be used to sort options in ids-list-box component.
+   * @param {number} value the index
+   */
+  set rowIndex(value: number) {
+    if (value !== null && value >= 0) {
+      this.setAttribute(attributes.ROW_INDEX, String(value));
+    } else {
+      this.removeAttribute(attributes.ROW_INDEX);
+    }
+  }
+
+  /**
+   * Gets the row index # of this row.
+   * @returns {number} the row-index
+   */
+  get rowIndex(): number { return Number(this.getAttribute(attributes.ROW_INDEX) ?? -1); }
 }

--- a/src/components/ids-list-box/ids-list-box.scss
+++ b/src/components/ids-list-box/ids-list-box.scss
@@ -104,7 +104,7 @@ $border-input-field-height-lg: calc(var(--ids-input-height-40) - 2px);
   max-height: none;
 }
 
-:host-context(ids-multiselect[tags='true']) {
+:host-context(ids-multiselect) {
   ::slotted(ids-list-box-option[selected].last-selected) {
     border-bottom: 1px solid var(--ids-dropdown-group-color-border);
     margin-bottom: var(--ids-dropdown-group-padding);

--- a/src/components/ids-list-box/ids-list-box.scss
+++ b/src/components/ids-list-box/ids-list-box.scss
@@ -103,3 +103,10 @@ $border-input-field-height-lg: calc(var(--ids-input-height-40) - 2px);
 :host(.module-nav) {
   max-height: none;
 }
+
+:host-context(ids-multiselect[tags='true']) {
+  ::slotted(ids-list-box-option[selected].last-selected) {
+    border-bottom: 1px solid var(--ids-dropdown-group-color-border);
+    margin-bottom: var(--ids-dropdown-group-padding);
+  }
+}

--- a/src/components/ids-list-box/ids-list-box.ts
+++ b/src/components/ids-list-box/ids-list-box.ts
@@ -1,5 +1,6 @@
 import { customElement, scss } from '../../core/ids-decorators';
 import IdsElement from '../../core/ids-element';
+import type IdsListBoxOption from './ids-list-box-option';
 import './ids-list-box-option';
 
 import styles from './ids-list-box.scss';
@@ -19,6 +20,7 @@ export default class IdsListBox extends IdsElement {
   connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('role', 'listbox');
+    this.#configureListBoxOptions();
   }
 
   /**
@@ -27,5 +29,25 @@ export default class IdsListBox extends IdsElement {
    */
   template(): string {
     return `<slot></slot>`;
+  }
+
+  /**
+   * Get list of options
+   * @returns {IdsListBoxOption[]} ids-list-box-option child elements
+   */
+  get options(): IdsListBoxOption[] {
+    return [...this.querySelectorAll<IdsListBoxOption>('ids-list-box-option')];
+  }
+
+  get optionsSorted() {
+    return this.options.sort(
+      (current: IdsListBoxOption, next: IdsListBoxOption) => (current.rowIndex >= next.rowIndex ? 1 : -1)
+    );
+  }
+
+  #configureListBoxOptions() {
+    this.options.forEach((option: IdsListBoxOption, index) => {
+      option.rowIndex = index;
+    });
   }
 }

--- a/src/components/ids-multiselect/demos/example.html
+++ b/src/components/ids-multiselect/demos/example.html
@@ -16,41 +16,69 @@
 
         <ids-multiselect id="dropdown-1" label="Multiselect (with max 3 choices and dirty tracker)" max="3" dirty-tracker="true">
           <ids-list-box>
-            <ids-list-box-option id="al2" value="al" tooltip="The State of Alabama"><ids-checkbox label="Alabama"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ak2" value="ak" tooltip="The State of Alaska"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="az2" value="az" tooltip="The State of Arizona"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ar2" value="ar" tooltip="The State of Arkansas"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ca2" value="ca" tooltip="The State of California"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="co2" value="co" tooltip="The State of Colorado"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="nj2" value="nj" tooltip="The State of New Jersey" selected><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="al1" value="al" tooltip="The State of Alabama"><ids-checkbox label="Alabama"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ak1" value="ak" tooltip="The State of Alaska"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="az1" value="az" tooltip="The State of Arizona"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ar1" value="ar" tooltip="The State of Arkansas"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ca1" value="ca" tooltip="The State of California"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="co1" value="co" tooltip="The State of Colorado"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="nj1" value="nj" tooltip="The State of New Jersey" selected><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
           </ids-list-box>
         </ids-multiselect>
 
         <ids-multiselect id="dropdown-2" tags="true" label="Multiselect (with tags and max 4 choices)" max="4" dirty-tracker="true">
           <ids-list-box>
-            <ids-list-box-option id="al3" value="al"><ids-checkbox label="Alabama"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ak3" value="ak"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="az3" value="az"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ar3" value="ar"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ca3" value="ca"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="co3" value="co"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="nj3" value="nj"><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ma3" value="ma"><ids-checkbox label="Massachusets"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ny3" value="ny"><ids-checkbox label="New York"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="nh3" value="nh"><ids-checkbox label="New Hampshire"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="nm3" value="nm"><ids-checkbox label="New Mexico"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="al2" value="al"><ids-checkbox label="Alabama"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ak2" value="ak"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="az2" value="az"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ar2" value="ar"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ca2" value="ca"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="co2" value="co"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="nj2" value="nj"><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ma2" value="ma"><ids-checkbox label="Massachusets"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ny2" value="ny"><ids-checkbox label="New York"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="nh2" value="nh"><ids-checkbox label="New Hampshire"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="nm2" value="nm"><ids-checkbox label="New Mexico"></ids-checkbox></ids-list-box-option>
           </ids-list-box>
         </ids-multiselect>
 
-        <ids-multiselect id="dropdown-3" tags="true" disabled="true" label="Disabled Multiselect" max="3" dirty-tracker="true">
+        <ids-multiselect id="dropdown-3" tags="true" label="Multiselect (with icons)" max="4" dirty-tracker="true">
           <ids-list-box>
-            <ids-list-box-option id="al" value="al"><ids-checkbox label="Alabama"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ak" value="ak"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="az" value="az"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ar" value="ar"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ca" value="ca"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="co" value="co"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="nj" value="nj" selected><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option value="opt1" id="opt1-d5">
+              <ids-icon icon="user-profile"></ids-icon>
+              <span>Option One</span>
+            </ids-list-box-option>
+            <ids-list-box-option value="opt2" id="opt2-d5">
+              <ids-icon icon="project"></ids-icon>
+              <span>Option Two</span>
+            </ids-list-box-option>
+            <ids-list-box-option value="opt3" id="opt3-d5">
+              <ids-icon icon="purchasing"></ids-icon>
+              <span>Option Three</span>
+            </ids-list-box-option>
+            <ids-list-box-option value="opt4" id="opt4-d5">
+              <ids-icon icon="quality"></ids-icon>
+              <span>Option Four</span></ids-list-box-option>
+            <ids-list-box-option value="opt5" id="opt5-d5">
+              <ids-icon icon="rocket"></ids-icon>
+              <span>Option Five</span>
+            </ids-list-box-option>
+            <ids-list-box-option value="opt6" id="opt6-d5">
+              <ids-icon icon="roles"></ids-icon>
+              <span>Option Six</span>
+            </ids-list-box-option>
+          </ids-list-box>
+        </ids-multiselect>
+
+        <ids-multiselect id="dropdown-4" tags="true" disabled="true" label="Disabled Multiselect" max="3" dirty-tracker="true">
+          <ids-list-box>
+            <ids-list-box-option id="al4" value="al"><ids-checkbox label="Alabama"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ak4" value="ak"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="az4" value="az"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ar4" value="ar"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ca4" value="ca"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="co4" value="co"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="nj4" value="nj" selected><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
           </ids-list-box>
         </ids-multiselect>
 

--- a/src/components/ids-multiselect/demos/example.html
+++ b/src/components/ids-multiselect/demos/example.html
@@ -20,7 +20,7 @@
             <ids-list-box-option id="ak1" value="ak" tooltip="The State of Alaska"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="az1" value="az" tooltip="The State of Arizona"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="ar1" value="ar" tooltip="The State of Arkansas"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ca1" value="ca" tooltip="The State of California"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ca1" value="ca" tooltip="The State of California" selected><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="co1" value="co" tooltip="The State of Colorado"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="nj1" value="nj" tooltip="The State of New Jersey" selected><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
           </ids-list-box>
@@ -32,7 +32,7 @@
             <ids-list-box-option id="ak2" value="ak"><ids-checkbox label="Alaska"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="az2" value="az"><ids-checkbox label="Arizona"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="ar2" value="ar"><ids-checkbox label="Arkansas"></ids-checkbox></ids-list-box-option>
-            <ids-list-box-option id="ca2" value="ca"><ids-checkbox label="California"></ids-checkbox></ids-list-box-option>
+            <ids-list-box-option id="ca2" value="ca"><ids-checkbox checked="true" label="California"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="co2" value="co"><ids-checkbox label="Colorado"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="nj2" value="nj"><ids-checkbox label="New Jersey"></ids-checkbox></ids-list-box-option>
             <ids-list-box-option id="ma2" value="ma"><ids-checkbox label="Massachusets"></ids-checkbox></ids-list-box-option>

--- a/src/components/ids-multiselect/ids-multiselect.ts
+++ b/src/components/ids-multiselect/ids-multiselect.ts
@@ -345,6 +345,7 @@ class IdsMultiselect extends IdsDropdown {
 
     (this.dropdownList?.listBox?.optionsSorted ?? [])
       .forEach((option: IdsListBoxOption) => {
+        option.classList.remove('last-selected');
         option.hidden = false;
         if (this.#selectedList.includes(option.value)) {
           option.selected = true;
@@ -355,6 +356,7 @@ class IdsMultiselect extends IdsDropdown {
         }
       });
 
+    selectedOptions.at(-1)?.classList.add('last-selected');
     this.dropdownList.listBox.prepend(...selectedOptions.concat(unselectedOptions));
   }
 

--- a/src/components/ids-multiselect/ids-multiselect.ts
+++ b/src/components/ids-multiselect/ids-multiselect.ts
@@ -35,6 +35,12 @@ class IdsMultiselect extends IdsDropdown {
     super.connectedCallback();
     this.resetDirtyTracker();
     this.#populateSelected();
+
+    const defaultSlot = this.container?.querySelector<HTMLSlotElement>('slot');
+    this.offEvent('slotchange.mulitselect', defaultSlot);
+    this.onEvent('slotchange.mulitselect', defaultSlot, () => {
+      this.#populateSelected();
+    });
   }
 
   #selectedList: Array<string> = [];
@@ -364,6 +370,8 @@ class IdsMultiselect extends IdsDropdown {
    * Update options list on the component mount with classes/attributes
    */
   #populateSelected() {
+    this.#selectedList = [];
+
     this.options.forEach((item: any) => {
       const checkbox = item.querySelector('ids-checkbox');
 

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -67,6 +67,7 @@ export const attributes = {
   CHARACTER_COUNTER: 'character-counter',
   CHAR_MAX_TEXT: 'char-max-text',
   CHAR_REMAINING_TEXT: 'char-remaining-text',
+  CHECKBOX: 'checkbox',
   CHECKED: 'checked',
   CHILD_FILTER_MATCH: 'child-filter-match',
   CLEARABLE: 'clearable',

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -67,7 +67,6 @@ export const attributes = {
   CHARACTER_COUNTER: 'character-counter',
   CHAR_MAX_TEXT: 'char-max-text',
   CHAR_REMAINING_TEXT: 'char-remaining-text',
-  CHECKBOX: 'checkbox',
   CHECKED: 'checked',
   CHILD_FILTER_MATCH: 'child-filter-match',
   CLEARABLE: 'clearable',

--- a/test/ids-multiselect/ids-multiselect-func-test.ts
+++ b/test/ids-multiselect/ids-multiselect-func-test.ts
@@ -414,6 +414,8 @@ describe('IdsMultiselect Component', () => {
     );
     const getText = () => multiselect.input.querySelector('ids-text');
 
+    await processAnimFrame();
+
     expect(multiselect.value).toEqual(['opt1', 'opt2', 'opt3']);
     expect(getText()?.textContent).toEqual('Option One, Option Two, Option Three');
 

--- a/test/ids-multiselect/ids-multiselect-func-test.ts.snap
+++ b/test/ids-multiselect/ids-multiselect-func-test.ts.snap
@@ -2,21 +2,12 @@
 
 exports[`IdsMultiselect Component renders correctly 1`] = `
 "<ids-multiselect id="multiselect-1" label="Normal Multiselect" dirty-tracker="true" role="combobox" aria-expanded="false" aria-autocomplete="list" aria-haspopup="listbox" aria-description="Press down arrow to select" aria-controls="ids-list-box-multiselect-1">
-        <ids-list-box size="md" id="ids-list-box-multiselect-1" aria-label="Listbox" role="listbox">
-      <ids-list-box-option class="multiselect-option" id="opt2" value="opt2" role="option" tabindex="-1">
-        <ids-checkbox no-margin="" class="justify-center multiselect-checkbox" label="" checked="true"></ids-checkbox>
-      </ids-list-box-option>
-      <ids-list-box-option class="multiselect-option multiselect-border" id="opt3" value="opt3" role="option" tabindex="-1">
-        <ids-checkbox no-margin="" class="justify-center multiselect-checkbox" label=""></ids-checkbox>
-      </ids-list-box-option>
-      <ids-list-box-option class="multiselect-option" id="opt4" value="opt4" role="option" tabindex="-1">
-        <ids-checkbox no-margin="" class="justify-center multiselect-checkbox" label=""></ids-checkbox>
-      </ids-list-box-option>
-      <ids-list-box-option class="multiselect-option" id="opt5" value="opt5" role="option" tabindex="-1">
-        <ids-checkbox no-margin="" class="justify-center multiselect-checkbox" label=""></ids-checkbox>
-      </ids-list-box-option>
-      <ids-list-box-option class="multiselect-option" id="opt6" value="opt6" role="option" tabindex="-1">
-        <ids-checkbox no-margin="" class="justify-center multiselect-checkbox" label=""></ids-checkbox>
-      </ids-list-box-option></ids-list-box>
+        <ids-list-box size="md" id="ids-list-box-multiselect-1" aria-label="Listbox" role="listbox"><ids-list-box-option value="opt2" id="opt2" selected="true" class="multiselect-option last-selected" role="option" tabindex="-1"><ids-checkbox label="Option Two" tooltip="Additional Info on Option Two" no-margin="" class="justify-center multiselect-checkbox" checked="true"></ids-checkbox></ids-list-box-option><ids-list-box-option value="opt3" id="opt3" class="multiselect-option" role="option" tabindex="-1"><ids-checkbox label="Option Three" tooltip="Additional Info on Option Three" no-margin="" class="justify-center multiselect-checkbox"></ids-checkbox></ids-list-box-option><ids-list-box-option value="opt4" id="opt4" class="multiselect-option" role="option" tabindex="-1"><ids-checkbox label="Option Four" tooltip="Additional Info on Option Four" no-margin="" class="justify-center multiselect-checkbox"></ids-checkbox></ids-list-box-option><ids-list-box-option value="opt5" id="opt5" class="multiselect-option" role="option" tabindex="-1"><ids-checkbox label="Option Five" tooltip="Additional Info on Option Five" no-margin="" class="justify-center multiselect-checkbox"></ids-checkbox></ids-list-box-option><ids-list-box-option value="opt6" id="opt6" class="multiselect-option" role="option" tabindex="-1"><ids-checkbox label="Option Six" tooltip="Additional Info on Option Six" no-margin="" class="justify-center multiselect-checkbox"></ids-checkbox></ids-list-box-option>
+          
+          
+          
+          
+          
+        </ids-list-box>
       </ids-multiselect>"
 `;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

When using `ngModel` directive in Angular's some custom components () did not update their values properly. This PR fixes ids-checkbox, ids-checkbox-group, ids-radio, ids-radio-group, and ids-switch.

**Related github/jira issue (required)**:

Closes #1411 

**Steps necessary to review your pull request (required)**:

1. Check out this PRs' branch and run: `nvm use && npm run start`
2. Regression test this page: http://localhost:4300/ids-multiselect/example.html
3. Run (in another command-line tab): `npm run publish:link`
4. Check out the WC examples repository: https://github.com/infor-design/enterprise-wc-examples
5. In the examples repository run: `npm install`
6. In the examples repository run: `npm link ids-enterprise-wc`
7. In the examples repository run: `rm -fr .angular/cache`
8. In the examples repository run: `npm run build && npm run start` 
9. Go to: http://localhost:4200/ids-multiselect/example
10. The 4th multiselect called `Test Multiselect (using ngFor)` is dynamically populated using nFor 
11. Go to: http://localhost:4200/ids-forms/example
12. Open your browser's developer console to see updated values for ids-multiselect field.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
