### PR TITLE
1813 - IdsDataGrid contextmenu duplicate selected event

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[ColorPicker]` Fix Color Picker support for angular form controls. ([#1774](https://github.com/infor-design/enterprise-wc/issues/1774))
 - `[DataGrid]` Added dirty tracker to checkbox editor. ([#1747](https://github.com/infor-design/enterprise-wc/issues/1747))
+- `[DataGrid]` Fixed duplicate context menu selected events. ([#1813](https://github.com/infor-design/enterprise-wc/issues/1813))
 - `[Dropdown]` Fixed incorrect form values in reactive forms. ([#1850](https://github.com/infor-design/enterprise-wc/issues/1850))
 - `[Slider]` Rounded up the value to decimal to match the tooltip. ([#1746](https://github.com/infor-design/enterprise-wc/issues/1746))
 - `[TimePicker/Calendar]` Fixed outside click when interacting with the popup. ([#1860](https://github.com/infor-design/enterprise-wc/issues/1860))

--- a/src/components/ids-data-grid/ids-data-grid-contextmenu.ts
+++ b/src/components/ids-data-grid/ids-data-grid-contextmenu.ts
@@ -158,11 +158,7 @@ function handleContextmenu(
  * @param {IdsPopupMenu} menuEl The menu element for contextmenu.
  * @returns {void}
  */
-function handleContextmenuSelectedItem(
-  this: IdsDataGrid,
-  e: IdsDataGridContextmenuSelected,
-  menuEl?: IdsPopupMenu,
-): void {
+function handleContextmenuSelectedItem(this: IdsDataGrid, e: IdsDataGridContextmenuSelected, menuEl?: IdsPopupMenu): void {
   if (menuEl) {
     const args = {
       data: {
@@ -207,8 +203,8 @@ export function setContextmenu(this: IdsDataGrid) {
 
     // Selected item for header, and header group.
     if (headerMenu) {
-      this.offEvent('selected.datagrid-contextmenu-item', headerMenu);
-      this.onEvent('selected.datagrid-contextmenu-item', headerMenu, (e: IdsDataGridContextmenuSelected) => {
+      this.offEvent('selected.datagrid-header-contextmenu-item', headerMenu);
+      this.onEvent('selected.datagrid-header-contextmenu-item', headerMenu, (e: IdsDataGridContextmenuSelected) => {
         handleContextmenuSelectedItem.apply(this, [e, headerMenu]);
       });
     }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes duplicate contextmenu selected events for datagrid

**Related github/jira issue (required)**:
Closes #1813 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/contextmenu-before-show.html
3. Right-click on grid cells/header and select an item
4. Check the console logs to see that the select event is fired
5. Repeat steps 3-4 a few times to check that each item select click fires only 1 selected event each time

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

