### PR TITLE
1529/1530 - Improve IdsModal behavior on resize, and while containing splitter panes

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))
 - `[Inputs]` Fixed removing `readonly` and `disabled` not working after form additions. ([#1570](https://github.com/infor-design/enterprise-wc/issues/1570))
 - `[Modal]` Add `showCloseButton` setting to modal. ([#1527](https://github.com/infor-design/enterprise-wc/issues/1527))
+- `[Modal]` Fix problems with slotting scrollable components and resize behavior. ([#1529](https://github.com/infor-design/enterprise-wc/issues/1529)/[#1530](https://github.com/infor-design/enterprise-wc/issues/1530))
 - `[Module Nav]` Small improvements to better enable usage in an Angular codebase. ([#1597](https://github.com/infor-design/enterprise-wc/issues/1597))
 - `[Textarea]` Made sure strings are translated and fixed `character-count`` setting. ([#1598](https://github.com/infor-design/enterprise-wc/issues/1598))
 

--- a/src/components/ids-action-panel/demos/empty.html
+++ b/src/components/ids-action-panel/demos/empty.html
@@ -7,7 +7,7 @@
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-action-panel id="cap-company-info"></ids-action-panel>
+    <ids-action-panel id="cap-company-info" scrollable></ids-action-panel>
 
     <ids-layout-grid auto-fit="true" padding="md">
       <ids-layout-grid-column>

--- a/src/components/ids-action-panel/demos/example.html
+++ b/src/components/ids-action-panel/demos/example.html
@@ -14,7 +14,7 @@
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
-    <ids-action-panel id="cap-company-info" fullsize="lg">
+    <ids-action-panel id="cap-company-info" fullsize="lg" scrollable>
       <ids-toolbar slot="toolbar">
         <ids-toolbar-section type="title">
           <ids-text font-size="20" type="h2">Company Information</ids-text>

--- a/src/components/ids-modal/README.md
+++ b/src/components/ids-modal/README.md
@@ -20,6 +20,7 @@ The IDS Modal Component builds on top of the [Ids Popup](../ids-popup/README.md)
 - `visible` can be used to make the Modal show or hide
 - `buttons` (readonly) contains a list of references to any Modal Buttons present
 - `messageTitle` The text present at the very top of the Modal to indicate its purpose
+- `scrollable` If true, allows the "modal-content" element inside the modal to scroll its contents
 - `showCloseButton` used to show and position close button in modal. Can be set to values `left` or `right`.
 
 ## Themeable Parts
@@ -103,6 +104,12 @@ IdsModal can alter its display mode to take up 100% of the browser viewport's wi
 The fullsize attribute can be defined with an IDS Breakpoint, as defined in the [IdsBreakpointMixin](../../mixins/ids-breakpoint-mixin/README.md).  Alternatively, this setting can be changed to `null` or `''` resulting in no fullscreen mode, or `'always'` which forces the fullscreen mode to be displayed indefinitely.
 
 By default, the fullsize setting on all modals is set to Small (sm) and will break when the viewport width is below 600px.
+
+### Handling scrolled content
+
+Scrolled content on IdsModal can be configured using the `scrollable` setting.  By default, scrolling is disabled on the internal `ids-modal-content` element, which wraps the slot containing all nested content outside the header and footer areas.  In situations where scrolling is not handled by one of the slotted elements, using `scrollable="true"` will enable the scrolling internally.
+
+If a scrollable element such as [IdsSplitter](../ids-splitter/README.md) has been slotted, a best practice is to defer to that element for scrolling behavior on its own child elements.  In this case, `scrollable` should be set to false.
 
 ## Converting from Previous Versions (Breaking Changes)
 

--- a/src/components/ids-modal/demos/contains-components.html
+++ b/src/components/ids-modal/demos/contains-components.html
@@ -7,7 +7,7 @@
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-modal id="my-modal" aria-labelledby="my-modal-title">
+    <ids-modal id="my-modal" aria-labelledby="my-modal-title" scrollable>
       <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Insert Anchor</ids-text>
 
       <ids-layout-grid class="data-grid-container" auto-fit="true" gap="md" no-margins="true" min-col-width="300px">

--- a/src/components/ids-modal/demos/contains-tree-detail.html
+++ b/src/components/ids-modal/demos/contains-tree-detail.html
@@ -11,7 +11,7 @@
     <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
       <span>OK</span>
     </ids-modal-button>
-    <ids-splitter>
+    <ids-splitter id="splitter-container">
       <ids-splitter-pane size="25%">
         <ids-tree id="tree" label="Tree"></ids-tree>
       </ids-splitter-pane>

--- a/src/components/ids-modal/demos/contains-tree-detail.html
+++ b/src/components/ids-modal/demos/contains-tree-detail.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+
+  <ids-modal id="my-modal" aria-labelledby="my-modal-title">
+    <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
+    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
+      <span>OK</span>
+    </ids-modal-button>
+    <ids-splitter>
+      <ids-splitter-pane size="25%">
+        <ids-tree id="tree" label="Tree"></ids-tree>
+      </ids-splitter-pane>
+      <ids-splitter-pane>
+        <ids-list-view item-height="76" selectable="single">
+          <template>
+            <ids-text font-size="16" type="h2" font-weight="semi-bold">${name}</ids-text>
+            <ids-layout-grid cols="1" padding-y="xxs">
+              <ids-layout-grid-cell>
+                <ids-text font-size="16" type="span">${type}</ids-text>
+                <ids-text font-size="14" type="span">${location}</ids-text>
+              </ids-layout-grid-cell>
+            </ids-layout-grid>
+          </template>
+        </ids-list-view>
+      </ids-splitter-pane>
+    </ids-splitter>
+  </ids-modal>
+
+  <ids-layout-grid auto-fit="true" padding="md">
+    <ids-text font-size="12" type="h1">Modal</ids-text>
+  </ids-layout-grid>
+  <ids-layout-grid auto-fit="true" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-button id="modal-trigger-btn" appearance="secondary">
+        <span>Trigger a Modal</span>
+      </ids-button>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+
+</body>
+</html>

--- a/src/components/ids-modal/demos/contains-tree-detail.ts
+++ b/src/components/ids-modal/demos/contains-tree-detail.ts
@@ -11,6 +11,7 @@ import '../../ids-tree/ids-tree';
 
 import type IdsModal from '../ids-modal';
 import type IdsListView from '../../ids-list-view/ids-list-view';
+import type IdsSplitter from '../../ids-splitter/ids-splitter';
 
 document.addEventListener('DOMContentLoaded', () => {
   const triggerId = '#modal-trigger-btn';
@@ -18,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const modal = document.querySelector<IdsModal>('ids-modal')!;
   const tree: any = document.querySelector('ids-tree');
   const listView = document.querySelector<IdsListView>('ids-list-view:not([id])');
+  const splitter = document.querySelector<IdsSplitter>('ids-splitter');
 
   modal.style.setProperty('--ids-modal-content-padding', '0');
   modal.style.setProperty('--ids-modal-footer-margin', '1px 0 0 0');
@@ -55,6 +57,10 @@ document.addEventListener('DOMContentLoaded', () => {
   modal.addEventListener('beforeshow', () => {
     triggerBtn.disabled = true;
     return true;
+  });
+
+  modal.addEventListener('aftershow', () => {
+    splitter?.resize();
   });
 
   // Close the modal when its inner button is clicked.

--- a/src/components/ids-modal/demos/contains-tree-detail.ts
+++ b/src/components/ids-modal/demos/contains-tree-detail.ts
@@ -1,0 +1,69 @@
+import treeBasicJSON from '../../../assets/data/tree-basic.json';
+import eventsJSON from '../../../assets/data/accounts.json';
+
+import '../../ids-button/ids-button';
+import '../../ids-list-view/ids-list-view';
+import '../ids-modal';
+import '../../ids-modal-button/ids-modal-button';
+import '../../ids-splitter/ids-splitter';
+import '../../ids-splitter/ids-splitter-pane';
+import '../../ids-tree/ids-tree';
+
+import type IdsModal from '../ids-modal';
+import type IdsListView from '../../ids-list-view/ids-list-view';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const triggerId = '#modal-trigger-btn';
+  const triggerBtn: any = document.querySelector(triggerId);
+  const modal = document.querySelector<IdsModal>('ids-modal')!;
+  const tree: any = document.querySelector('ids-tree');
+  const listView = document.querySelector<IdsListView>('ids-list-view:not([id])');
+
+  modal.style.setProperty('--ids-modal-content-padding', '0');
+  modal.style.setProperty('--ids-modal-footer-margin', '1px 0 0 0');
+
+  // get tree data
+  if (tree) {
+    (async function init() {
+      // Do an ajax request
+      const res = await fetch(treeBasicJSON as any);
+      const data: any = await res.json();
+      tree.data = data;
+    }());
+  }
+
+  // get listView data
+  if (listView) {
+    // Do an ajax request and apply the data to the list
+    const url: any = eventsJSON;
+
+    const setData = async () => {
+      const res = await fetch(url);
+      const data = await res.json();
+      (listView as any).data = data;
+    };
+
+    setData();
+  }
+
+  // Links the Modal to its trigger button (sets up click/focus events)
+  modal.target = triggerBtn;
+  modal.triggerType = 'click';
+  modal.fullsize = 'always';
+
+  // Disable the trigger button when showing the Modal.
+  modal.addEventListener('beforeshow', () => {
+    triggerBtn.disabled = true;
+    return true;
+  });
+
+  // Close the modal when its inner button is clicked.
+  modal.onButtonClick = () => {
+    modal.hide();
+  };
+
+  // After the modal is done hiding, re-enable its trigger button.
+  modal.addEventListener('hide', () => {
+    triggerBtn.disabled = false;
+  });
+});

--- a/src/components/ids-modal/demos/index.yaml
+++ b/src/components/ids-modal/demos/index.yaml
@@ -11,6 +11,9 @@
   - link: contains-components.html
     type: Example
     description: Showing a modal that contains other IDS components that break containment
+  - link: contains-tree-detail.html
+    type: Example
+    description: Showing a modal that contains a tree/detail pattern
   - link: focus.html
     type: Example
     description: Demonstrates Focus Capture behavior

--- a/src/components/ids-modal/ids-modal.scss
+++ b/src/components/ids-modal/ids-modal.scss
@@ -21,6 +21,10 @@
   &[visible] {
     pointer-events: auto;
   }
+
+  &.fullsize {
+    height: 100%;
+  }
 }
 
 .ids-modal-header {

--- a/src/components/ids-modal/ids-modal.scss
+++ b/src/components/ids-modal/ids-modal.scss
@@ -25,6 +25,18 @@
   &.fullsize {
     height: 100%;
   }
+
+  &:not(.scrollable) {
+    .has-scrollbar {
+      overflow: hidden;
+    }
+  }
+
+  &.scrollable {
+    .has-scrollbar {
+      overflow: auto;
+    }
+  }
 }
 
 .ids-modal-header {
@@ -35,10 +47,6 @@
   padding: var(--ids-modal-content-padding);
   flex-grow: 1;
   flex-shrink: 1;
-
-  &.has-scrollbar {
-    overflow: auto;
-  }
 }
 
 .ids-modal-header + .ids-modal-content {

--- a/src/components/ids-modal/ids-modal.ts
+++ b/src/components/ids-modal/ids-modal.ts
@@ -227,6 +227,7 @@ export default class IdsModal extends Base {
       this.popup.height = doFullsize ? '100%' : '';
       this.popup.place();
       if (this.popup.open) {
+        this.setScrollable();
         this.popup.correct3dMatrix();
       }
     };
@@ -485,6 +486,8 @@ export default class IdsModal extends Base {
       if (this.popup.animated && this.popup.container) {
         await waitForTransitionEnd(this.popup.container, 'opacity');
       }
+      this.setScrollable();
+      this.popup.correct3dMatrix();
     }
 
     this.removeAttribute('aria-hidden');

--- a/src/components/ids-modal/ids-modal.ts
+++ b/src/components/ids-modal/ids-modal.ts
@@ -11,6 +11,7 @@ import IdsPopupOpenEventsMixin from '../../mixins/ids-popup-open-events-mixin/id
 import IdsXssMixin from '../../mixins/ids-xss-mixin/ids-xss-mixin';
 import IdsElement from '../../core/ids-element';
 
+import { setBooleanAttr } from '../../utils/ids-attribute-utils/ids-attribute-utils';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 import { toggleScrollbar, waitForTransitionEnd } from '../../utils/ids-dom-utils/ids-dom-utils';
 import { cssTransitionTimeout } from '../../utils/ids-timer-utils/ids-timer-utils';
@@ -86,6 +87,7 @@ export default class IdsModal extends Base {
     }
     this.state.fullsize = '';
     this.state.overlay = null;
+    this.state.scrollable = true;
     this.state.messageTitle = null;
   }
 
@@ -94,6 +96,7 @@ export default class IdsModal extends Base {
       ...super.attributes,
       attributes.FULLSIZE,
       attributes.MESSAGE_TITLE,
+      attributes.SCROLLABLE,
       attributes.SHOW_CLOSE_BUTTON,
       attributes.VISIBLE
     ];
@@ -360,6 +363,16 @@ export default class IdsModal extends Base {
 
       this.#refreshModalHeader(!!trueVal);
     }
+  }
+
+  set scrollable(val: string | boolean | null) {
+    const bool = stringToBool(val);
+    setBooleanAttr(attributes.SCROLLABLE, this, bool);
+    this.state.scrollable = bool;
+  }
+
+  get scrollable() {
+    return this.state.scrollable;
   }
 
   /**

--- a/src/components/ids-splitter/ids-splitter.scss
+++ b/src/components/ids-splitter/ids-splitter.scss
@@ -3,6 +3,7 @@
   display: flex;
   position: relative;
   height: 100%;
+  white-space: nowrap;
   width: 100%;
 
   &.axis-x {

--- a/src/components/ids-splitter/ids-splitter.ts
+++ b/src/components/ids-splitter/ids-splitter.ts
@@ -312,7 +312,7 @@ export default class IdsSplitter extends Base {
    * Attach the resize observer.
    * @private
    */
-  #resizeObserver = new ResizeObserver(() => this.#resize());
+  #resizeObserver = new ResizeObserver(() => this.resize());
 
   /**
    * Attach the initialize observer.
@@ -384,10 +384,9 @@ export default class IdsSplitter extends Base {
 
   /**
    * Resize the component
-   * @private
    * @returns {void}
    */
-  #resize(): void {
+  resize(): void {
     this.#setProp();
     requestAnimationFrame(() => {
       this.#setContainer();
@@ -1186,7 +1185,7 @@ export default class IdsSplitter extends Base {
 
   /** Handle Languages Changes - for switching between RTL to LTR */
   onLanguageChange = () => {
-    this.#resize();
+    this.resize();
   };
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes some adjustments to IdsModal to better enable it's containment of other scrollable/resizable components, such as IdsSplitter.  It also makes some improvements to its own resizable behavior.

**Related github/jira issue (required)**:
Closes #1529 
Closes #1530

**Steps necessary to review your pull request (required)**:
Pull/build/run, then test the following:

_Test main issues:_
- Open http://localhost:4300/ids-modal/contains-tree-detail.html
- Use the button to open the Modal.  When the modal opens, the default position of the splitter handle should line up with the space between both split panes, and the IdsListView contained in the right-side pane should not be breaking the boundaries of the modal content area.
- Using the splitter handle to adjust the available size of the split panes should not cause any content to appear broken.
- Resizing the browser viewport should keep all modal elements in bounds

Also smoke test the following component pages to make sure all behavior matches `main`:
- http://localhost:4300/ids-action-panel/example.html
- http://localhost:4300/ids-modal/contains-components.html
- http://localhost:4300/ids-splitter/list-detail.html

**Included in this Pull Request**:
- [x] A note to the change log.