### PR TITLE
1614 - IdsDatePicker Set trigger field's value when today button is clicked

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[DataGrid]` Fix setting `rtl` direction on component init. ([#1501](https://github.com/infor-design/enterprise-wc/issues/1501))
 - `[DataGrid]` Make hyperlink cells clickable when `rowNavigation` is enabled. ([#1523](https://github.com/infor-design/enterprise-wc/issues/1523))
 - `[DataGrid]` Add `filterAlign` setting to columns for independently aligning filter row contents. ([#1575](https://github.com/infor-design/enterprise-wc/issues/1575))
+- `[DatePicker]` Set trigger field's value with today's date when today button is clicked. ([#1614](https://github.com/infor-design/enterprise-wc/issues/1614))
 - `[DatePicker]` Fixed time picker value change is not reflected dynamically in date time picker trigger field. ([#1576](https://github.com/infor-design/enterprise-wc/issues/1576))
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))
 - `[Input]` Fixed input allowing to enter not number characters when mask is number. ([#1608](https://github.com/infor-design/enterprise-wc/issues/1608))

--- a/src/components/ids-date-picker/ids-date-picker-popup.ts
+++ b/src/components/ids-date-picker/ids-date-picker-popup.ts
@@ -747,15 +747,7 @@ class IdsDatePickerPopup extends Base implements IdsRangeSettingsInterface {
             } else if (navBtn.classList.contains('btn-previous')) {
               this.monthView?.changeDate('previous-month');
             } else if (navBtn.classList.contains('btn-today')) {
-              this.monthView?.changeDate('today');
-              this.setCurrentTime();
-              if (this.target) {
-                this.value = this.localeAPI.formatDate(
-                  this.setTime(this.getActiveDate()),
-                  { pattern: this.format }
-                );
-              }
-              this.triggerSelectedEvent();
+              this.handleTodayEvent();
             }
           }
         }
@@ -947,6 +939,32 @@ class IdsDatePickerPopup extends Base implements IdsRangeSettingsInterface {
       this.hide(true);
       this.triggerSelectedEvent(e);
     }
+  }
+
+  /**
+   * Click to Today button event handler
+   * @returns {void}
+   */
+  private handleTodayEvent(): void {
+    if (!this.monthView) return;
+    this.monthView.changeDate('today');
+
+    // If range is enabled just set the start date to today
+    if (this.useRange) {
+      const rangeSettings = this.getRangeSettings();
+      rangeSettings.start = this.getActiveDate();
+      rangeSettings.end = null;
+      this.setRangeSettings(rangeSettings);
+
+      return;
+    }
+
+    this.value = this.localeAPI.formatDate(
+      this.setTime(this.getActiveDate()),
+      { pattern: this.format }
+    );
+    this.triggerSelectedEvent();
+    this.hide(true);
   }
 
   /**

--- a/src/components/ids-date-picker/ids-date-picker-popup.ts
+++ b/src/components/ids-date-picker/ids-date-picker-popup.ts
@@ -749,6 +749,13 @@ class IdsDatePickerPopup extends Base implements IdsRangeSettingsInterface {
             } else if (navBtn.classList.contains('btn-today')) {
               this.monthView?.changeDate('today');
               this.setCurrentTime();
+              if (this.target) {
+                this.value = this.localeAPI.formatDate(
+                  this.setTime(this.getActiveDate()),
+                  { pattern: this.format }
+                );
+              }
+              this.triggerSelectedEvent();
             }
           }
         }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Set trigger field's value when today button is clicked in the popup

**Related github/jira issue (required)**:
Closes #1614

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-date-picker/example.html
- check examples with Today button in the popup
- click on Today button
- see the input's value changes to today's date and the popup is closed
- go to http://localhost:4300/ids-date-picker/sandbox.html
- check `Date Time Picker AM/PM` and `Date Time Picker 24-Hour`
- set time and click Today
- see the day changed to today's date but the time doesn't change
- go to http://localhost:4300/ids-date-picker/range.html
- check the examples where range is set
- click Today and see that start date is set to today's date

**Included in this Pull Request**:
- [x] A note to the change log.

