### PR TITLE
1580 - datagrid remove empty text when adding row

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 1.0.0-beta.19 Fixes
 
+- `[Datagrid]` Fix for empty-data text still showing after adding a grid row. ([#1580](https://github.com/infor-design/enterprise-wc/issues/1580))
 - `[Input]` Renamed internal labels and fixed routines that look for labels to fix an issue with missing labels. ([#1752](https://github.com/infor-design/enterprise-wc/issues/1752))
 - `[LoadingIndicator]` Fixed an issue where the inner bars within the loader where not the same size. ([#1768](https://github.com/infor-design/enterprise-wc/issues/1768))
 - `[Locale]` Changed all `zh` time formats to 24hr as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise-wc/issues/8313))

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -2368,6 +2368,8 @@ export default class IdsDataGrid extends Base {
    * @param {number} index insert position for new row
    */
   addRow(data: Record<string, unknown>, index?: number) {
+    if (data) hideEmptyMessage.apply(this);
+
     // Update data
     const insertIdx = index ?? this.datasource.originalData.length;
     this.datasource.create([data], insertIdx);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

The datagrid initially has no data and shows the message "No data available", but when adding new rows to the grid, the empty-data message was not going away.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1580 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out this branch and run: `npm i && npm run start`
2. Go to: http://localhost:4300/ids-data-grid/empty-message.html
3. Paste this in dev console: `$('ids-data-grid').addRow({id: 1, name: 'name 1'})`
4. Ensure empty-data message goes away.

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
