### PR TITLE
1602 - IdsDataGrid tree xxs height dirty indicator alignment

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.18 Fixes
 
 - `[DataGrid]` Add number mask to pager input. ([#1613](https://github.com/infor-design/enterprise-wc/issues/1613))
+- `[DataGrid]` Fix dirty indicator alignment for xxs row height. ([#1602](https://github.com/infor-design/enterprise-wc/issues/1602))
 
 ## 1.0.0-beta.17
 

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -507,8 +507,11 @@ td.ids-data-grid-cell {
       border-inline-end-width: 0;
     }
 
-    &.is-dirty::before {
-      border-color: var(--ids-input-dirty-indicator-color-background-dirty)  var(--ids-input-dirty-indicator-color-background-dirty) transparent  transparent;
+    &.is-dirty {
+      .ids-data-grid-tree-field-container::before,
+      &::before {
+        border-color: var(--ids-input-dirty-indicator-color-background-dirty)  var(--ids-input-dirty-indicator-color-background-dirty) transparent  transparent;
+      }
     }
   }
 }

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -223,7 +223,7 @@
   );
 
   $row-height-outline-offsets: (
-    'xxs': 4,
+    'xxs': 2,
     'xs': 2,
     'sm': 5,
     'md': 8,


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fix dirty indicator icon alignment for tree grids with row height of xxs.
Fix rtl style of dirty indicator for tree grid inline inputs.

**Related github/jira issue (required)**:
Closes #1602 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/tree-grid-inline.html
3. Make changes to inline inputs to show dirty indicators
4. Change rowHeight to xxs `$('ids-data-grid').rowHeight = 'xxs';`
5. Check dirty icon alignment
6. Change to RTL language and check that dirty icon is flipped

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

