### PR TITLE
1664 - IdsDataGrid empty message height

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[DataGrid]` Fix virtual scrolling for tree grids. ([#1573](https://github.com/infor-design/enterprise-wc/issues/1573))/([#1587](https://github.com/infor-design/enterprise-wc/issues/1587))
 - `[DataGrid]` Add `filterAlign` setting to columns for independently aligning filter row contents. ([#1575](https://github.com/infor-design/enterprise-wc/issues/1575))
 - `[DataGrid]` Fix an issue where inline-editable cells in the first column were not considered when navigating the grid in edit mode with the Tab key. ([#1616](https://github.com/infor-design/enterprise-wc/issues/1616))
+- `[DataGrid]` Fix an issue where empty message permanently removes the datagrid container height. ([#1664](https://github.com/infor-design/enterprise-wc/issues/1664))
 - `[DatePicker]` Set trigger field's value with today's date when today button is clicked. ([#1614](https://github.com/infor-design/enterprise-wc/issues/1614))
 - `[DatePicker]` Fixed time picker value change is not reflected dynamically in date time picker trigger field. ([#1576](https://github.com/infor-design/enterprise-wc/issues/1576))
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.18
+
+### 1.0.0-beta.18 Fixes
+
+- `[DataGrid]` Fix an issue where empty message permanently removes the datagrid container height. ([#1664](https://github.com/infor-design/enterprise-wc/issues/1664))
+
 ## 1.0.0-beta.17
 
 ### 1.0.0-beta.17 Breaking Changes
@@ -26,7 +32,6 @@
 - `[DataGrid]` Fix virtual scrolling for tree grids. ([#1573](https://github.com/infor-design/enterprise-wc/issues/1573))/([#1587](https://github.com/infor-design/enterprise-wc/issues/1587))
 - `[DataGrid]` Add `filterAlign` setting to columns for independently aligning filter row contents. ([#1575](https://github.com/infor-design/enterprise-wc/issues/1575))
 - `[DataGrid]` Fix an issue where inline-editable cells in the first column were not considered when navigating the grid in edit mode with the Tab key. ([#1616](https://github.com/infor-design/enterprise-wc/issues/1616))
-- `[DataGrid]` Fix an issue where empty message permanently removes the datagrid container height. ([#1664](https://github.com/infor-design/enterprise-wc/issues/1664))
 - `[DatePicker]` Set trigger field's value with today's date when today button is clicked. ([#1614](https://github.com/infor-design/enterprise-wc/issues/1614))
 - `[DatePicker]` Fixed time picker value change is not reflected dynamically in date time picker trigger field. ([#1576](https://github.com/infor-design/enterprise-wc/issues/1576))
 - `[FlexLayout]` Added a flex example using IdsButtons and IdsInputs. ([#1395](https://github.com/infor-design/enterprise-wc/issues/1395))

--- a/src/components/ids-data-grid/ids-data-grid-empty-message.ts
+++ b/src/components/ids-data-grid/ids-data-grid-empty-message.ts
@@ -12,6 +12,10 @@ export interface IdsDataGridEmptyMessageElements {
   em?: IdsEmptyMessage;
   /* Description element for empty message */
   emDesc?: IdsText;
+  /* Description element container */
+  emDescContainer?: HTMLElement;
+  /* Button element container */
+  emBtnContainer?: HTMLElement;
   /* Is this use slotted element for empty message */
   emIsSlotted?: boolean;
   /* Label element for empty message */
@@ -74,6 +78,8 @@ export function setEmptyMessageElements(this: IdsDataGrid): void {
   this.emptyMessageElements = {
     em,
     emDesc: em?.querySelector('[slot="description"]') as IdsText,
+    emDescContainer: em?.container?.querySelector('.description') as HTMLElement,
+    emBtnContainer: em?.container?.querySelector('.button') as HTMLElement,
     emIsSlotted: !!slotted,
     emLabel: em?.querySelector('[slot="label"]') as IdsText,
     vs: this.shadowRoot?.querySelector('ids-virtual-scroll') as IdsVirtualScroll
@@ -99,15 +105,25 @@ export function showEmptyMessage(this: IdsDataGrid): void {
 
   // Set elements
   if (this.initialized && !this.emptyMessageElements) setEmptyMessageElements.apply(this);
-  const { em, emDesc, vs } = this.emptyMessageElements || {};
+  const {
+    em,
+    emDesc,
+    emDescContainer,
+    emBtnContainer,
+    vs
+  } = this.emptyMessageElements || {};
 
   // Empty message
   em?.removeAttribute('hidden');
 
   // Filtered (show/hide description element)
   const isFiltered = (this.datasource as any).filtered;
-  if (isFiltered) emDesc?.removeAttribute('hidden');
-  else emDesc?.setAttribute('hidden', '');
+  emDescContainer?.toggleAttribute('hidden', !isFiltered);
+  emDesc?.toggleAttribute('hidden', !isFiltered);
+
+  // Hide button is one isn't provided
+  const slottedBtn = emBtnContainer?.querySelector<HTMLSlotElement>('slot[name="button"]')?.assignedElements();
+  emBtnContainer?.toggleAttribute('hidden', !slottedBtn?.length);
 
   // Virtual scroll
   if (this.virtualScroll) {

--- a/src/components/ids-data-grid/ids-data-grid-empty-message.ts
+++ b/src/components/ids-data-grid/ids-data-grid-empty-message.ts
@@ -112,7 +112,6 @@ export function showEmptyMessage(this: IdsDataGrid): void {
   // Virtual scroll
   if (this.virtualScroll) {
     vs?.setAttribute('hidden', '');
-    this.container?.style.setProperty('height', '');
   }
 
   this.wrapper?.classList.add('has-empty-message');

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -375,5 +375,6 @@ table.ids-data-grid {
 
   .ids-data-grid {
     min-height: var(--ids-data-grid-height-min);
+    height: unset !important;
   }
 }

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -361,20 +361,20 @@ table.ids-data-grid {
 // Empty Message
 .ids-data-grid-wrapper.has-empty-message {
   position: relative;
-  display: grid;
 
   ids-empty-message:not([hidden]),
   ::slotted(ids-empty-message:not([hidden])) {
-    position: absolute;
     display: flex;
-    align-self: center;
-    justify-self: center;
-    top: 80px;
-    bottom: 20px;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    justify-content: center;
+    align-items: center;
+    top: 0;
+    pointer-events: none;
   }
 
   .ids-data-grid {
     min-height: var(--ids-data-grid-height-min);
-    height: unset !important;
   }
 }

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -2618,7 +2618,7 @@ export default class IdsDataGrid extends Base {
     this.removeAttribute(attributes.AUTO_FIT);
   }
 
-  get autoFit(): boolean | string | null {
+  get autoFit(): boolean {
     return stringToBool(this.getAttribute(attributes.AUTO_FIT));
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes an issue where the datagrid container loses its original inline style height when empty message mode is enabled.
https://github.com/infor-design/enterprise-wc/blob/349398009a9e081244c44d3c82044ad13442cb52/src/components/ids-data-grid/ids-data-grid-empty-message.ts#L115
I moved the line above to css where `height: unset !important` is only applied when ids-data-grid `.has-empty-message`.
The inline height applied by `auto-fit` should remain intact

**Related github/jira issue (required)**:
Closes #1664 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/virtual-scroll.html
3. Run `const copy = $('ids-data-grid').data;` to create data copy
4. Run `$('ids-data-grid').data = [];` to make datagrid empty
5. Run `$('ids-data-grid').data = copy;` to re populate datagrid
6. Check that datagrid virtual-scroll still works ok
7. Also test on http://localhost:4300/ids-data-grid/example.html, to check non-virtual scroll examples

**Included in this Pull Request**:
- [ ] A test for the bug or feature.
- [x] A note to the change log.

