### PR TITLE
1575 - Add 'filterAlign' column setting for independently setting filter row alignment

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Calendar]` Add `afterrendermonth` event to calendar and month view. ([#1465](https://github.com/infor-design/enterprise-wc/issues/1465))
 - `[Calendar]` Add `disableSettings` property to calendar. ([#1471](https://github.com/infor-design/enterprise-wc/issues/1471))
 - `[DataGrid]` Make hyperlink cells clickable when `rowNavigation` is enabled. ([#1523](https://github.com/infor-design/enterprise-wc/issues/1523))
+- `[DataGrid]` Add `filterAlign` setting to columns for independently aligning filter row contents. ([#1575](https://github.com/infor-design/enterprise-wc/issues/1575))
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))
 - `[Inputs]` Fixed removing `readonly` and `disabled` not working after form additions. ([#1570](https://github.com/infor-design/enterprise-wc/issues/1570))
 - `[Modal]` Add `showCloseButton` setting to modal. ([#1527](https://github.com/infor-design/enterprise-wc/issues/1527))

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -363,6 +363,7 @@ When used as an attribute in the DOM the settings are kebab case, when used in J
 |`formatter`| {Function} | Controls how the data is rendered in the cell.|
 |`hidden` | {boolean} | Excludes the column from being added to the DOM.|
 |`align` | {string} | Can be `left` or `right` or `center` to align both the cell and the header. Left is the default so does not need to be specified. |
+|`filterAlign` | {string} | Can be `left` or `right` or `center` to control the alignment of just the filter row in the cell header. Left is the default so does not need to be specified. |
 |`headerAlign` | {string} | Can be `left` or `right` or `center` to align just the header. Left is the default so does not need to be specified. |
 |`minWidth` | {number} | The minimum width used to prevent resizing a column below this size. |
 |`maxWidth` | {number} | The maximum width used to prevent resizing a column above this size. |

--- a/src/components/ids-data-grid/demos/filter.ts
+++ b/src/components/ids-data-grid/demos/filter.ts
@@ -98,6 +98,8 @@ const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-filter')!;
     sortable: true,
     resizable: true,
     reorderable: true,
+    align: 'right',
+    filterAlign: 'left',
     formatter: dataGrid.formatters.text,
     filterType: dataGrid.filters.text
   });

--- a/src/components/ids-data-grid/ids-data-grid-column.ts
+++ b/src/components/ids-data-grid/ids-data-grid-column.ts
@@ -195,6 +195,8 @@ export interface IdsDataGridColumn {
   headerIcon?: string;
   /** Align the column to either `left`, `center` or `right` */
   align?: string;
+  /** Separately align the filter row contents to either `left`, `center`, or `right` */
+  filterAlign?: string;
   /** Seperately align the header to either `left`, `center` or `right` */
   headerAlign?: string;
   /** Freeze the columns to either the `left` or `right` sides */

--- a/src/components/ids-data-grid/ids-data-grid-filters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-filters.ts
@@ -1104,7 +1104,8 @@ export default class IdsDataGridFilters {
   #btnAndInputTemplate(type: string, column: IdsDataGridColumn) {
     const input = `${this.#inputTemplate(type, column)}`;
     const button = `${this.#filterButtonTemplate(type, column)}`;
-    if (column.align === 'right') {
+    const align = column.filterAlign || column.align;
+    if (align === 'right') {
       return `${input}${button}`;
     }
     return `${button}${input}`;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds a new setting `filterAlign` setting to IdsDataGridColumn, which allows for independent alignment of the filter row contents.  This is helpful for right-aligned columns (such as ones dealing with numbers) where header cell contents can be right aligned.

**Related github/jira issue (required)**:
Closes #1575

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/filter.html
- Observe the "Units" column is right-aligned, but its filter menu/input are aligned the same as all the others (compare to https://main.wc.design.infor.com/ids-data-grid/filter.html)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.