### PR TITLE
1616 - Fix focusing on IdsDataGrid cells in first column when using the Tab key in edit mode

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[DataGrid]` Make hyperlink cells clickable when `rowNavigation` is enabled. ([#1523](https://github.com/infor-design/enterprise-wc/issues/1523))
 - `[DataGrid]` Fix virtual scrolling for tree grids. ([#1573](https://github.com/infor-design/enterprise-wc/issues/1573))/([#1587](https://github.com/infor-design/enterprise-wc/issues/1587))
 - `[DataGrid]` Add `filterAlign` setting to columns for independently aligning filter row contents. ([#1575](https://github.com/infor-design/enterprise-wc/issues/1575))
+- `[DataGrid]` Fix an issue where inline-editable cells in the first column were not considered when navigating the grid in edit mode with the Tab key. ([#1616](https://github.com/infor-design/enterprise-wc/issues/1616))
 - `[DatePicker]` Set trigger field's value with today's date when today button is clicked. ([#1614](https://github.com/infor-design/enterprise-wc/issues/1614))
 - `[DatePicker]` Fixed time picker value change is not reflected dynamically in date time picker trigger field. ([#1576](https://github.com/infor-design/enterprise-wc/issues/1576))
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))

--- a/src/components/ids-data-grid/demos/editable-inline-first.html
+++ b/src/components/ids-data-grid/demos/editable-inline-first.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid (Editable)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-toolbar>
+          <ids-toolbar-section align="end" favor>
+            <ids-menu-button id="menu-button" menu="row-height-menu">
+              <ids-icon icon="more"></ids-icon>
+              <span class="audible">Settings Menu Button</span>
+            </ids-menu-button>
+            <ids-popup-menu id="row-height-menu" target="menu-button" trigger-type="click">
+              <ids-menu-group select="single">
+                <ids-menu-header><ids-text font-weight="semi-bold">Style</ids-text></ids-menu-header>
+                <ids-menu-item value="is-list" toggleable>List</ids-menu-item>
+              </ids-menu-group>
+              <ids-menu-group select="single">
+                <ids-menu-header><ids-text font-weight="semi-bold">Row Height</ids-text></ids-menu-header>
+                <ids-menu-item value="xxs">Extra Extra Small</ids-menu-item>
+                <ids-menu-item value="xs">Extra Small</ids-menu-item>
+                <ids-menu-item value="sm">Small</ids-menu-item>
+                <ids-menu-item value="md">Medium</ids-menu-item>
+                <ids-menu-item value="lg" selected="true">Large</ids-menu-item>
+              </ids-menu-group>
+            </ids-popup-menu>
+          </ids-toolbar-section>
+        </ids-toolbar>
+        <ids-data-grid id="data-grid-editable" suppress-row-click-selection="true" row-selection="multiple" label="Books" editable="true"></ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/editable-inline-first.ts
+++ b/src/components/ids-data-grid/demos/editable-inline-first.ts
@@ -34,25 +34,6 @@ rowHeightMenu?.addEventListener('deselected', (e: Event) => {
   const url: any = booksJSON;
   const columns: IdsDataGridColumn[] = [];
 
-  // Set up columns
-  columns.push({
-    id: 'selectionCheckbox',
-    name: 'selection',
-    sortable: false,
-    resizable: false,
-    formatter: dataGrid.formatters.selectionCheckbox,
-    align: 'center'
-  });
-  columns.push({
-    id: 'rowNumber',
-    name: '#',
-    formatter: dataGrid.formatters.rowNumber,
-    sortable: false,
-    resizable: true,
-    reorderable: true,
-    readonly: true,
-    width: 65
-  });
   columns.push({
     id: 'description',
     name: 'Description',
@@ -76,7 +57,7 @@ rowHeightMenu?.addEventListener('deselected', (e: Event) => {
     field: 'ledger',
     resizable: true,
     reorderable: true,
-    formatter: dataGrid.formatters.text
+    formatter: dataGrid.formatters.text,
   });
   columns.push({
     id: 'publishDate',

--- a/src/components/ids-data-grid/demos/editable-inline.ts
+++ b/src/components/ids-data-grid/demos/editable-inline.ts
@@ -35,24 +35,25 @@ rowHeightMenu?.addEventListener('deselected', (e: Event) => {
   const columns: IdsDataGridColumn[] = [];
 
   // Set up columns
-  columns.push({
-    id: 'selectionCheckbox',
-    name: 'selection',
-    sortable: false,
-    resizable: false,
-    formatter: dataGrid.formatters.selectionCheckbox,
-    align: 'center'
-  });
-  columns.push({
-    id: 'rowNumber',
-    name: '#',
-    formatter: dataGrid.formatters.rowNumber,
-    sortable: false,
-    resizable: true,
-    reorderable: true,
-    readonly: true,
-    width: 65
-  });
+  // columns.push({
+  //   id: 'selectionCheckbox',
+  //   name: 'selection',
+  //   sortable: false,
+  //   resizable: false,
+  //   formatter: dataGrid.formatters.selectionCheckbox,
+  //   align: 'center'
+  // });
+  // columns.push({
+  //   id: 'rowNumber',
+  //   name: '#',
+  //   formatter: dataGrid.formatters.rowNumber,
+  //   sortable: false,
+  //   resizable: true,
+  //   reorderable: true,
+  //   readonly: true,
+  //   width: 65
+  // });
+
   columns.push({
     id: 'description',
     name: 'Description',
@@ -76,7 +77,7 @@ rowHeightMenu?.addEventListener('deselected', (e: Event) => {
     field: 'ledger',
     resizable: true,
     reorderable: true,
-    formatter: dataGrid.formatters.text
+    formatter: dataGrid.formatters.text,
   });
   columns.push({
     id: 'publishDate',

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -113,6 +113,9 @@
   - link: editable-inline.html
     type: Example
     description: Shows a data grid with inline editable cells
+  - link: editable-inline-first.html
+    type: Test
+    description: Shows a data grid with inline editable cells, with editable cells in the first column
   - link: expandable-row.html
     type: Example
     description: Shows a data grid with and expandable row

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -922,6 +922,10 @@ export default class IdsDataGrid extends Base {
     if (!nextCell && rows && direction === IdsDirection.Next) {
       for (let index = this.activeCell.row + 1; index < rows.length; index++) {
         const row = rows[index];
+        if ((row.firstChild as Element).classList?.contains('is-editable')) {
+          nextCell = row.firstChild as IdsDataGridCell;
+          break;
+        }
         nextCell = next(row.firstChild, '.is-editable') as IdsDataGridCell;
         if (nextCell) break;
       }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes an issue on IdsDataGrid where it was not possible to focus editable cells that were located in the first column while using the Tab key to navigate the grid in edit mode.

**Related github/jira issue (required)**:
Closes #1616

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/editable-inline-first.html
- Focus the first cell in the first column.  Change its value to enter edit mode (I used "123")
- Press the tab key 4 times.   This should loop focus around to the next row (the "Ledger" and "Price" columns are not editable and should not become focused)
- Check that focus has landed on the first cell in the second row.

**Included in this Pull Request**:
- [] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
