### PR TITLE
1732 - fix listview space key not working inside input

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### 1.0.0-beta.19 Fixes
 
-- `[Input]` Renamed internal labels and fixed routines that look for labels to fix an issue with missing labels. ([#1752](https://github.com/infor-design/enterprise-wc/issues/1752))
+- `[Input]` Renamed internal labels and fixed routines that look for labels to fix an issue with missing labels. ([#1732](https://github.com/infor-design/enterprise-wc/issues/1732))
+- `[ListBuilder]` Fixed spacebar on IdsListBuilder so that input-field properly displays spaces. ([#1768](https://github.com/infor-design/enterprise-wc/issues/1768))
 - `[LoadingIndicator]` Fixed an issue where the inner bars within the loader where not the same size. ([#1768](https://github.com/infor-design/enterprise-wc/issues/1768))
 - `[Locale]` Changed all `zh` time formats to 24hr as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise-wc/issues/8313))
 - `[Widget]` Added css part to the widget body element. ([#1771](https://github.com/infor-design/enterprise-wc/issues/1771))

--- a/src/components/ids-list-builder/ids-list-builder.ts
+++ b/src/components/ids-list-builder/ids-list-builder.ts
@@ -240,6 +240,11 @@ export default class IdsListBuilder extends IdsListView {
     itemFocused?.prepend(input); // insert into DOM
     input.focus();
 
+    this.onEvent('keydown.listbuilder-editor', input, (evt) => {
+      const code = evt.code || 'Space';
+      if (code === 'Space') evt.stopImmediatePropagation(); // keep spacebar working
+    });
+
     this.onEvent('keyup.listbuilder-editor', input, (evt) => {
       evt.stopImmediatePropagation();
       firstEditableField.innerHTML = input.value ?? '';


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
`IdsListView` unable to use "space" upon creating/editing an item

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1732 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. Checkout this branch and run: `nvm use && npm run start`
2. Go to: http://localhost:4300/ids-list-builder/example.html
3. Press `+` to create new list-item, and type a sentence.  Spacebar should create space.
4. Also press `Enter` key to edit existing list-item, and ensure spacebar works as expected.

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
