### PR TITLE
1759 - Line icons up in ids text

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Calendar]` Add `eventsrendered` event and slot `custom-legend` for custom legends. ([#1564](https://github.com/infor-design/enterprise-wc/issues/1564))
 - `[LoadingIndicator]` Added new settings and example to show a full page loading indicator with page blocking. ([#1520](https://github.com/infor-design/enterprise-wc/issues/1520))
 - `[TriggerField]` Added an example showing a menu on trigger button click. ([#1697](https://github.com/infor-design/enterprise-wc/issues/1697))
+- `[Text]` Added code to line up an icon with text in the IdsText component. ([#1759](https://github.com/infor-design/enterprise-wc/issues/1759))
 
 ### 1.0.0-beta.18 Fixes
 

--- a/src/components/ids-icon/demos/align-icon.html
+++ b/src/components/ids-icon/demos/align-icon.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Ids Icon (Aligned With Text)</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto-fit="true" padding-x="md" min-col-width="100px">
+        <ids-text>Example Text <ids-icon icon="info"></ids-icon></ids-text>
+        <ids-text>
+          More Example Text
+          <ids-icon icon="info"></ids-icon>
+        </ids-text>
+        <ids-text>
+          <span>Example Text in a span</span>
+          <ids-icon icon="info"></ids-icon>
+        </ids-text>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-icon/demos/align-icon.ts
+++ b/src/components/ids-icon/demos/align-icon.ts
@@ -1,0 +1,1 @@
+import '../../ids-layout-flex/ids-layout-flex';

--- a/src/components/ids-icon/demos/index.yaml
+++ b/src/components/ids-icon/demos/index.yaml
@@ -17,6 +17,9 @@
   - link: notification-badge.html
     type: Example
     description: Example of notifications badges on icons
+  - link: align-icon.html
+    type: Example
+    description: Icon lined up within text
   - link: variant-alternate.html
     type: Test
     description: Test showing the alternate variant color

--- a/src/components/ids-icon/demos/status-color.html
+++ b/src/components/ids-icon/demos/status-color.html
@@ -21,6 +21,9 @@
         <ids-icon icon="success" status-color="success"></ids-icon>
         <ids-icon icon="error" status-color="error"></ids-icon>
         <ids-icon icon="alert" status-color="warning"></ids-icon>
+        <br>
+        <br>
+        <ids-text>Test Text <ids-icon icon="rocket"></ids-icon></ids-text>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 

--- a/src/components/ids-text/ids-text.scss
+++ b/src/components/ids-text/ids-text.scss
@@ -171,6 +171,11 @@
   font-weight: var(--ids-font-weight-bold);
 }
 
+::slotted(ids-icon) {
+  margin: var(--ids-text-icon-margin);
+  vertical-align: text-bottom;
+}
+
 /* Ids Typography System */
 .ids-text-10 {
   font-size: var(--ids-font-size-10);

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -1420,6 +1420,9 @@
   --ids-tag-color-text-disabled: var(--ids-color-neutral-50);
   --ids-tag-secondary-color-text-disabled: var(--ids-color-neutral-40);
 
+  // Text Component
+  --ids-text-icon-margin: 0 2px;
+
   // Textarea
   --ids-textarea-alert-color-border-default: var(--ids-color-warning-50);
   --ids-textarea-alert-color-border-disabled: var(--ids-color-warning-30);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Responding to a Teams chat, decided to add a little css to make it easy to line up an icon inside an ids text element.

**Related github/jira issue (required)**:
Fixes #1759 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-icon/align-icon.html
- check icon is lined up vertically with text

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A note to the change log.
