### PR TITLE
1746 -IdsSlider rounds up value

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[DataGrid]` Added dirty tracker to checkbox editor. ([#1747](https://github.com/infor-design/enterprise-wc/issues/1747))
 - `[Dropdown]` Fixed incorrect form values in reactive forms. ([#1850](https://github.com/infor-design/enterprise-wc/issues/1850))
 - `[TimePicker/Calendar]` Fixed outside click when interacting with the popup. ([#1860](https://github.com/infor-design/enterprise-wc/issues/1860))
+- `[Slider]` Rounded up the value to decimal to match the tooltip. ([#1746](https://github.com/infor-design/enterprise-wc/issues/1746))
 
 ## 1.0.0-beta.20
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - `[DataGrid]` Added dirty tracker to checkbox editor. ([#1747](https://github.com/infor-design/enterprise-wc/issues/1747))
 - `[Dropdown]` Fixed incorrect form values in reactive forms. ([#1850](https://github.com/infor-design/enterprise-wc/issues/1850))
-- `[TimePicker/Calendar]` Fixed outside click when interacting with the popup. ([#1860](https://github.com/infor-design/enterprise-wc/issues/1860))
 - `[Slider]` Rounded up the value to decimal to match the tooltip. ([#1746](https://github.com/infor-design/enterprise-wc/issues/1746))
+- `[TimePicker/Calendar]` Fixed outside click when interacting with the popup. ([#1860](https://github.com/infor-design/enterprise-wc/issues/1860))
 
 ## 1.0.0-beta.20
 

--- a/src/components/ids-slider/ids-slider.ts
+++ b/src/components/ids-slider/ids-slider.ts
@@ -641,7 +641,7 @@ export default class IdsSlider extends Base {
    * @returns {number} the corrected slider number
    */
   #sanitizeValue(value: string | number | any, secondary?: boolean): number {
-    const fixedValue = parseFloat(value);
+    const fixedValue = Math.ceil(parseFloat(value));
     if (fixedValue <= this.min) {
       return this.min;
     }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Rounded up the value to decimal to match the tooltip.

**Related github/jira issue (required)**:
Closes #1746 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-slider/example.html
- inspect the single slider example in the browser's elements
- change the slider value clicking or dragging on the component
- on the inspection of the value attribute see the value is the same a the tooltip shows
- you can also check `$('ids-slider').value` and `$('ids-slider').getAttribute('value')` in the console

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
