### PR TITLE
1670 - ids-lookup apply button not hiding modal in angular

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[AppMenu]` Added an issue to reclaim space on app menu. ([#1563](https://github.com/infor-design/enterprise-wc/issues/1563))
 - `[Lookup/Datagrid]` Fixed an issue where newer added primary key logic caused selection to select the first row in certain cases. ([#1751](https://github.com/infor-design/enterprise-wc/issues/1751))
+- `[Lookup]` Fix "Apply" button on `ids-lookup` so that it properly closes modal. ([#1670](https://github.com/infor-design/enterprise-wc/issues/1670))
 - `[ModuleNav]` Added an example with no header area to ensure it reclaims space. ([#1563](https://github.com/infor-design/enterprise-wc/issues/1563))
 - `[Popupmenu]` Fixed an issue where a popupmenu is in the wrong position on the filter row when in a modal. ([#1766](https://github.com/infor-design/enterprise-wc/issues/1766))
 - `[Pager]` Fixed an issue in angular where the buttons were invisible. ([#1826](https://github.com/infor-design/enterprise-wc/issues/1826))

--- a/src/components/ids-lookup/README.md
+++ b/src/components/ids-lookup/README.md
@@ -23,13 +23,16 @@ A normal lookup used as a web component. To distinguish between single and multi
 <ids-lookup id="lookup-1" label="Normal Lookup"></ids-lookup>
 ```
 
-If necessary you can provide your own custom modal to the lookup. When doing this you control the modal contents and events entirely. The lookup will just open it for you.
+If necessary you can provide your own custom modal to the lookup. When doing this you control the modal contents and events entirely. The lookup will just open it for you. Add the `confirm` or the `cancel` attribute to your custom modal-button to set which action should take place.
 
 ```html
 <ids-lookup id="custom-lookup" label="Custom Lookup">
     <ids-modal slot="lookup-modal" id="custom-lookup-modal" aria-labelledby="custom-lookup-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="lookup-modal-title">Custom Lookup Modal</ids-text>
-    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
+    <ids-modal-button slot="buttons" cancel id="modal-confirm-btn" appearance="primary">
+        <span>Cancel</span>
+    </ids-modal-button>
+    <ids-modal-button slot="buttons" confirm id="modal-close-btn" appearance="primary">
         <span>Apply</span>
     </ids-modal-button>
     </ids-modal>

--- a/src/components/ids-lookup/demos/example.html
+++ b/src/components/ids-lookup/demos/example.html
@@ -20,7 +20,7 @@
         <ids-lookup id="lookup-5" label="Custom Lookup">
           <ids-modal slot="lookup-modal" id="custom-lookup-modal" aria-labelledby="custom-lookup-modal-title">
             <ids-text slot="title" font-size="24" type="h2" id="lookup-modal-title">Custom Lookup Modal</ids-text>
-            <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="primary">
+            <ids-modal-button slot="buttons" confirm id="modal-confirm-btn" appearance="primary">
               <span>Apply</span>
             </ids-modal-button>
           </ids-modal>

--- a/src/components/ids-lookup/ids-lookup.ts
+++ b/src/components/ids-lookup/ids-lookup.ts
@@ -194,10 +194,10 @@ export default class IdsLookup extends Base {
           </ids-layout-grid-cell>
         </ids-layout-grid>
 
-        <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="secondary">
+        <ids-modal-button slot="buttons" cancel id="modal-cancel-btn" appearance="secondary">
           <span>Cancel</span>
         </ids-modal-button>
-        <ids-modal-button slot="buttons" id="modal-apply-btn" appearance="primary">
+        <ids-modal-button slot="buttons" confirm id="modal-confirm-btn" appearance="primary">
           <span>Apply</span>
         </ids-modal-button>
       </ids-modal>
@@ -624,15 +624,13 @@ export default class IdsLookup extends Base {
   #handleEvents() {
     this.onEvent('click.lookup', this.modal, (e: any) => {
       const btnId = e.target?.getAttribute('id');
+      const isCancelButton = e.target?.hasAttribute('cancel') || btnId === 'modal-cancel-btn';
+      const isConfirmButton = e.target?.hasAttribute('confirm') || ['modal-confirm-btn', 'modal-apply-btn'].includes(btnId);
 
-      // Cancel
-      if (btnId === 'modal-cancel-btn') {
+      if (isCancelButton) {
         this.modal?.hide();
         this.#syncSelectedRows();
-      }
-
-      // Apply
-      if (btnId === 'modal-apply-btn') {
+      } else if (isConfirmButton) {
         this.modal?.hide();
         this.#setInputValue();
       }

--- a/src/components/ids-modal-button/ids-modal-button.ts
+++ b/src/components/ids-modal-button/ids-modal-button.ts
@@ -31,7 +31,8 @@ export default class IdsModalButton extends IdsButton {
   static get attributes(): Array<string> {
     return [
       ...super.attributes,
-      attributes.CANCEL
+      attributes.CONFIRM,
+      attributes.CANCEL,
     ];
   }
 

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -109,6 +109,7 @@ export const attributes = {
   COMPLETED_LABEL: 'completed-label',
   COMPONENT_NAME: 'component-name',
   CONDITION: 'condition',
+  CONFIRM: 'confirm',
   CONTENT_ALIGN: 'content-align',
   COPYRIGHT_YEAR: 'copyright-year',
   COUNT: 'count',

--- a/tests/ids-lookup/snapshots/lookup-shadow.snap
+++ b/tests/ids-lookup/snapshots/lookup-shadow.snap
@@ -16,10 +16,10 @@
           </ids-layout-grid-cell>
         </ids-layout-grid>
 
-        <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="secondary">
+        <ids-modal-button slot="buttons" cancel="" id="modal-cancel-btn" appearance="secondary">
           <span>Cancel</span>
         </ids-modal-button>
-        <ids-modal-button slot="buttons" id="modal-apply-btn" appearance="primary">
+        <ids-modal-button slot="buttons" confirm="" id="modal-confirm-btn" appearance="primary">
           <span>Apply</span>
         </ids-modal-button>
       </ids-modal>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
When clicking the modal "apply" button on `ids-lookup` modal the modal does not hide (the pop up remains in the display state).


**Related github/jira issue(s) (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes https://github.com/infor-design/enterprise-wc/issues/1670

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Check out this branch and run: `nvm use && npm i && npm run start`
- Go to: http://localhost:4300/ids-lookup/example.html
- Click the search icon on the "Custom Modal" lookup to open the modal.
- Ensure the "apply" button closes the modal
- Run `npm run publish:link`
- Then check out this angular-examples-wc PR: https://github.com/infor-design/enterprise-wc-examples/pull/56
- Run `rm -fr .angular && npm run build && npm run start`
- Go to: http://localhost:4200/ids-lookup/example
- Ensure the "apply" button closes the modal

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.