### PR TITLE
1681 - IdsDropdown prevent auto scroll

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 1.0.0-beta.19 Fixes
 
+- `[Dropdown]` Prevent dropdown from auto scrolling view when list box is opened. ([#1681](https://github.com/infor-design/enterprise-wc/issues/1681))
 - `[Input]` Renamed internal labels and fixed routines that look for labels to fix an issue with missing labels. ([#1752](https://github.com/infor-design/enterprise-wc/issues/1752))
 - `[LoadingIndicator]` Fixed an issue where the inner bars within the loader where not the same size. ([#1768](https://github.com/infor-design/enterprise-wc/issues/1768))
 - `[Locale]` Changed all `zh` time formats to 24hr as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise-wc/issues/8313))

--- a/src/components/ids-dropdown/ids-dropdown-list.ts
+++ b/src/components/ids-dropdown/ids-dropdown-list.ts
@@ -460,10 +460,6 @@ export default class IdsDropdownList extends Base {
     if (targetOption.id) {
       this.listBox?.setAttribute('aria-activedescendant', targetOption.id);
     }
-
-    if (typeof targetOption.scrollIntoView === 'function') {
-      targetOption.scrollIntoView({ block: 'center' });
-    }
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Removed some `scrollIntoView()` code that forces a page scroll when dropdowns are opened.

**Related github/jira issue (required)**:
Closes #1681 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-personalize/example.html
3. Scroll down to dropdown example
4. Open dropdown and check that the page doesn't scroll

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
