### PR TITLE
1804 - Add dynamic popup menu (beforeShow)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0-beta.22
+
+### 1.0.0-beta.22 Features
+
+- `[PopupMenu]` Added ability to load menu data in a callback with `beforeShow`. ([#1804](https://github.com/infor-design/enterprise-wc/issues/1804))
+
+### 1.0.0-beta.22 Fixes
+
+- `[Datagrid]` Fixed a display issue with the new loading indicator in firefox. ([#1617](https://github.com/infor-design/enterprise-wc/issues/1617))
+
 ## 1.0.0-beta.21
 
 ### 1.0.0-beta.21 Fixes

--- a/src/assets/data/menu-array-lazy.json
+++ b/src/assets/data/menu-array-lazy.json
@@ -1,0 +1,32 @@
+[
+  {
+    "items": [
+      {
+        "id": "item-1",
+        "text": "Item One",
+        "value": 1
+      },
+      {
+        "id": "item-2",
+        "text": "Item Two",
+        "value": 2
+      },
+      {
+        "id": "item-3",
+        "text": "Item Three",
+        "value": 3
+      },
+      {
+        "id": "item-4",
+        "text": "Sub Menu One",
+        "submenu": {
+            "id": "submenu-item-1",
+            "contents": [
+              {
+              }
+            ]
+        }
+      }
+    ]
+  }
+]

--- a/src/assets/data/menu-array-submenu.json
+++ b/src/assets/data/menu-array-submenu.json
@@ -1,20 +1,20 @@
 {
-  "id": "submenu-group-n",
+  "id": "submenu-group-{0}",
   "select": "none",
   "items": [
     {
-      "id": "submenu-item-1",
+      "id": "submenu-item-1-{0}",
       "text": "Sub Menu Item One"
     },
     {
-      "id": "submenu-item-2",
+      "id": "submenu-item-2-{0}",
       "text": "Sub Menu Item Two"
     },
     {
-      "id": "submenu-item-3",
-      "text": "Another Sub Menu",
+      "id": "submenu-item-3-{0}",
+      "text": "Sub Menu {0}",
       "submenu": {
-          "id": "submenu-group-n",
+          "id": "submenu-group-{0}",
           "contents": [
             {
             }

--- a/src/assets/data/menu-array-submenu.json
+++ b/src/assets/data/menu-array-submenu.json
@@ -1,0 +1,25 @@
+{
+  "id": "submenu-group-n",
+  "select": "none",
+  "items": [
+    {
+      "id": "submenu-item-1",
+      "text": "Sub Menu Item One"
+    },
+    {
+      "id": "submenu-item-2",
+      "text": "Sub Menu Item Two"
+    },
+    {
+      "id": "submenu-item-3",
+      "text": "Another Sub Menu",
+      "submenu": {
+          "id": "submenu-group-n",
+          "contents": [
+            {
+            }
+          ]
+      }
+    }
+  ]
+}

--- a/src/components/ids-data-grid/ids-data-grid-header.ts
+++ b/src/components/ids-data-grid/ids-data-grid-header.ts
@@ -239,7 +239,6 @@ export default class IdsDataGridHeader extends IdsEventsMixin(IdsElement) {
         offsetLeft = this.offsetParent.getBoundingClientRect().left
           - (this.offsetParent as HTMLElement).offsetLeft;
       }
-      cellLeft -= 32;
       cellLeft = cellLeft < 3 ? 0 : cellLeft;
       dragArrows?.style.setProperty('left', `${this.dataGrid?.localeAPI.isRTL() ? cellRight - offsetLeft : cellLeft - offsetLeft}px`);
       dragArrows?.style.setProperty('height', `${rect.height - 2}px`);

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -360,20 +360,20 @@ table.ids-data-grid {
 }
 
 // Empty Message
-.ids-data-grid-wrapper.has-empty-message {
+.ids-data-grid-wrapper {
   position: relative;
+}
 
-  ids-empty-message:not([hidden]),
-  ::slotted(ids-empty-message:not([hidden])) {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    justify-content: center;
-    align-items: center;
-    top: 0;
-    pointer-events: none;
-  }
+ids-empty-message:not([hidden]),
+::slotted(ids-empty-message:not([hidden])) {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  pointer-events: none;
 }
 
 // Loading Indicator

--- a/src/components/ids-menu-button/README.md
+++ b/src/components/ids-menu-button/README.md
@@ -22,6 +22,10 @@ The IDS Menu Button component is an extension of the standard [Button component]
 - `menu` can be defined as a CSS selector string, or if using the JS property, can be a direct reference to an IdsPopupMenu component.
 - `value` sets/gets selected menu items by providing list of menu item values
 
+## Methods
+
+- `async beforeShow(opts)` A callback that fires when the menu is opened. You can use the opts to see what menu and details about what is opening. Since the method is async you can do a call back and return structured [menu data](https://github.com/infor-design/enterprise-wc/blob/main/src/assets/data/menu-contents.json) when returned the menu will show with this data. See [popup menu](https://github.com/infor-design/enterprise-wc/blob/main/src/components/ids-popup-menu/README.md) for more details.
+
 ## States and Variations
 
 Since the menu button combined from several IDS Components, you can refer to their documentation for information about states/variants:

--- a/src/components/ids-menu-button/demos/index.yaml
+++ b/src/components/ids-menu-button/demos/index.yaml
@@ -14,6 +14,9 @@
   - link: display-selected.html
     type: Example
     description: Demonstrates how to update the text value of the menu button on selection
+  - link: load-data.html
+    type: Example
+    description: Showing loading data on beforeShow (with ajax)
   - link: side-by-side.html
     type: Side-by-side Example
     description: Showing a menu button side by side with 4.x

--- a/src/components/ids-menu-button/demos/load-data.html
+++ b/src/components/ids-menu-button/demos/load-data.html
@@ -7,17 +7,20 @@
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-popup-menu id="popupmenu" align="left, top"></ids-popup-menu>
 
     <ids-layout-grid auto-fit="true" padding="md">
       <ids-layout-grid-cell>
-        <ids-text font-size="12" type="h1">Popup Menu (ajax data driven)</ids-text>
+        <ids-text font-size="12" type="h1">Menu Button (ajax data driven)</ids-text>
       </ids-layout-grid-cell>
     </ids-layout-grid>
 
     <ids-layout-grid auto-fit="true" padding-x="md">
       <ids-layout-grid-cell>
-        <ids-text>This Popupmenu's contents are loaded via an async callback when opening the menu and submenu</ids-text>
+        <ids-menu-button id="menu-button" icon="settings" appearance="tertiary" menu="my-menu" dropdown-icon>
+          <span>Settings</span>
+        </ids-menu-button>
+        <ids-popup-menu id="my-menu" target="menu-button" trigger-type="click">
+        </ids-popup-menu>
       </ids-layout-grid-cell>
     </ids-layout-grid>
   </ids-container>

--- a/src/components/ids-menu-button/demos/load-data.ts
+++ b/src/components/ids-menu-button/demos/load-data.ts
@@ -1,9 +1,9 @@
 import json from '../../../assets/data/menu-array-lazy.json';
 import submenuJson from '../../../assets/data/menu-array-submenu.json';
-import IdsPopupMenu from '../ids-popup-menu';
+import IdsPopupMenu from '../../ids-popup-menu/ids-popup-menu';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const popupmenuEl: IdsPopupMenu = document.querySelector('#popupmenu')!;
+  const popupmenuEl: IdsPopupMenu = document.querySelector('#my-menu')!;
   let submenuCount = 1;
   // Load/set data on ajax request this fires for submenus
   popupmenuEl.beforeShow = async (opts: any) => {

--- a/src/components/ids-menu-button/ids-menu-button.ts
+++ b/src/components/ids-menu-button/ids-menu-button.ts
@@ -220,6 +220,7 @@ export default class IdsMenuButton extends IdsButton {
 
     if (this.menuEl.popup) {
       this.menuEl.popup.align = 'bottom, left';
+      this.menuEl.popup.alignEdge = 'top';
       this.menuEl.popup.y = 8;
       this.setPopupArrow();
     }

--- a/src/components/ids-menu/ids-menu-item.scss
+++ b/src/components/ids-menu/ids-menu-item.scss
@@ -217,7 +217,7 @@
   &.has-icon {
     a {
       padding-inline-start: 8px;
-      padding-inline-end: 8px;
+      padding-inline-end: 14px;
       grid-template-columns: 30px max-content;
     }
   }
@@ -320,7 +320,7 @@
 
   &.has-icon.has-submenu {
     a {
-      grid-template-columns: 30px calc(100% - 55px) 25px;
+      grid-template-columns: 30px calc(100% - 53px) 31px;
     }
   }
 

--- a/src/components/ids-popup-menu/README.md
+++ b/src/components/ids-popup-menu/README.md
@@ -56,6 +56,10 @@ The Ids Popup Menu is a complex component that combines an [`IdsMenu`](../ids-me
 - `tabindex` {number} set the `tabindex` attribute on the internal anchor.
 - `value` {string} set the radio value.
 
+## Methods
+
+- `async beforeShow(opts)` A callback that fires when the menu is opened. You can use the opts to see what menu and details about what is opening. Since the method is async you can do a call back and return structured [menu data](https://github.com/infor-design/enterprise-wc/blob/main/src/assets/data/menu-contents.json) when returned the menu will show with this data. See [popup menu](https://github.com/infor-design/enterprise-wc/blob/main/src/components/ids-popup-menu/README.md) for more details.
+
 ## Features (With Code Examples)
 
 It's possible to create a Popupmenu that stands alone and takes the place of the browser's context menu by default:
@@ -120,6 +124,19 @@ menu.data = {
     ]
 }
 document.body.appendChild(menu);
+```
+
+In some cases you may want to dynamically fetch data for the menu when it opens. You can do this by using the `beforeShow` callback.  This callback is called when the menu is opened and can be used to fetch data for the menu. This also fires when opening submenus. For a working example see [load-data.html](./demos//load-data.html) and [load-data.ts](./demos//load-data.ts). You should return return structured [menu data](https://github.com/infor-design/enterprise-wc/blob/main/src/assets/data/menu-contents.json) to control the menu. For dynamic submenus you can either return the submenu data directly on the initial call or use an empty contents area for the submenu if you plan  on fetching that dynamically `"contents": [{}]`.
+
+```js
+popupmenuEl.beforeShow = async (opts: any) => {
+  if (opts.isSubmenu) {
+    const submenuData = await fetch(...);
+    return submenuData;
+  }
+  const menuData = await fetch(...);
+  return menuData;
+};
 ```
 
 ### Size

--- a/src/components/ids-popup-menu/demos/index.ts
+++ b/src/components/ids-popup-menu/demos/index.ts
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Log to the console on `selected`
     popupmenuEl.addEventListener('selected', (e: any) => {
-      console.info(`Item "${e.detail.elem.text}" was selected`);
+      console.info(`Item "${e.detail.elem.text}" was selected (id "${e.detail.elem.id}")`);
     });
   }
 });

--- a/src/components/ids-popup-menu/demos/index.yaml
+++ b/src/components/ids-popup-menu/demos/index.yaml
@@ -20,6 +20,9 @@
   - link: shortcut-keys.html
     type: Example
     description: Showing a Popup Menu displaying shortcut key icons
+  - link: load-data.html
+    type: Example
+    description: Showing loading data on beforeShow (with ajax)
   - link: trigger-immediate.html
     type: Test
     description: Showing a Popup Menu invoked on demand

--- a/src/components/ids-popup-menu/demos/load-data.html
+++ b/src/components/ids-popup-menu/demos/load-data.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-popup-menu id="popupmenu" align="left, top"></ids-popup-menu>
+
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-layout-grid-cell>
+        <ids-text font-size="12" type="h1">Popup Menu (Data Driven)</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-text>This Popupmenu's contents are loaded via an async callback when opening the menu and submenu</ids-text>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-popup-menu/demos/load-data.ts
+++ b/src/components/ids-popup-menu/demos/load-data.ts
@@ -1,0 +1,20 @@
+import json from '../../../assets/data/menu-array-lazy.json';
+import submenuJson from '../../../assets/data/menu-array-submenu.json';
+import IdsPopupMenu from '../ids-popup-menu';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const popupmenuEl: IdsPopupMenu = document.querySelector('#popupmenu')!;
+
+  // Load/set data on ajax request
+  popupmenuEl.beforeShow = async (opts: any) => {
+    if (opts.isSubmenu) {
+      console.info('submenu', opts.contextElement);
+      const res = await fetch(submenuJson as any);
+      const submenuData = await res.json();
+      return submenuData;
+    }
+    const res = await fetch(json as any);
+    const data = await res.json();
+    return data;
+  };
+});

--- a/src/components/ids-popup/demos/index.ts
+++ b/src/components/ids-popup/demos/index.ts
@@ -19,6 +19,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Toggle the Popup
   triggerBtn?.addEventListener('click', () => {
-    popup.visible = !popup.visible;
+    if (!popup.visible) popup.visible = true; // closes automatically on click out
+  });
+
+  popup.addEventListener('hide', () => {
+    console.info('Hide event fired');
+  });
+  popup.addEventListener('show', () => {
+    console.info('Show event fired');
   });
 });

--- a/src/components/ids-popup/ids-popup.ts
+++ b/src/components/ids-popup/ids-popup.ts
@@ -1110,23 +1110,12 @@ export default class IdsPopup extends Base {
 
     // Fix location first
     this.place();
-
     this.placeArrow(this.#targetAlignEdge);
-
     this.removeAttribute('aria-hidden');
 
     // Change transparency/visibility
     this.container.classList.add('open');
     this.open = true;
-
-    if (this.animated) {
-      await waitForTransitionEnd(this.container, 'opacity');
-    }
-
-    // Unblur if needed
-    this.correct3dMatrix();
-
-    this.addOpenEvents();
 
     this.triggerEvent('show', this, {
       bubbles: true,
@@ -1134,6 +1123,14 @@ export default class IdsPopup extends Base {
         elem: this
       }
     });
+
+    if (this.animated) {
+      await waitForTransitionEnd(this.container, 'opacity');
+    }
+
+    // Unblur if needed
+    this.correct3dMatrix();
+    this.addOpenEvents();
   }
 
   /**
@@ -1142,19 +1139,12 @@ export default class IdsPopup extends Base {
    * @returns {void}
    */
   async hide() {
-    if (this.visible || !this.container) {
-      return;
-    }
-
+    if (!this.visible && !this.open) return;
+    this.setAttribute('aria-hidden', 'true');
+    this.visible = false;
     this.open = false;
     this.#remove3dMatrix();
-    this.container.classList.remove('open');
-
-    if (this.animated) {
-      await waitForTransitionEnd(this.container, 'opacity');
-    }
-
-    this.removeOpenEvents();
+    this.container!.classList.remove('open');
 
     // Always fire the 'hide' event
     this.triggerEvent('hide', this, {
@@ -1164,7 +1154,11 @@ export default class IdsPopup extends Base {
       }
     });
 
-    this.setAttribute('aria-hidden', 'true');
+    if (this.animated) {
+      await waitForTransitionEnd(this.container!, 'opacity');
+    }
+
+    this.removeOpenEvents();
   }
 
   /**
@@ -1177,7 +1171,6 @@ export default class IdsPopup extends Base {
     if (!e?.target || this.contains(e.target as HTMLElement)) {
       return;
     }
-    this.visible = false;
     this.hide();
   }
 

--- a/src/mixins/ids-events-mixin/README.md
+++ b/src/mixins/ids-events-mixin/README.md
@@ -30,7 +30,7 @@ console.info(this.handledEvents());
 The events mixin also lets you use a few convenient "custom events" for common interactions. We currently have the following events:
 
 - `hoverend` Fires when the user hovers the target and stops. This is to ensure they actually hovered the element and didn't just accidentally pass the mouse over it.
-- `sloped-mouseleave` Fires after a native `mouseleave` event, followed by a specified delay.  After the delay, the event only fires if mouse movement has occured and places the cursor a specified distance away from its original point.  The `event.detail.mouseLeaveNode` returned represents the element located at the new coordinates.
+- `sloped-mouseleave` Fires after a native `mouseleave` event, followed by a specified delay.  After the delay, the event only fires if mouse movement has occurred and places the cursor a specified distance away from its original point.  The `event.detail.mouseLeaveNode` returned represents the element located at the new coordinates.
 - `swipe` Fires when a user swipes left or right on a scrollable element. The direction can be seen in `event.detail`
 - `longpress` Fires when the user presses and olds on a touch device.
 - `keydown` Fires when the user presses a sequence of keys and stops typing

--- a/src/mixins/ids-events-mixin/ids-events-mixin.ts
+++ b/src/mixins/ids-events-mixin/ids-events-mixin.ts
@@ -470,8 +470,8 @@ const IdsEventsMixin = <T extends IdsBaseConstructor>(superclass: T) => class ex
         this.startX = e.pageX;
         this.startY = e.pageY;
         this.slopedMouseLeaveTimer = requestAnimationTimeout(() => {
-          const outOfBoundsX = (this.trackedX - this.startX) > 3.5;
-          const outOfBoundsY = (this.trackedY - this.startY) > 3.5;
+          const outOfBoundsX = (this.trackedX - this.startX) > 3.5 || (this.trackedX - this.startX) < 3.5;
+          const outOfBoundsY = (this.trackedY - this.startY) > 3.5 || (this.trackedY - this.startY) < 3.5;
           if (outOfBoundsX || outOfBoundsY) {
             dispatchCustomEvent(document.elementFromPoint(this.trackedX, this.trackedY), e);
           }

--- a/tests-to-convert/ids-popup-menu/ids-popup-menu-data-driven-func-test.ts
+++ b/tests-to-convert/ids-popup-menu/ids-popup-menu-data-driven-func-test.ts
@@ -22,37 +22,6 @@ describe('IdsPopupMenu Component', () => {
     document.body.appendChild(menu);
   });
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-    menu = null;
-  });
-
-  test('should render', () => {
-    const errors = jest.spyOn(global.console, 'error');
-
-    // Three popupmenus (top level and 2 submenus)
-    expect(document.querySelectorAll('ids-popup-menu').length).toEqual(3);
-    expect(errors).not.toHaveBeenCalled();
-  });
-
-  test('reverts to markup-driven if handed an empty dataset', () => {
-    menu.data = null;
-
-    // both old data and markup should stay in-tact
-    let menus = document.querySelectorAll('ids-popup-menu');
-
-    expect(menu.data).toEqual([]);
-    expect(menus.length).toEqual(3);
-
-    // Removing one via markup should work fine
-    menus[2].remove();
-    menus = document.querySelectorAll('ids-popup-menu');
-
-    // Data shouldn't change, but markup will
-    expect(menu.data).toEqual([]);
-    expect(menus.length).toEqual(2);
-  });
-
   test('accepts an array as a `contents` property', () => {
     const errors = jest.spyOn(global.console, 'error');
 

--- a/tests-to-convert/ids-popup/ids-popup-func-test.ts
+++ b/tests-to-convert/ids-popup/ids-popup-func-test.ts
@@ -621,20 +621,6 @@ describe('IdsPopup Component', () => {
     expect(popup.container.classList.contains('position-viewport')).toBeTruthy();
   });
 
-  test('can enable/disable visibility', async () => {
-    popup.visible = true;
-    popup.show();
-    await wait(200);
-    expect(popup.hasAttribute('aria-hidden')).toBeFalsy();
-    expect(popup.hasAttribute('visible')).toBeTruthy();
-
-    popup.visible = false;
-    popup.hide();
-    await wait(300);
-    expect(popup.hasAttribute('aria-hidden')).toBeTruthy();
-    expect(popup.hasAttribute('visible')).toBeFalsy();
-  });
-
   test('can enable/disable container bleed', () => {
     popup.bleed = true;
 

--- a/tests/ids-popup-menu/ids-popup-menu.spec.ts
+++ b/tests/ids-popup-menu/ids-popup-menu.spec.ts
@@ -63,4 +63,41 @@ test.describe('IdsPopupMenu tests', () => {
       await percySnapshot(page, 'ids-popup-menu-light');
     });
   });
+
+  test.describe('callback tests', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/ids-popup-menu/load-data.html');
+    });
+
+    test('supports async beforeShow', async ({ page }) => {
+      await page.evaluate(() => {
+        const elem = document.querySelector<IdsPopupMenu>('ids-popup-menu')!;
+        elem.show();
+      });
+      await page.waitForFunction(() => document.querySelector<IdsPopupMenu>('ids-popup-menu')?.visible === true);
+      const markup: string = await page.evaluate(() => {
+        const elem = document.querySelector<IdsPopupMenu>('ids-popup-menu')!;
+        return elem.innerHTML;
+      });
+      expect(markup).toContain('Sub Menu One');
+    });
+  });
+
+  test.describe('data drive tests', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/ids-popup-menu/data-driven.html');
+    });
+
+    test('reverts to markup-driven when provided an empty dataset', async ({ page }) => {
+      const results = await page.evaluate(() => {
+        const menu = document.querySelector<IdsPopupMenu>('ids-popup-menu')!;
+        const menus = document.querySelectorAll('ids-popup-menu');
+        menu.data = null as any;
+        return [menu.data, menus.length];
+      });
+
+      expect(results[0]).toEqual([]);
+      expect(results[1]).toEqual(1);
+    });
+  });
 });

--- a/tests/ids-popup-menu/ids-popup-menu.spec.ts
+++ b/tests/ids-popup-menu/ids-popup-menu.spec.ts
@@ -89,15 +89,16 @@ test.describe('IdsPopupMenu tests', () => {
     });
 
     test('reverts to markup-driven when provided an empty dataset', async ({ page }) => {
-      const results = await page.evaluate(() => {
-        const menu = document.querySelector<IdsPopupMenu>('ids-popup-menu')!;
-        const menus = document.querySelectorAll('ids-popup-menu');
-        menu.data = null as any;
-        return [menu.data, menus.length];
+      await page.evaluate(() => {
+        const elem = document.querySelector<IdsPopupMenu>('ids-popup-menu')!;
+        elem.show();
       });
-
-      expect(results[0]).toEqual([]);
-      expect(results[1]).toEqual(1);
+      await page.waitForFunction(() => document.querySelector<IdsPopupMenu>('ids-popup-menu')?.visible === true);
+      const markup: string = await page.evaluate(() => {
+        const elem = document.querySelector<IdsPopupMenu>('ids-popup-menu')!;
+        return elem.innerHTML;
+      });
+      expect(markup).toContain(' Sub Sub Menu 1');
     });
   });
 });

--- a/tests/ids-popup/ids-popup.spec.ts
+++ b/tests/ids-popup/ids-popup.spec.ts
@@ -63,4 +63,47 @@ test.describe('IdsPopup tests', () => {
       await percySnapshot(page, 'ids-popup-light');
     });
   });
+
+  test.describe('event tests', () => {
+    test('should fire show event', async ({ page }) => {
+      const noOfCalls = await page.evaluate(() => {
+        let calls = 0;
+        const popup = document.querySelector<IdsPopup>('#popup-1')!;
+        popup?.addEventListener('show', () => { calls++; });
+        popup.visible = true;
+        return calls;
+      });
+      expect(await noOfCalls).toBe(1);
+    });
+
+    test('should fire hide event', async ({ page }) => {
+      const noOfCalls = await page.evaluate(() => {
+        let calls = 0;
+        const popup = document.querySelector<IdsPopup>('#popup-1')!;
+        popup.visible = true;
+        popup?.addEventListener('hide', () => { calls++; });
+        popup.visible = false;
+        return calls;
+      });
+      expect(await noOfCalls).toBe(1);
+    });
+
+    test('can set visibility', async ({ page }) => {
+      const locator = await page.locator('#popup-1').first();
+      await page.evaluate(() => {
+        const popup = document.querySelector<IdsPopup>('#popup-1')!;
+        popup.visible = true;
+      });
+
+      expect(await locator.getAttribute('aria-hidden')).toBeFalsy();
+      expect(await locator.getAttribute('visible')).toBe('');
+
+      await page.evaluate(() => {
+        const popup = document.querySelector<IdsPopup>('#popup-1')!;
+        popup.visible = false;
+      });
+      expect(await locator.getAttribute('visible')).toBeFalsy();
+      expect(await locator.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds a `beforeShow` method to popup menu so it can be loaded dynamically and in addition

- Fixed issue with events firing too many times
- Fixed an issue with recent loading indicator fixes in fire fox
- Added a menu button example

**Related github/jira issue (required)**:
Fixes #1804 
Fixes https://github.com/infor-design/enterprise-wc/issues/1617

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-popup-menu/load-data.html and open the menu, contents should be fetched  dynamically
- go to  http://localhost:4300/ids-menu-button/load-data.html and open the menu, contents should be fetched  dynamically
- open this page in FF and it should lay out correctly http://localhost:4300/ids-data-grid/loading-indicator.html

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.