### PR TITLE
1586 - IdsTriggerField fix side by side example

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `[PopupMenu]` Fix arrow icon direction in RTL. ([#1545](https://github.com/infor-design/enterprise-wc/issues/1545))
 - `[Text]` Fixed wrong status warning color. ([#1619](https://github.com/infor-design/enterprise-wc/issues/1619))
 - `[Textarea]` Made sure strings are translated and fixed `character-count`` setting. ([#1598](https://github.com/infor-design/enterprise-wc/issues/1598))
+- `[Trigger Field]` Fixed side by side example. ([#1586](https://github.com/infor-design/enterprise-wc/issues/1586))
 
 ## 1.0.0-beta.16
 

--- a/src/components/ids-trigger-field/demos/side-by-side.html
+++ b/src/components/ids-trigger-field/demos/side-by-side.html
@@ -15,9 +15,8 @@
     </ids-layout-grid>
     <ids-layout-grid auto-fit="true" padding-x="md">
       <ids-layout-grid-cell>
-        <ids-trigger-field size="sm" label="Date Field" tabbable="false">
-          <ids-input label="Date Field"></ids-input>
-          <ids-trigger-button>
+        <ids-trigger-field size="sm" tabbable="false" label="Date Field">
+          <ids-trigger-button slot="trigger-end">
             <ids-text audible="true">Date Field trigger</ids-text>
             <ids-icon icon="schedule"></ids-icon>
           </ids-trigger-button>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Due to the input in the shadow DOM, `ids-input` was removed from trigger's side-by-side example. 

**Related github/jira issue (required)**:
Closes #1586 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-trigger-field/side-by-side.html
- see the trigger field web component looks the same as on http://localhost:4300/ids-trigger-field/example.html

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
