### PR TITLE
1290 - Fix to set menu arrow property

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.19
+
+### 1.0.0-beta.19 Features
+
+- `[PopupMenu]` Added ability to set `arrow` on the IdsPopupMenu so that it filters down to IdsPopup underneath, can now disable or change arrow direction. ([#1290](https://github.com/infor-design/enterprise-wc/issues/1290))
+
 ## 1.0.0-beta.18
 
 ### 1.0.0-beta.18 Breaking Changes

--- a/src/components/ids-menu-button/demos/example.html
+++ b/src/components/ids-menu-button/demos/example.html
@@ -10,12 +10,12 @@
     <ids-layout-grid auto-fit="true" padding="md">
       <ids-text font-size="12" type="h1">Menu Buttons</ids-text>
     </ids-layout-grid>
-    <ids-layout-grid cols="4" gap="md" padding-x="md">
+    <ids-layout-grid cols="2" gap="md" padding-x="md">
       <ids-layout-grid-cell>
           <ids-menu-button id="menu-button" icon="settings" appearance="tertiary" menu="my-menu" dropdown-icon>
             <span>Settings</span>
           </ids-menu-button>
-          <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click" arrow="none">
+          <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click">
             <ids-menu-group>
               <ids-menu-item>Personalize Columns...</ids-menu-item>
             </ids-menu-group>

--- a/src/components/ids-menu-button/demos/example.html
+++ b/src/components/ids-menu-button/demos/example.html
@@ -15,7 +15,7 @@
           <ids-menu-button id="menu-button" icon="settings" appearance="tertiary" menu="my-menu" dropdown-icon>
             <span>Settings</span>
           </ids-menu-button>
-          <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click">
+          <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click" arrow="none">
             <ids-menu-group>
               <ids-menu-item>Personalize Columns...</ids-menu-item>
             </ids-menu-group>
@@ -36,11 +36,22 @@
             </ids-menu-group>
           </ids-popup-menu>
 
-          <ids-menu-button id="icon-button" menu="icon-menu" icon="more">
-            <span class="audible">Icon Only Button</span>
+          <ids-menu-button id="icon-button" menu="icon-menu" icon="more" tooltip="Multiselect">
+            <span class="audible">Icon only button</span>
           </ids-menu-button>
           <ids-popup-menu id="icon-menu" target="icon-button" trigger-type="click">
             <ids-menu-group select="multiple" keep-open="true">
+              <ids-menu-item value="1">Option One</ids-menu-item>
+              <ids-menu-item value="2">Option Two</ids-menu-item>
+              <ids-menu-item value="3">Option Three</ids-menu-item>
+            </ids-menu-group>
+          </ids-popup-menu>
+
+          <ids-menu-button id="icon-button-no-arrow" menu="icon-menu-no-arrow" icon="add" tooltip="No arrow">
+            <span class="audible">Icon only no arrow</span>
+          </ids-menu-button>
+          <ids-popup-menu id="icon-menu-no-arrow" arrow="none" target="icon-button" trigger-type="click">
+            <ids-menu-group>
               <ids-menu-item value="1">Option One</ids-menu-item>
               <ids-menu-item value="2">Option Two</ids-menu-item>
               <ids-menu-item value="3">Option Three</ids-menu-item>

--- a/src/components/ids-menu-button/ids-menu-button.ts
+++ b/src/components/ids-menu-button/ids-menu-button.ts
@@ -287,7 +287,8 @@ export default class IdsMenuButton extends IdsButton {
     const popupMenuEl = document.querySelector(`#${this.menu}`);
     let arrow = 'bottom';
     this.menuEl.popup.arrowTarget = this.dropdownIconEl || this;
-    if (popupMenuEl && (popupMenuEl as IdsPopupMenu).arrow) {
+
+    if (popupMenuEl && (popupMenuEl as IdsPopupMenu).getAttribute('arrow')) {
       arrow = (popupMenuEl as IdsPopupMenu).arrow || '';
     }
     this.menuEl.popup.arrow = arrow;

--- a/src/components/ids-menu-button/ids-menu-button.ts
+++ b/src/components/ids-menu-button/ids-menu-button.ts
@@ -13,6 +13,7 @@ import '../ids-menu/ids-menu-item';
 import styles from '../ids-button/ids-button.scss';
 
 import type IdsIcon from '../ids-icon/ids-icon';
+import type IdsPopupMenu from '../ids-popup-menu/ids-popup-menu';
 
 /**
  * IDS Menu Button Component
@@ -282,8 +283,14 @@ export default class IdsMenuButton extends IdsButton {
     if (!this.menuEl || !this.menuEl.popup) {
       return;
     }
+
+    const popupMenuEl = document.querySelector(`#${this.menu}`);
+    let arrow = 'bottom';
     this.menuEl.popup.arrowTarget = this.dropdownIconEl || this;
-    this.menuEl.popup.arrow = 'bottom';
+    if (popupMenuEl && (popupMenuEl as IdsPopupMenu).arrow) {
+      arrow = (popupMenuEl as IdsPopupMenu).arrow || '';
+    }
+    this.menuEl.popup.arrow = arrow;
   }
 
   /**

--- a/src/components/ids-popup-menu/README.md
+++ b/src/components/ids-popup-menu/README.md
@@ -39,6 +39,7 @@ The Ids Popup Menu is a complex component that combines an [`IdsMenu`](../ids-me
 
 - `target` {HTMLElement} if defined, creates a link between this Popup Menu and another element in the DOM.
 - `trigger` {string} the action on which to activate the Popupmenu. This defaults to `contextmenu`, but can also be `click` or `immediate`.
+- `arrow` {string} If defined overrides the default arrow position. The typical use case is to set this to `none` to not show any arrow.
 
 ### Menu Group
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Some previous work i added some pass through options from ids-popup-menu. One of them was arrow which is needed for the use case on #1290 however this needed one small tweak to make it work for this use case.

**Related github/jira issue (required)**:
Fixes #1290 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-menu-button/example.html
- click new + button, should not show an arrow

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.