### PR TITLE
1775 - IdsText fix attribute order bug

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[ModuleNav]` Added an example with no header area to ensure it reclaims space. ([#1563](https://github.com/infor-design/enterprise-wc/issues/1563))
 - `[Popupmenu]` Fixed an issue where a popupmenu is in the wrong position on the filter row when in a modal. ([#1766](https://github.com/infor-design/enterprise-wc/issues/1766))
 - `[Pager]` Fixed an issue in angular where the buttons were invisible. ([#1826](https://github.com/infor-design/enterprise-wc/issues/1826))
+- `[Text]` Fix attribute order bug where a rerender ignores font weight. ([#1775](https://github.com/infor-design/enterprise-wc/issues/1775))
 - `[Textarea]` Fixed an issue where could not type in textarea. ([#1827](https://github.com/infor-design/enterprise-wc/issues/1827))
 
 ## 1.0.0-beta.19

--- a/src/components/ids-text/ids-text.ts
+++ b/src/components/ids-text/ids-text.ts
@@ -170,7 +170,6 @@ export default class IdsText extends Base {
    * @param {string | null} value (if bold)
    */
   set fontWeight(value: 'lighter' | 'bold' | 'semi-bold' | null) {
-    console.log('this fontWeight', value);
     this.container?.classList.remove(...fontWeightClasses);
 
     if (value && fontWeightClasses.includes(value)) {
@@ -190,7 +189,6 @@ export default class IdsText extends Base {
    * @param {string | null} value  The type of element
    */
   set type(value: string | null) {
-    console.log('set type', value);
     if (value) {
       this.setAttribute(attributes.TYPE, value);
     } else {

--- a/src/components/ids-text/ids-text.ts
+++ b/src/components/ids-text/ids-text.ts
@@ -104,6 +104,7 @@ export default class IdsText extends Base {
    */
   template(): string {
     const tag = this.type || 'span';
+    const fontWeight = this.fontWeight;
 
     let classList = 'ids-text';
     classList += this.status ? ` ${this.statusClass()}` : '';
@@ -112,7 +113,7 @@ export default class IdsText extends Base {
     classList += (this.audible) ? ' audible' : '';
     classList += (this.label) ? ' label' : '';
     classList += this.fontSize ? ` ids-text-${this.fontSize}` : '';
-    classList += (this.fontWeight === 'bold' || this.fontWeight === 'lighter')
+    classList += (fontWeight === 'bold' || fontWeight === 'lighter' || fontWeight === 'semi-bold')
       ? ` ${this.fontWeight}` : '';
 
     return `<${tag}
@@ -169,6 +170,7 @@ export default class IdsText extends Base {
    * @param {string | null} value (if bold)
    */
   set fontWeight(value: 'lighter' | 'bold' | 'semi-bold' | null) {
+    console.log('this fontWeight', value);
     this.container?.classList.remove(...fontWeightClasses);
 
     if (value && fontWeightClasses.includes(value)) {
@@ -188,6 +190,7 @@ export default class IdsText extends Base {
    * @param {string | null} value  The type of element
    */
   set type(value: string | null) {
+    console.log('set type', value);
     if (value) {
       this.setAttribute(attributes.TYPE, value);
     } else {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes bug where order of attributes `type` and `font-weight` sometimes ignores the `font-weight` setting.
`template()` function was missing a check for `semi-bold`

**Related github/jira issue (required)**:
Closes #1775 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-text/example.html
3. Add these examples to the `example.html` file for ids-text
```
        <ids-text type="p" font-weight="semi-bold">
            This text is bold
        </ids-text>

        <ids-text font-weight="semi-bold" type="p">
            This text is NOT bold
        </ids-text>
```
4. Check that both ids-text example are semi-bold regardless of the order of `type` and `font-weight` attributes

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

