### PR TITLE
1776 - Add no formatting to stats component

### DIFF
--- a/src/components/ids-stats/demos/example.html
+++ b/src/components/ids-stats/demos/example.html
@@ -24,12 +24,13 @@
               <ids-layout-grid-cell>
                 <ids-stats
                   actionable
-                  trend-label="28.62"
+                  trend-label="99"
                   icon="rocket"
                   status-color="success"
-                  kpi="12"
+                  kpi="12 Hrs"
                   main-label="Main title"
-                  subtitle="Sub title goes here">
+                  subtitle="Sub title goes here"
+                  id="stat-ac-one">
                 </ids-stats>
               </ids-layout-grid-cell>
               <ids-layout-grid-cell>

--- a/src/components/ids-stats/demos/example.ts
+++ b/src/components/ids-stats/demos/example.ts
@@ -3,6 +3,8 @@ import '../../ids-home-page/ids-home-page';
 import '../ids-stats';
 import IdsStats from '../ids-stats';
 
+document.querySelector<IdsStats>('#stat-ac-one')!.kpiFormat = '';
+
 document.querySelector<IdsStats>('#stat-ac-two')!.kpiFormat = {
   notation: 'compact',
   compactDisplay: 'short',

--- a/src/components/ids-stats/ids-stats.ts
+++ b/src/components/ids-stats/ids-stats.ts
@@ -297,8 +297,8 @@ export default class IdsStats extends IdsLocaleMixin(IdsEventsMixin(IdsElement))
   }
 
   formats: {
-    kpi?: Intl.NumberFormatOptions | undefined,
-    trend?: Intl.NumberFormatOptions | undefined
+    kpi?: Intl.NumberFormatOptions | undefined | string,
+    trend?: Intl.NumberFormatOptions | undefined | string
   } = {
       kpi: undefined,
       trend: { signDisplay: 'exceptZero' }
@@ -306,22 +306,22 @@ export default class IdsStats extends IdsLocaleMixin(IdsEventsMixin(IdsElement))
 
   /**
    * Set the locale format for the kpi
-   * @param {Intl.NumberFormatOptions | undefined} value If 2 will span 2 columns, nothing else is valid
+   * @param {Intl.NumberFormatOptions | undefined | string} value If 2 will span 2 columns, nothing else is valid
    */
-  set kpiFormat(value: Intl.NumberFormatOptions | undefined) {
-    if (value !== null) {
+  set kpiFormat(value: Intl.NumberFormatOptions | undefined | string) {
+    if (value !== undefined && typeof value !== 'string') {
       this.formats.kpi = value;
     } else {
-      this.formats.kpi = undefined;
+      this.formats.kpi = typeof value === 'string' ? '' : undefined;
     }
     this.#applyKpiFormat();
   }
 
   /**
    * Get col-span attribute
-   * @returns {Intl.NumberFormatOptions | undefined} The number value for the columns to span in the grid
+   * @returns {Intl.NumberFormatOptions | undefined | string} The number value for the columns to span in the grid
    */
-  get kpiFormat(): Intl.NumberFormatOptions | undefined {
+  get kpiFormat(): Intl.NumberFormatOptions | undefined | string {
     return this.formats.kpi;
   }
 
@@ -330,7 +330,13 @@ export default class IdsStats extends IdsLocaleMixin(IdsEventsMixin(IdsElement))
    */
   #applyKpiFormat() {
     const elem = this.container?.querySelector('.kpi-label');
-    if (elem) elem.textContent = new Intl.NumberFormat(this.locale || 'en', this.kpiFormat).format(Number(this.kpi));
+    if (elem && typeof this.kpiFormat === 'string') {
+      elem.textContent = this.kpi;
+      return;
+    }
+    if (elem && typeof this.kpiFormat !== 'string') {
+      elem.textContent = new Intl.NumberFormat(this.locale || 'en', this.kpiFormat).format(Number(this.kpi));
+    }
   }
 
   /**
@@ -338,19 +344,19 @@ export default class IdsStats extends IdsLocaleMixin(IdsEventsMixin(IdsElement))
    * @param {Intl.NumberFormatOptions | undefined} value If 2 will span 2 columns, nothing else is valid
    */
   set trendFormat(value: Intl.NumberFormatOptions | undefined) {
-    if (value !== null) {
+    if (value !== undefined && typeof value !== 'string') {
       this.formats.trend = value;
     } else {
-      this.formats.trend = undefined;
+      this.formats.trend = typeof value === 'string' ? '' : undefined;
     }
     this.#applyTrendFormat();
   }
 
   /**
    * Get col-span attribute
-   * @returns {Intl.NumberFormatOptions | undefined} The number value for the columns to span in the grid
+   * @returns {Intl.NumberFormatOptions | undefined | string} The number value for the columns to span in the grid
    */
-  get trendFormat(): Intl.NumberFormatOptions | undefined {
+  get trendFormat(): Intl.NumberFormatOptions | undefined | string {
     return this.formats.trend;
   }
 
@@ -358,11 +364,17 @@ export default class IdsStats extends IdsLocaleMixin(IdsEventsMixin(IdsElement))
    * Apply the format on the field
    */
   #applyTrendFormat() {
-    const formatted = new Intl.NumberFormat(this.locale || 'en', this.trendFormat).format(Number(this.trendLabel));
-    const isNegative = (formatted || '').indexOf('-') > -1;
-    const isPositive = !isNegative && formatted !== '';
-    const trendIcon = `${isPositive ? this.trendingUpIcon : ''}`;
     const elem = this.container?.querySelector('.trend-label');
-    if (elem && formatted !== '0') elem.innerHTML = `${formatted}${trendIcon}`;
+    if (elem && typeof this.trendFormat === 'string') {
+      elem.textContent = this.trendLabel;
+      return;
+    }
+    if (typeof this.trendFormat !== 'string') {
+      const formatted = new Intl.NumberFormat(this.locale || 'en', this.trendFormat).format(Number(this.trendLabel));
+      const isNegative = (formatted || '').indexOf('-') > -1;
+      const isPositive = !isNegative && formatted !== '';
+      const trendIcon = `${isPositive ? this.trendingUpIcon : ''}`;
+      if (elem && formatted !== '0') elem.innerHTML = `${formatted}${trendIcon}`;
+    }
   }
 }

--- a/tests/ids-stats/snapshots/stats-html.snap
+++ b/tests/ids-stats/snapshots/stats-html.snap
@@ -1,2 +1,2 @@
-<ids-stats actionable="true" trend-label="28.62" icon="rocket" status-color="success" kpi="12" main-label="Main title" subtitle="Sub title goes here">
+<ids-stats actionable="true" trend-label="99" icon="rocket" status-color="success" kpi="12 Hrs" main-label="Main title" subtitle="Sub title goes here" id="stat-ac-one">
                 </ids-stats>

--- a/tests/ids-stats/snapshots/stats-shadow.snap
+++ b/tests/ids-stats/snapshots/stats-shadow.snap
@@ -3,7 +3,7 @@
         <ids-layout-flex direction="column">
           <ids-layout-flex justify-content="space-between" align-items="center">
             <ids-layout-flex-item>
-              <div class="trend-label is-positive">+28.62<svg width="20" height="12" viewBox="0 0 20 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <div class="trend-label is-positive">+99<svg width="20" height="12" viewBox="0 0 20 12" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="M1.4 12L0 10.6L7.4 3.15L11.4 7.15L16.6 2H14V0H20V6H18V3.4L11.4 10L7.4 6L1.4 12Z" fill="#2AC371"></path>
   </svg></div>
             </ids-layout-flex-item>
@@ -12,7 +12,7 @@
             </ids-layout-flex-item>
           </ids-layout-flex>
           <ids-layout-flex-item>
-            <ids-text font-size="40" class="kpi-label" font-weight="semi-bold" overflow="ellipsis" tooltip="true">12</ids-text>
+            <ids-text font-size="40" class="kpi-label" font-weight="semi-bold" overflow="ellipsis" tooltip="true">12 Hrs</ids-text>
           </ids-layout-flex-item>
           <ids-layout-flex-item>
             <ids-text font-size="14" class="main-label" font-weight="semi-bold" overflow="ellipsis" tooltip="true">Main title</ids-text>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Add the ability to set format for kpi to '' so something can be set other than a number. Setting the format to '' will just put the raw value in.

**Related github/jira issue (required)**:
Fixes #1776

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-stats/example.html
- first KPI should show 12 hrs (the raw text value)
- the rest use number format
- changing the locale in the .. menu will update it

**Included in this Pull Request**:
- [x] A note to the change log.
