### PR TITLE
1523 - IdsDataGrid: Allow hyperlinks to be clickable when 'rowNavigation' is enabled

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Calendar]` Fix multiple `beforerendermonth` events. ([#1464](https://github.com/infor-design/enterprise-wc/issues/1464))
 - `[Calendar]` Add `afterrendermonth` event to calendar and month view. ([#1465](https://github.com/infor-design/enterprise-wc/issues/1465))
 - `[Calendar]` Add `disableSettings` property to calendar. ([#1471](https://github.com/infor-design/enterprise-wc/issues/1471))
+- `[DataGrid]` Make hyperlink cells clickable when `rowNavigation` is enabled. ([#1523](https://github.com/infor-design/enterprise-wc/issues/1523))
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))
 - `[Inputs]` Fixed removing `readonly` and `disabled` not working after form additions. ([#1570](https://github.com/infor-design/enterprise-wc/issues/1570))
 - `[Modal]` Add `showCloseButton` setting to modal. ([#1527](https://github.com/infor-design/enterprise-wc/issues/1527))

--- a/src/components/ids-data-grid/ids-data-grid-row.scss
+++ b/src/components/ids-data-grid/ids-data-grid-row.scss
@@ -166,4 +166,10 @@ tr.ids-data-grid-row {
     box-shadow: none;
     outline: none;
   }
+
+  // Fixes an issue where hyperlinks in row-navigation mode cannot be directly clicked
+  ids-hyperlink,
+  .ids-hyperlink {
+    transform: translateZ(1px);
+  }
 }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes a small adjustment to IdsHyperlinks residing inside data grid cells to allow them to remain clickable when using the `rowNavigation` setting.  A previous change to the visual state enabled the CSS property `transform-style: preserve-3d` to help properly display the selected state on rows, but unexpectedly broke the ability to click hyperlinks.  The fix simply sets a transform on all nested hyperlinks to bring it to the "top" of the row on the Z-axis, making the link clickable.

**Related github/jira issue (required)**:
Closes #1523

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/columns-formatters.html
- Also open a dev tools console.
- Click any of the hyperlinks inside the "Hyperlink" column.  Then, check the dev tools console.  A "Link Clicked" message should appear with a reference to the corresponding hyperlink.
- In the dev tools console, type the following to enable row navigation: `document.querySelector("#data-grid-formatters").rowNavigation = true`
- Try clicking any of the hyperlinks again.  The same "Link clicked" messages should appear.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
