### PR TITLE
1730 - process-indicator labels and icons were overlapping

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.22 Features
 
+- `[ProcessIndicator]` Style fix prevent labels and icons from overlapping on initial page-load. ([#1730](https://github.com/infor-design/enterprise-wc/issues/1730))
 - `[PopupMenu]` Added ability to load menu data in a callback with `beforeShow`. ([#1804](https://github.com/infor-design/enterprise-wc/issues/1804))
 
 ### 1.0.0-beta.22 Fixes

--- a/src/components/ids-process-indicator/ids-process-indicator-step.scss
+++ b/src/components/ids-process-indicator/ids-process-indicator-step.scss
@@ -47,6 +47,12 @@
       margin-top: unset;
     }
   }
+
+  @media (min-width: $breakpoint-lg) {
+    .label {
+      display: flex;
+    }
+  }
 }
 
 ::slotted(*) {
@@ -63,6 +69,7 @@
 
     &.label {
       margin: var(--ids-process-indicator-margin);
+      margin-bottom: 16px;
       white-space: nowrap;
     }
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Labels and icons are overlapping.

Steps to reproduce the behavior:

1. Go to https://main.wc.design.infor.com/ids-process-indicator/example.html
2. Continually refresh the page until you see the overlapping error

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1730 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Check out this branch and run: `nvm use && npm i && npm run start`
- Open this page in incognito mode: http://localhost:4300/ids-process-indicator/example.html
- Continually refresh the page and ensure labels and step icons never overlap.


**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
