### PR TITLE
1525 - IdsModal fullsize setting

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))
 - `[Inputs]` Fixed removing `readonly` and `disabled` not working after form additions. ([#1570](https://github.com/infor-design/enterprise-wc/issues/1570))
 - `[Modal]` Add `showCloseButton` setting to modal. ([#1527](https://github.com/infor-design/enterprise-wc/issues/1527))
+- `[Modal]` Fix `fullsize` setting on init. ([#1525](https://github.com/infor-design/enterprise-wc/issues/1525))
 - `[Module Nav]` Small improvements to better enable usage in an Angular codebase. ([#1597](https://github.com/infor-design/enterprise-wc/issues/1597))
 - `[Multiselect]` Fix rerender logic so that state is maintained while using ngFor directive in Angular. ([#1411](https://github.com/infor-design/enterprise-wc/issues/1411))
 - `[Text]` Fixed wrong status warning color. ([#1619](https://github.com/infor-design/enterprise-wc/issues/1619))

--- a/src/components/ids-modal/ids-modal.ts
+++ b/src/components/ids-modal/ids-modal.ts
@@ -232,7 +232,7 @@ export default class IdsModal extends Base {
     };
 
     const safeVal = `${val}`;
-    if (current !== val) {
+    if (current !== val && this.popup) {
       switch (val) {
         case 'always':
           this.#clearBreakpointResponse();


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed `fullsize` setting for IdsModal to work on component init.
Added a guard so that the internal `fullsize` state is only set (marked as active) when IdsPopup is ready and size related operations have been completed.

**Related github/jira issue (required)**:
Closes #1525 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Open up IdsModal's [example.html](https://github.com/infor-design/enterprise-wc/blob/main/src/components/ids-modal/demos/example.html) in a code editor
3. Add `fullsize="always"` to the ids-modal html
```
<ids-modal id="my-modal" aria-labelledby="my-modal-title" fullsize="always">
```
4. Go to http://localhost:4300/ids-modal/example.html and open modal
5. Modal should open in full width and height

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

