### PR TITLE
1615 - IdsPager standalone pager datagrid override

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `[Modal]` Fix problems with slotting scrollable components and resize behavior. ([#1529](https://github.com/infor-design/enterprise-wc/issues/1529)/[#1530](https://github.com/infor-design/enterprise-wc/issues/1530))
 - `[Module Nav]` Small improvements to better enable usage in an Angular codebase. ([#1597](https://github.com/infor-design/enterprise-wc/issues/1597))
 - `[Multiselect]` Fix `rerender` logic so that state is maintained while using `ngFor` directive in Angular. ([#1411](https://github.com/infor-design/enterprise-wc/issues/1411))
+- `[Pager]` Fix datagrid standalone pager html override. ([#1615](https://github.com/infor-design/enterprise-wc/issues/1615))
 - `[PopupMenu]` Fix arrow icon direction in RTL. ([#1545](https://github.com/infor-design/enterprise-wc/issues/1545))
 - `[Tabs]` Sync component with Figma design changes related to Alabaster default theme. ([#1050](https://github.com/infor-design/enterprise-wc/issues/1050))
 - `[PopupMenu]` Fix arrow icon direction in RTL. ([#1545](https://github.com/infor-design/enterprise-wc/issues/1545))

--- a/src/components/ids-data-grid/demos/pagination-standalone.html
+++ b/src/components/ids-data-grid/demos/pagination-standalone.html
@@ -21,7 +21,12 @@
           page-number="1"
           page-size="10">
         </ids-data-grid>
-        <ids-pager />
+        <ids-pager>
+          <ids-pager-button previous></ids-pager-button>
+          <ids-pager-input></ids-pager-input>
+          <ids-pager-button next></ids-pager-button>
+          <ids-pager-dropdown slot="end" label="Sample Text"></ids-pager-dropdown> 
+        </ids-pager>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/mixins/ids-pager-mixin/ids-pager-mixin.ts
+++ b/src/mixins/ids-pager-mixin/ids-pager-mixin.ts
@@ -50,7 +50,7 @@ const IdsPagerMixin = <T extends Constraints>(superclass: T) => class extends su
     const pageSize = Math.max(this.pageSize || 0, 1);
 
     this.datasource.pageSize = pageSize;
-    this.pager.innerHTML = this.pagerTemplate();
+    if (this.pagination !== PAGINATION_TYPES.STANDALONE) this.pager.innerHTML = this.pagerTemplate();
     this.pager.total = this.datasource.total;
     this.pager.pageNumber = pageNumber;
     this.pager.pageSize = pageSize;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes a problem where a user defined pager in `standalone` pagination mode is being overridden by a default pager template in  the IdsPagerMixin.

**Related github/jira issue (required)**:
Closes #1615 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/pagination-standalone.html
3. Check that the pager in the example matches the template in `src/components/ids-data-grid/demos/pagination-standalone.html`
4. Smoke test the other datagrid pagination examples
5. http://localhost:4300/ids-data-grid/pagination-client-side.html
6. http://localhost:4300/ids-data-grid/pagination-server-side.html

**Included in this Pull Request**:
- [ ] A test for the bug or feature.
- [x] A note to the change log.
