### PR TITLE
1601 - IdsDataGrid move dirty cells after column reorder

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.18 Fixes
 
 - `[DataGrid]` Add number mask to pager input. ([#1613](https://github.com/infor-design/enterprise-wc/issues/1613))
+- `[DataGrid]` Fix dirty indicator cell data after column reorder. ([#1601](https://github.com/infor-design/enterprise-wc/issues/1601))
 
 ## 1.0.0-beta.17
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -697,18 +697,19 @@ export default class IdsDataGrid extends Base {
     this.columns.splice(correctFromIndex, 1);
     this.columns.splice(correctToIndex, 0, element);
 
-    // Move the dirty data
-    this.dirtyCells.forEach((dirtyRow: Record<string, any>) => {
-      if (dirtyRow.cell === fromIndex) {
-        const row: any = this.data[dirtyRow?.row];
-        const cellIndex = row.dirtyCells.findIndex((item: any) => item.cell === fromIndex);
-        row.dirtyCells[cellIndex].cell = toIndex;
-      }
-      if (dirtyRow.cell === toIndex) {
-        const row: any = this.data[dirtyRow?.row];
-        const cellIndex = row.dirtyCells.findIndex((item: any) => item.cell === toIndex);
-        row.dirtyCells[cellIndex].cell = fromIndex;
-      }
+    // Map column id to new column index
+    const colIdToCellIndex = this.columns.reduce((obj, curr, idx) => {
+      obj[curr.id] = idx;
+      return obj;
+    }, {} as Record<string, number>);
+
+    // Move the dirty cell data
+    this.dirtyCells.forEach((dirtyCell: Record<string, any>) => {
+      const dirtyCellId = dirtyCell.columnId;
+      const row: any = this.data[dirtyCell?.row];
+      const cellIndex = row.dirtyCells.findIndex((item: any) => item.columnId === dirtyCellId);
+      const newCellIndex = colIdToCellIndex[dirtyCellId];
+      row.dirtyCells[cellIndex].cell = newCellIndex;
     });
 
     // Move the validation data


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed issue where the dirty cell indicators were not being moved after a column is reordered.

**Related github/jira issue (required)**:
Closes #1601 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/editable-inline.html
3. Update some datagrid cells to show dirty indicator
4. Reorder some columns
5. Check that the dirty cell indicators are correctly moved after columns are reordered
6. Check dirty cell data integrity via `$('ids-data-grid').dirtyCells`

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
