### PR TITLE
1553 - IdsValidationMixin: Allow required indicator display separate from validation rules

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Tree]` Added `beforeExpanded` async loading pattern to dynamically add tree children. ([#1516](https://github.com/infor-design/enterprise-wc/issues/1516))
 - `[Tree]` Renamed `useToggleTarget` to `expandTarget`, now available as a setting to toggle tree nodes only when clicking the icon. ([#1528](https://github.com/infor-design/enterprise-wc/issues/1528))
 - `[Tests]` Changed test framework to playwright. ([#1225](https://github.com/infor-design/enterprise-wc/issues/1225))
+- `[ValidationMixin]` Added a `required` attribute that can be used separately from `validate="required"` simply to display a required indicator. ([#1553](https://github.com/infor-design/enterprise-wc/issues/1553))
 
 ### 1.0.0-beta.17 Fixes
 

--- a/src/components/ids-input/README.md
+++ b/src/components/ids-input/README.md
@@ -52,7 +52,13 @@ Set the Dirty Tracking to Text Input this way. You can also call `resetDirtyTrac
 <ids-input label="Dirty Tracking" dirty-tracker="true"></ids-input>
 ```
 
-Set validation `required` to Text Input this way:
+To set the visible validation `required` indicator you can use the required attribute:
+
+```html
+<ids-input label="Last Name" required></ids-input>
+```
+
+Set validation to `required` and the indicator you can use:
 
 ```html
 <ids-input label="Last Name" validate="required"></ids-input>
@@ -146,7 +152,8 @@ setData();
 - `readonly` {boolean} sets the input's readonly state.
 - `text-align` {string} sets the text alignment (default is `left`).
 - `type` {string} set the input type, (default is `text`)
-- `validate` {string} sets the input validation rules, use `space` to add multiple validation rules.
+- `type` {string} set the input type, (default is `text`)
+- `required` {string} sets visible required indicator no matter what the validate is set to
 - `format` {string} if the validation rules include date/time, use the setting to set custom date/time format
 - `validationEvents` {string} set the input validation events, use `space` to add multiple validation rules, it will set `blur` as defaults.
 - `value` {string} sets the input value.

--- a/src/components/ids-input/demos/index.yaml
+++ b/src/components/ids-input/demos/index.yaml
@@ -20,6 +20,9 @@
   - link: validation-date-time.html
     type: Example
     description: Shows date/time validation and masks
+  - link: validation-required.html
+    type: Test
+    description: Shows required indicator display under different conditions
   - link: label-state.html
     type: Test
     description: Showing an example with hidden labels

--- a/src/components/ids-input/demos/validation-required.html
+++ b/src/components/ids-input/demos/validation-required.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-layout-grid-cell col-span="4" col-span-md="12">
+        <ids-text font-size="12" type="h1">Input - Required Validation</ids-text><br />
+        <ids-text type="p">The fields below demonstrate how to apply a "required" validation indicator in different ways.  The last field shows how to apply custom validation with a required indicator.  Remove text from the fields to see how error messages are applied.</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto-fit="true" gap="md" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-input label="No validation" id="input-validation-none" value="Some text"></ids-input>
+        <ids-input label="No validation + required indicator" id="input-validation-indicator" value="Some text" required></ids-input>
+        <ids-input label="Required validation" id="input-validation-required" value="Some text" validate="required"></ids-input>
+        <ids-input label="Custom validation + required indicator" id="input-validation-custom" value="Some text" validate="custom" required></ids-input>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-input/demos/validation-required.ts
+++ b/src/components/ids-input/demos/validation-required.ts
@@ -1,0 +1,14 @@
+import '../ids-input';
+
+import type IdsInput from '../ids-input';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const inputCustomValidation = document.querySelector<IdsInput>('#input-validation-custom')!;
+
+  inputCustomValidation.addValidationRule({
+    check: (input: any) => input.value,
+    message: 'Please complete this field',
+    type: 'error',
+    id: 'my-custom-required'
+  });
+});

--- a/src/mixins/ids-validation-mixin/README.md
+++ b/src/mixins/ids-validation-mixin/README.md
@@ -88,6 +88,7 @@ Set a validation message thru html markup.
   validation-icon="mail"
 ></ids-input>
 ```
+
 ### Set Thru JavaScript
 
 Add/Remove a single message.
@@ -178,6 +179,12 @@ There are built in validation rules can be use with the mixin as list below.
 <ids-input label="Required Validation" validate="required"></ids-input>
 <ids-input label="Email Validation" validate="email"></ids-input>
 <ids-input label="Email and Required Validation" validate="email required"></ids-input>
+```
+
+If you only want the required indicator and custom or no validation you can use.
+
+```html
+<ids-input label="Required Validation" required></ids-input>
 ```
 
 ## Custom Rules


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes some adjustments to IdsValidationMixin, creating a `required` boolean attribute that can be set outside of using `validate="required"` 

**Related github/jira issue (required)**:
Closes #1553

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-input/validation-required.html
- See that the bottom 3 input fields have a required validation indicator.  The 2nd and 4th fields down are configured to display the required indicator simply by using `<ids-input required>`.
- Remove the text from all 4 fields.  Only the 3rd and 4th fields down display a validation message.  The 4th field down has custom validation applied (which mimics the required validation rule but is NOT the built-in "required" rule), and shows as "required" due to the new attribute only.

Also review other required examples for accuracy.  Some I've found are:
- http://localhost:4300/ids-input/example.html (Last name and Email fields)
- http://localhost:4300/ids-trigger-field/example.html (Photos field)
- http://localhost:4300/ids-dropdown/example.html ("required" Dropdown)

**Included in this Pull Request**:
- [x] A test for the bug or feature.
- [x] A note to the change log.