### PR TITLE
1667 - IdsSlider Fix issue with setting value through attribute

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[LoadingIndicator]` Fixed an issue where the inner bars within the loader where not the same size. ([#1768](https://github.com/infor-design/enterprise-wc/issues/1768))
 - `[Locale]` Changed all `zh` time formats to 24hr as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise-wc/issues/8313))
 - `[NotificationBanner]` Made the message text updatable to fix rendering issues. ([#1782](https://github.com/infor-design/enterprise-wc/issues/1782))
+- `[Slider]` Fixed issue with setting value through attribute. ([#1667](https://github.com/infor-design/enterprise-wc/issues/1667))
 - `[Tabs]` Fixed `selected` attribute occasionally not working.  ([#1705](https://github.com/infor-design/enterprise-wc/issues/1705))
 - `[Widget]` Added css part to the widget body element. ([#1771](https://github.com/infor-design/enterprise-wc/issues/1771))
 

--- a/src/components/ids-slider/ids-slider.ts
+++ b/src/components/ids-slider/ids-slider.ts
@@ -699,21 +699,18 @@ export default class IdsSlider extends Base {
   set value(value: string | number | any) {
     if (this.readonly || this.disabled) return;
 
-    const currentValue = parseFloat(this.getAttribute(attributes.VALUE) ?? '') || this.min;
     const newValue = this.#sanitizeValue(value);
 
-    if (currentValue !== newValue) {
-      this.setAttribute(attributes.VALUE, `${newValue}`);
-      this.percent = ((newValue - this.min) / (this.max - this.min)) * 100;
-      this.thumbDraggable?.setAttribute(htmlAttributes.ARIA_VALUENOW, `${newValue}`);
-      this.thumbDraggable?.setAttribute(htmlAttributes.ARIA_VALUETEXT, `${newValue}`);
-      if (this.type === 'range') {
-        this.thumbDraggableSecondary?.setAttribute(htmlAttributes.ARIA_VALUEMIN, `${newValue}`);
-      }
-      this.#updateTooltip(newValue, 'primary');
-      this.#moveThumb('primary');
-      this.#triggerChangeEvent(newValue, 'primary');
+    this.setAttribute(attributes.VALUE, `${newValue}`);
+    this.percent = ((newValue - this.min) / (this.max - this.min)) * 100;
+    this.thumbDraggable?.setAttribute(htmlAttributes.ARIA_VALUENOW, `${newValue}`);
+    this.thumbDraggable?.setAttribute(htmlAttributes.ARIA_VALUETEXT, `${newValue}`);
+    if (this.type === 'range') {
+      this.thumbDraggableSecondary?.setAttribute(htmlAttributes.ARIA_VALUEMIN, `${newValue}`);
     }
+    this.#updateTooltip(newValue, 'primary');
+    this.#moveThumb('primary');
+    this.#triggerChangeEvent(newValue, 'primary');
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Modified the 'value' setter to accept values that are added through value attribute

**Related github/jira issue (required)**:
Closes #1667 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-slider/example.html
- open browser's console
- set value as attribute `$('ids-slider').setAttribute('value', 50)`
- see how the value of the `Single Slider` example changes visually
- set value as property `$('ids-slider').value = 20`
- see how the value of the `Single Slider` example changes visually
- set value in the dom in dev tools `<ids-slider value="30"...`
- see how the value of the `Single Slider` example changes visually


**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
