### PR TITLE
1676 - Re-add responsive demos to axis chart

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.18 Fixes
 
+- `[AxisChart]` Re-added a responsive example. ([#1676](https://github.com/infor-design/enterprise-wc/issues/1676))
 - `[DataGrid]` Add number mask to pager input. ([#1613](https://github.com/infor-design/enterprise-wc/issues/1613))
 - `[DataGrid]` Fix an issue where empty message permanently removes the datagrid container height. ([#1664](https://github.com/infor-design/enterprise-wc/issues/1664))
 

--- a/src/components/ids-axis-chart/demos/in-widget.html
+++ b/src/components/ids-axis-chart/demos/in-widget.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Axis Chart (responsive)</ids-text>
+    </ids-layout-grid>
+
+    <ids-home-page>
+      <ids-widget slot="widget" padding-y="4">
+        <div slot="widget-header">
+          <ids-text font-size="20" type="h2" overflow="ellipsis" tooltip="true">Axis Chart</ids-text>
+        </div>
+        <div slot="widget-content">
+          <ids-axis-chart
+            slot="card-content"
+            title="A line chart showing component usage"
+            width="340"
+            height="265"
+            show-tooltip="false"
+            id="index-example">
+          </ids-axis-chart>
+        </div>
+      </ids-widget>
+      <ids-widget slot="widget" padding-y="4">
+        <div slot="widget-header">
+          <ids-text font-size="20" type="h2" overflow="ellipsis" tooltip="true">Bar Chart</ids-text>
+        </div>
+        <div slot="widget-content">
+          <ids-bar-chart
+            slot="card-content"
+            id="bar-chart-example"
+            title="Bar Chart horizontal rotate name labels"
+            width="340"
+            height="265"
+            animated="false"
+            show-tooltip="false"
+            horizontal>
+          </ids-bar-chart>
+        </div>
+      </ids-widget>
+      <ids-widget slot="widget" padding-y="4">
+        <div slot="widget-header">
+          <ids-text font-size="20" type="h2" overflow="ellipsis" tooltip="true">Line Chart</ids-text>
+        </div>
+        <div slot="widget-content">
+          <ids-line-chart
+            slot="card-content"
+            title="A line chart showing component usage"
+            width="340"
+            height="265"
+            id="line-chart-example"
+            show-vertical-grid-lines="true"
+            show-tooltip="false">
+          </ids-line-chart>
+        </div>
+      </ids-widget>
+    </ids-home-page>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-axis-chart/demos/in-widget.ts
+++ b/src/components/ids-axis-chart/demos/in-widget.ts
@@ -4,11 +4,8 @@ import '../../ids-card/ids-card';
 import '../../ids-bar-chart/ids-bar-chart';
 import '../../ids-line-chart/ids-line-chart';
 import '../../ids-home-page/ids-home-page';
-import type IdsAxisChart from '../ids-axis-chart';
-import css from '../../../assets/css/ids-data-grid/auto-fit.css';
 
-const cssLink = `<link href="${css}" rel="stylesheet">`;
-document.querySelector('head')?.insertAdjacentHTML('afterbegin', cssLink);
+import type IdsAxisChart from '../ids-axis-chart';
 
 const setData = async () => {
   const res = await fetch(componentsJSON as any);

--- a/src/components/ids-axis-chart/demos/index.yaml
+++ b/src/components/ids-axis-chart/demos/index.yaml
@@ -26,6 +26,9 @@
   - link: responsive.html
     type: Example
     description: Shows responsive example
+  - link: in-widget.html
+    type: Example
+    description: Shows charts in widgets
   - link: ticks.html
     type: Example
     description: Shows controling the ticks with a setting

--- a/src/components/ids-axis-chart/demos/responsive.html
+++ b/src/components/ids-axis-chart/demos/responsive.html
@@ -5,62 +5,25 @@
   <%= htmlWebpackPlugin.options.font %>
 </head>
 <body>
+
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
     <ids-layout-grid auto-fit="true" padding="md">
       <ids-text font-size="12" type="h1">Axis Chart (responsive)</ids-text>
     </ids-layout-grid>
 
-    <ids-home-page>
-      <ids-widget slot="widget" padding-y="4">
-        <div slot="widget-header">
-          <ids-text font-size="20" type="h2" overflow="ellipsis" tooltip="true">Axis Chart</ids-text>
-        </div>
-        <div slot="widget-content">
-          <ids-axis-chart
-            slot="card-content"
-            title="A line chart showing component usage"
-            width="340"
-            height="265"
-            show-tooltip="false"
-            id="index-example">
-          </ids-axis-chart>
-        </div>
-      </ids-widget>
-      <ids-widget slot="widget" padding-y="4">
-        <div slot="widget-header">
-          <ids-text font-size="20" type="h2" overflow="ellipsis" tooltip="true">Bar Chart</ids-text>
-        </div>
-        <div slot="widget-content">
-          <ids-bar-chart
-            slot="card-content"
-            id="bar-chart-example"
-            title="Bar Chart horizontal rotate name labels"
-            width="340"
-            height="265"
-            animated="false"
-            show-tooltip="false"
-            horizontal>
-          </ids-bar-chart>
-        </div>
-      </ids-widget>
-      <ids-widget slot="widget" padding-y="4">
-        <div slot="widget-header">
-          <ids-text font-size="20" type="h2" overflow="ellipsis" tooltip="true">Line Chart</ids-text>
-        </div>
-        <div slot="widget-content">
-          <ids-line-chart
-            slot="card-content"
-            title="A line chart showing component usage"
-            width="340"
-            height="265"
-            id="line-chart-example"
-            show-vertical-grid-lines="true"
-            show-tooltip="false">
-          </ids-line-chart>
-        </div>
-      </ids-widget>
-    </ids-home-page>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <div class="parent-container">
+        <ids-axis-chart
+          slot="card-content"
+          title="A line chart showing component usage"
+          width="inherit"
+          height="inherit"
+          show-tooltip="false"
+          id="index-example">
+        </ids-axis-chart>
+      </div>
+    </ids-layout-grid>
   </ids-container>
 </body>
 </html>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adjusting some recent work to rename some examples and show an axis chart with height/width set to disabled. Could not provoke the error.

**Related github/jira issue (required)**:
Fixes #1676 

**Steps necessary to review your pull request (required)**:
- http://localhost:4300/ids-axis-chart/responsive.html -> new example added and shows a height constrained to 500px but fill width
- http://localhost:4300/ids-axis-chart/in-widget.html -> moved the widget examples to their own example

**Included in this Pull Request**:
- [x] A test for the bug or feature.
- [x] A note to the change log.
