### PR TITLE
1714 - datagrid editor dropdown column settings

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.0.0-beta.22 Features
 
+- `[Datagrid]` Add ability (and example) to set editor's column settings from server. ([#1714](https://github.com/infor-design/enterprise-wc/issues/1714))
 - `[ProcessIndicator]` Style fix prevent labels and icons from overlapping on initial page-load. ([#1730](https://github.com/infor-design/enterprise-wc/issues/1730))
 - `[PopupMenu]` Added ability to load menu data in a callback with `beforeShow`. ([#1804](https://github.com/infor-design/enterprise-wc/issues/1804))
 

--- a/src/components/ids-data-grid/demos/column-settings-server-side.html
+++ b/src/components/ids-data-grid/demos/column-settings-server-side.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-data-grid id="data-grid-1" editable="true" row-selection="single"></ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/column-settings-server-side.ts
+++ b/src/components/ids-data-grid/demos/column-settings-server-side.ts
@@ -1,4 +1,4 @@
-import booksJSON from '../../../assets/data/books.json';
+// import booksJSON from '../../../assets/data/books.json';
 import '../ids-data-grid';
 import type IdsDataGrid from '../ids-data-grid';
 import type { IdsDataGridColumn } from '../ids-data-grid-column';
@@ -117,7 +117,7 @@ if (dataGrid) {
       if (!updatedColumns?.[3]?.editor?.editorSettings) return;
 
       // set options later simulating options comming from server
-      console.log('Now setting >>> updatedColumns[3].editor.editorSettings.options');
+      console.info('Now setting >>> updatedColumns[3].editor.editorSettings.options');
       updatedColumns[3].editor.editorSettings.options = [
         {
           value: 'Administration',

--- a/src/components/ids-data-grid/demos/column-settings-server-side.ts
+++ b/src/components/ids-data-grid/demos/column-settings-server-side.ts
@@ -1,0 +1,140 @@
+import booksJSON from '../../../assets/data/books.json';
+import '../ids-data-grid';
+import type IdsDataGrid from '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-1')!;
+
+if (dataGrid) {
+  (async function init() {
+    // Do an ajax request
+    // const url: any = booksJSON;
+
+    const columns: IdsDataGridColumn[] = [];
+    columns.push({
+      id: 'id',
+      name: 'ID',
+      field: 'id',
+      editor: {
+        type: 'input',
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true
+        }
+      }
+    });
+    columns.push({
+      id: 'name',
+      name: 'Name',
+      field: 'name',
+      editor: {
+        type: 'input',
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true
+        }
+      }
+    });
+    columns.push({
+      id: 'isAdmin',
+      name: 'Is Admin',
+      field: 'isAdmin',
+      formatter: dataGrid.formatters.checkbox,
+      editor: {
+        type: 'checkbox',
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true
+        }
+      }
+    });
+    columns.push({
+      id: 'role',
+      name: 'Role',
+      field: 'role',
+      // NOTE: commenting this out to set later in setTimeout()
+      // formatter: dataGrid.formatters.dropdown,
+      editor: {
+        type: 'dropdown',
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true,
+          // NOTE: commenting these out to set later in setTimeout()
+          // options: [{
+          //   value: 'Administration',
+          //   label: 'Administration'
+          // },{
+          //   value: 'Manager',
+          //   label: 'Manager'
+          // },{
+          //   value: 'Developer',
+          //   label: 'Developer'
+          // }]
+        }
+      }
+    });
+    columns.push({
+      id: 'date',
+      name: 'Date',
+      field: 'date',
+      editor: {
+        type: 'datepicker',
+        editorSettings: {
+          autoselect: true,
+          dirtyTracker: true
+        }
+      }
+    });
+
+    const gridData = [{
+      id: 1,
+      name: 'User 1',
+      isAdmin: true,
+      date: '05-11-2022',
+      role: 'Administration'
+    },
+    {
+      id: 2,
+      name: 'User 2',
+      isAdmin: false,
+      date: '06-11-2022',
+      role: 'Manager'
+    },
+    {
+      id: 3,
+      name: 'User 3',
+      isAdmin: true,
+      date: '07-11-2022',
+      role: 'Developer'
+    }];
+
+    dataGrid.columns = columns;
+    dataGrid.data = gridData;
+
+    setTimeout(() => {
+      const updatedColumns = dataGrid.columns;
+      if (!updatedColumns?.[3]?.editor?.editorSettings) return;
+
+      // set options later simulating options comming from server
+      console.log('Now setting >>> updatedColumns[3].editor.editorSettings.options');
+      updatedColumns[3].editor.editorSettings.options = [
+        {
+          value: 'Administration',
+          label: 'Administration'
+        },
+        {
+          value: 'Manager',
+          label: 'Manager'
+        },
+        {
+          value: 'Developer',
+          label: 'Developer'
+        }
+      ];
+
+      updatedColumns[3].formatter = dataGrid.formatters.dropdown;
+      dataGrid.columns = updatedColumns;
+    }, 2000);
+  }());
+}

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -239,6 +239,9 @@
   - link: tooltip.html
     type: Example
     description: Shows a data grid with tooltip
+  - link: column-settings-server-side.html
+    type: Example
+    description: Shows a data grid with server-side column-settings
   - link: save-settings.html
     type: Example
     description: Shows a data grid to save user settings

--- a/src/components/ids-data-grid/ids-data-grid-editors.ts
+++ b/src/components/ids-data-grid/ids-data-grid-editors.ts
@@ -213,7 +213,7 @@ export class DropdownEditor implements IdsDataGridEditor {
   clickEvent?: MouseEvent;
 
   init(cell?: IdsDataGridCell): void {
-    this.#value = cell?.querySelector('[data-value]')?.getAttribute('data-value') ?? null;
+    this.#value = cell?.querySelector('[data-value]')?.getAttribute('data-value') ?? cell?.value ?? null;
     const isInline = cell?.column.editor?.inline;
     const settings = { ...cell?.column?.editor?.editorSettings };
     const dataset = <any[]>settings?.options ?? [];
@@ -262,7 +262,7 @@ export class DropdownEditor implements IdsDataGridEditor {
       };
     }
 
-    this.input.value = this.#value;
+    this.input.value = this.#value ?? '';
     this.input.size = 'full';
     this.input.labelState = 'collapsed';
     this.input.colorVariant = isInline ? 'in-cell' : 'borderless';
@@ -325,7 +325,7 @@ export class DropdownEditor implements IdsDataGridEditor {
       });
     }
 
-    this.list?.onEvent('keydown', this.list, (e) => {
+    this.input?.onEvent('keydown', this.list, (e) => {
       const key = e.key;
       if (key === 'Enter') {
         e.stopPropagation();


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added ability (and example) to set editor's column settings from server.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1714 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out this PRs' branch and run: `nvm use && npm run start`
2. Go to: http://localhost:4300/ids-data-grid/column-settings-server-side.html
3. Open the web developer console
4. Click on any cell in the "Role" column as quickly as possible.
5. The list of options should update after you see this text in the dev console: "Now setting >>> updatedColumns[3].editor.editorSettings.options"


**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
