### PR TITLE
1669 - Fix for rtl direction of datagrid filter header

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Dropdown|Multiselect]` Broken Dropdown and Multiselect fixed in Angular. ([#1762](https://github.com/infor-design/enterprise-wc/issues/1762))
 - `[Dropdown]` Prevent dropdown from auto scrolling view when list box is opened. ([#1681](https://github.com/infor-design/enterprise-wc/issues/1681))
 - `[Datagrid]` Fix for empty-data text still showing after adding a grid row. ([#1580](https://github.com/infor-design/enterprise-wc/issues/1580))
+- `[Datagrid]` Fix for rtl direction of datagrid filter header. ([#1669](https://github.com/infor-design/enterprise-wc/issues/1669))
 - `[Input]` Renamed internal labels and fixed routines that look for labels to fix an issue with missing labels. ([#1752](https://github.com/infor-design/enterprise-wc/issues/1752))
 - `[LoadingIndicator]` Fixed an issue where the inner bars within the loader where not the same size. ([#1768](https://github.com/infor-design/enterprise-wc/issues/1768))
 - `[Locale]` Changed all `zh` time formats to 24hr as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise-wc/issues/8313))

--- a/src/components/ids-data-grid/ids-data-grid-header.scss
+++ b/src/components/ids-data-grid/ids-data-grid-header.scss
@@ -457,8 +457,7 @@ th.ids-data-grid-header-cell {
 :host([dir='rtl']) {
   // Negate right alignment
   .ids-data-grid-header-cell {
-    &.align-right .ids-data-grid-header-cell-content,
-    &.align-right .ids-data-grid-header-cell-filter-wrapper {
+    &.align-right .ids-data-grid-header-cell-content {
       direction: ltr;
     }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Removed ltr direction (when in rtl) style for header filter.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1669 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4300/ids-data-grid/filter.html
- Switch to rtl
- Header filter button should be rtl

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
