### PR TITLE
1625 - Improve handing of `tooltip` attribute in Angular environments

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `[PopupMenu]` Fix arrow icon direction in RTL. ([#1545](https://github.com/infor-design/enterprise-wc/issues/1545))
 - `[Text]` Fixed wrong status warning color. ([#1619](https://github.com/infor-design/enterprise-wc/issues/1619))
 - `[Textarea]` Made sure strings are translated and fixed `character-count`` setting. ([#1598](https://github.com/infor-design/enterprise-wc/issues/1598))
+- `[Tooltip]` Adds a check on the `tooltip` attribute to fix event handling in Angular environments. ([#1625](https://github.com/infor-design/enterprise-wc/issues/1625))
 
 ## 1.0.0-beta.16
 

--- a/src/components/ids-tooltip/ids-tooltip.ts
+++ b/src/components/ids-tooltip/ids-tooltip.ts
@@ -47,6 +47,7 @@ export default class IdsTooltip extends Base {
   connectedCallback(): void {
     super.connectedCallback();
     this.#updateAria();
+    this.#attachEventHandlers();
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes a small change to IdsTooltip to (re)-run its event handling on `connectedCallback`.  This change allows Angular components using IdsTooltip to use the target attribute directly, instead of using `[attr.target]` with an inline string.

**Related github/jira issue (required)**:
Closes #1625

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Smoke test all IdsTooltip examples to make sure there are no behavior changes: http://localhost:4300/ids-tooltip
- Run `npm run publish:link`
- Pull the Enterprise Web Components examples project, and use `npm link ids-enterprise-wc` to link your local published copy.
- Switch branches on the Enterprise Web Components examples project to use `1625-tooltip-attribute`
- Open http://localhost:4200/ids-tooltip/sandbox and check that all examples work (these are using `tooltip=` instead of `[attr.tooltip]=`)

**Included in this Pull Request**:
- [x] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
