### PR TITLE
1600 - Make IdsDropdown in IdsDataGridCell attach its list to the Datagrid container

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.18 Fixes
 
+- `[DataGrid]` Fix dropdown cells to no longer open their lists inside cells (attach to grid instead). ([#1600](https://github.com/infor-design/enterprise-wc/issues/1600))
 - `[DataGrid]` Add number mask to pager input. ([#1613](https://github.com/infor-design/enterprise-wc/issues/1613))
 
 ## 1.0.0-beta.17

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -91,7 +91,8 @@
 
   // Focus State
   &:focus,
-  &.is-editing:not(.is-inline):focus-within {
+  &.is-editing:not(.is-inline):focus-within,
+  &.is-focused {
     box-shadow: var(--ids-shadow-20);
     outline: 1px solid var(--ids-color-border-focus);
     outline-offset: -1px;
@@ -143,7 +144,7 @@
     }
 
     .editor-cell-icon {
-      margin-inline-end: 12px;
+      margin-inline-end: 14px;
       margin-block-start: 2px;
       display: none;
     }
@@ -183,7 +184,6 @@
   }
 
   // Editing with popups
-  &.is-editing.is-dropdown,
   &.is-editing.is-lookup,
   &.is-editing.is-datepicker,
   &.is-editing.is-timepicker {
@@ -197,28 +197,12 @@
     }
   }
 
-  // Dropdown Editing
-  &.is-editing.is-dropdown {
-    &.is-dirty::before {
-      margin-inline: 3px;
-    }
-  }
-
-  // Dropdown Editing Borderless
-  &.is-editing.is-dropdown:not(.is-inline) {
-    border-left-width: 0;
-  }
-
   // Dropdown Editing Inline
   &.is-editing.is-dropdown.is-inline {
     box-shadow: none;
 
     ids-dropdown {
       padding: 0 4px;
-    }
-
-    &.is-dirty::before {
-      margin-inline: 6px;
     }
   }
 

--- a/src/components/ids-data-grid/ids-data-grid-editors.ts
+++ b/src/components/ids-data-grid/ids-data-grid-editors.ts
@@ -17,7 +17,6 @@ import type IdsTimePickerPopup from '../ids-time-picker/ids-time-picker-popup';
 import '../ids-time-picker/ids-time-picker';
 import '../ids-date-picker/ids-date-picker';
 import '../ids-lookup/ids-lookup';
-import { cssTransitionTimeout } from '../../utils/ids-timer-utils/ids-timer-utils';
 
 export interface IdsDataGridEditorOptions {
   /** The type of editor (i.e. text, data, time, dropdown, checkbox, number ect) */

--- a/src/components/ids-dropdown/ids-dropdown.scss
+++ b/src/components/ids-dropdown/ids-dropdown.scss
@@ -74,11 +74,16 @@ ids-trigger-field[readonly-background]:not([disabled])::part(input) {
 // Dropdown Editor Borderless
 .ids-dropdown.color-variant-borderless {
   ids-trigger-field::part(container) {
-    margin: 0;
+    margin: -1px;
   }
 
   ids-trigger-field::part(field-container) {
     box-shadow: none !important;
+  }
+
+  .ids-trigger-field-slot-trigger-end,
+  ::slotted(*[slot='trigger-end']:last-of-type:not([inline]):not([compact]):not([field-height='xs'])) {
+    margin-inline-end: 0;
   }
 
   &.field-height-lg {

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -239,6 +239,7 @@ export default class IdsDropdown extends Base {
         ${this.validate && this.validationEvents ? ` validation-events="${this.validationEvents}"` : ''}
       >
         <ids-trigger-button
+          class="ids-trigger-field-slot-trigger-end"
           id="triggerBtn-${this.id ? this.id : ''}"
           slot="trigger-end"
           part="trigger-button"
@@ -648,7 +649,7 @@ export default class IdsDropdown extends Base {
   loadDataSet(dataset: IdsDropdownOptions) {
     let html = '';
 
-    const listbox = this.querySelector('ids-list-box');
+    const listbox = this.dropdownList?.querySelector('ids-list-box') || this.querySelector('ids-list-box');
     if (listbox) listbox.innerHTML = '';
 
     dataset.forEach((option: IdsDropdownOption) => {
@@ -1097,7 +1098,7 @@ export default class IdsDropdown extends Base {
   #templatelistBoxOption(option: IdsDropdownOption): string {
     return `<ids-list-box-option
       ${option.id ? `id=${option.id}` : ''}
-      ${option.value ? `value="${option.value}"` : 'value=""'}
+      ${option.value ? `value="${option.value}"` : /* 'value=""' */ ''}
       ${option.groupLabel ? 'group-label' : ''}>${option.icon ? `<ids-icon icon="${option.icon}"></ids-icon>` : ''}${option.label || ''}</ids-list-box-option>`;
   }
 

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -498,26 +498,44 @@ $input-size-full: 100%;
       box-shadow: none;
     }
 
-    &.ids-input.field-height-lg .ids-input-field {
-      padding-inline: calc(var(--ids-space-60) - 2px);
+    &.ids-input.field-height-lg {
+      .ids-input-field {
+        padding-inline: calc(var(--ids-space-60) - 2px);
+      }
     }
 
-    &.ids-input.field-height-md .ids-input-field {
-      padding-inline: calc(var(--ids-space-50) - 2px);
+    &.ids-input.field-height-md {
+      .ids-input-field {
+        padding-inline: calc(var(--ids-space-50) - 2px);
+      }
     }
 
-    &.ids-input.field-height-sm .ids-input-field {
-      padding-inline: calc(var(--ids-space-40) - 2px);
+    &.ids-input.field-height-sm {
+      .ids-input-field {
+        padding-inline: calc(var(--ids-space-40) - 2px);
+      }
     }
 
-    &.ids-input.field-height-xs .ids-input-field {
-      font-size: var(--ids-data-grid-font-size-sm);
-      padding-inline: var(--ids-space-20);
+    &.ids-input.field-height-xs {
+      .ids-input-field {
+        font-size: var(--ids-data-grid-font-size-sm);
+        padding-inline: var(--ids-space-20);
+      }
+
+      slot[name=trigger-end]  {
+        padding-inline-end: 0;
+      }
     }
 
-    &.ids-input.field-height-xxs .ids-input-field {
-      font-size: var(--ids-data-grid-font-size-sm);
-      padding-inline: var(--ids-space-10);
+    &.ids-input.field-height-xxs {
+      .ids-input-field {
+        font-size: var(--ids-data-grid-font-size-sm);
+        padding-inline: var(--ids-space-10);
+      }
+
+      slot[name=trigger-end]  {
+        padding-inline-end: 0;
+      }
     }
   }
 

--- a/src/components/ids-input/ids-input.scss
+++ b/src/components/ids-input/ids-input.scss
@@ -522,7 +522,7 @@ $input-size-full: 100%;
         padding-inline: var(--ids-space-20);
       }
 
-      slot[name=trigger-end]  {
+      slot[name="trigger-end"]  {
         padding-inline-end: 0;
       }
     }
@@ -533,7 +533,7 @@ $input-size-full: 100%;
         padding-inline: var(--ids-space-10);
       }
 
-      slot[name=trigger-end]  {
+      slot[name="trigger-end"]  {
         padding-inline-end: 0;
       }
     }

--- a/src/components/ids-list-box/ids-list-box-option.scss
+++ b/src/components/ids-list-box/ids-list-box-option.scss
@@ -12,7 +12,6 @@
   text-indent: 8px;
   user-select: none;
   min-width: calc(var(--ids-input-width-10) - 2px);
-  max-width: 298px;
   text-transform: capitalize;
   text-overflow: ellipsis;
   width: 100%;

--- a/src/components/ids-list-box/ids-list-box.scss
+++ b/src/components/ids-list-box/ids-list-box.scss
@@ -18,7 +18,6 @@ $border-input-field-height-lg: calc(var(--ids-input-height-40) - 2px);
   max-height: var(--ids-input-width-40);
   scroll-behavior: smooth;
   min-width: $border-input-size-xs;
-  max-width: $border-input-size-md;
   width: var(--ids-input-width-full);
 }
 

--- a/tests/ids-dropdown/snapshots/dropdown-shadow.snap
+++ b/tests/ids-dropdown/snapshots/dropdown-shadow.snap
@@ -1,7 +1,7 @@
 
     <div class="ids-dropdown field-height-md" part="container" tooltip="California">
       <ids-trigger-field id="triggerField-dropdown-1" readonly="true" readonly-background="true" size="md" label="Normal Dropdown with Dirty Tracker" part="trigger-field" exportparts="container: triggerfield-container, field-container: triggerfield-field-container, content-area: triggerfield-content-area, input: triggerfield-input, popup: triggerfield-popup" field-height="md" list="#dropdownList-dropdown-1" value="California">
-        <ids-trigger-button id="triggerBtn-dropdown-1" slot="trigger-end" part="trigger-button" field-height="md">
+        <ids-trigger-button class="ids-trigger-field-slot-trigger-end" id="triggerBtn-dropdown-1" slot="trigger-end" part="trigger-button" field-height="md">
           <ids-text audible="true" translate-text="true" translation-key="DropdownTriggerButton">Click to open dropdown</ids-text>
           <ids-icon icon="dropdown" part="icon"></ids-icon>
         </ids-trigger-button>

--- a/tests/ids-multiselect/snapshots/multiselect-shadow.snap
+++ b/tests/ids-multiselect/snapshots/multiselect-shadow.snap
@@ -1,7 +1,7 @@
 
     <div class="ids-dropdown field-height-md has-value" part="container">
       <ids-trigger-field id="triggerField-dropdown-1" readonly="true" readonly-background="true" size="md" label="Multiselect (with max 3 choices and dirty tracker)" part="trigger-field" exportparts="container: triggerfield-container, field-container: triggerfield-field-container, content-area: triggerfield-content-area, input: triggerfield-input, popup: triggerfield-popup" field-height="md" list="#dropdownList-dropdown-1" value="California, New Jersey"><ids-text overflow="ellipsis" tooltip="true">California, New Jersey</ids-text>
-        <ids-trigger-button id="triggerBtn-dropdown-1" slot="trigger-end" part="trigger-button" field-height="md">
+        <ids-trigger-button class="ids-trigger-field-slot-trigger-end" id="triggerBtn-dropdown-1" slot="trigger-end" part="trigger-button" field-height="md">
           
           <ids-icon icon="dropdown" part="icon"></ids-icon>
         </ids-trigger-button>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes a visual bug that was making the IdsDataGrid display a scrollbar in some cases when opening an IdsDropdown cell's list, causing a visual shift on all cells.  The fix was to make the IdsDropdownList that was previously inside the editor external, similar to the previous work we did on all filter row popups, date cells, and time cells.

**Related github/jira issue (required)**:
Closes #1600

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4300/ids-data-grid/editable.html
- Using the "currency" column, open the dropdown editor in any cell.  Selecting an item from the list should work, and commit the value.
- Try opening the cells closer to the bottom of the grid.  Resize the browser viewport so the menu can bleed off the bottom of the grid (see screenshot).  This should be possible and not cause a scrollbar to appear.
- Try using keyboard to navigate, and different row heights

![Screenshot 2023-12-11 at 10 35 44 AM](https://github.com/infor-design/enterprise-wc/assets/3249601/f0f0a3e0-b716-4fcb-81fb-ca6f0bd35a77)

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
