### PR TITLE
1501 - IdsDataGrid popups arrow position in rtl

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Calendar]` Fix multiple `beforerendermonth` events. ([#1464](https://github.com/infor-design/enterprise-wc/issues/1464))
 - `[Calendar]` Add `afterrendermonth` event to calendar and month view. ([#1465](https://github.com/infor-design/enterprise-wc/issues/1465))
 - `[Calendar]` Add `disableSettings` property to calendar. ([#1471](https://github.com/infor-design/enterprise-wc/issues/1471))
+- `[DataGrid]` Fix setting rtl direction on component init. ([#1501](https://github.com/infor-design/enterprise-wc/issues/1501))
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))
 - `[Inputs]` Fixed removing `readonly` and `disabled` not working after form additions. ([#1570](https://github.com/infor-design/enterprise-wc/issues/1570))
 - `[Modal]` Add `showCloseButton` setting to modal. ([#1527](https://github.com/infor-design/enterprise-wc/issues/1527))

--- a/src/mixins/ids-locale-mixin/ids-locale-mixin.ts
+++ b/src/mixins/ids-locale-mixin/ids-locale-mixin.ts
@@ -27,9 +27,17 @@ const IdsLocaleMixin = <T extends Constraints>(superclass: T) => class extends s
   connectedCallback() {
     super.connectedCallback?.();
 
+    const language = this.localeAPI.language.name;
+    const locale = this.localeAPI.name;
+
     // Set initial lang and locale
-    if (this.localeAPI.language.name !== 'en') this.setAttribute('language', this.localeAPI.language.name);
-    if (this.localeAPI.name !== 'en-US') this.setAttribute('locale', this.localeAPI.name);
+    if (language !== 'en') this.setAttribute('language', language);
+    if (locale !== 'en-US') this.setAttribute('locale', locale);
+
+    // set initial direction
+    if (language === 'ar' || language === 'he') {
+      this.setAttribute('dir', 'rtl');
+    }
   }
 
   static get attributes() {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes popup arrow position when an RTL language is loaded.
Updated `LocaleMixin` to set `dir` attribute inside `connectedCallback`.

**Related github/jira issue (required)**:
Fixes #1501 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/editable.html
3. Switch to RTL language
4. Open filter column filter, datepicker, timepicker popups
5. Check that the arrow is positioned correctly

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
