### PR TITLE
2059 - Fix error that was thrown upon modal open after detach/reattach of lookup

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 1.0.0-beta.22 Fixes
 
+- `[Lookup]` Fix error that was thrown upon modal open after detach/reattach of lookup. ([#2059](https://github.com/infor-design/enterprise-wc/issues/2059))
 - `[Card]` Fix selected state styles for dark mode. ([#1887](https://github.com/infor-design/enterprise-wc/issues/1887))
 - `[Datagrid]` Fixed a display issue with the new loading indicator in firefox. ([#1617](https://github.com/infor-design/enterprise-wc/issues/1617))
 - `[Datagrid]` Added custom validation for editable datagrid cells. ([#1791](https://github.com/infor-design/enterprise-wc/issues/1791))

--- a/src/mixins/ids-focus-capture-mixin/ids-focus-capture-mixin.ts
+++ b/src/mixins/ids-focus-capture-mixin/ids-focus-capture-mixin.ts
@@ -3,7 +3,7 @@ import { attributes } from '../../core/ids-attributes';
 
 // Import Utils
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
-import { getClosestContainerNode } from '../../utils/ids-dom-utils/ids-dom-utils';
+import { getClosestContainerNode, getClosestRootNode } from '../../utils/ids-dom-utils/ids-dom-utils';
 import { IdsConstructor } from '../../core/ids-element';
 import { EventsMixinInterface } from '../ids-events-mixin/ids-events-mixin';
 
@@ -41,6 +41,7 @@ const IdsFocusCaptureMixin = <T extends Constraints>(superclass: T) => class ext
   connectedCallback() {
     super.connectedCallback?.();
     if (this.hasAttribute(attributes.FOCUS_INLINE)) this.syncInline(true);
+    else this.#hostNode = getClosestRootNode(this);
   }
 
   disconnectedCallback(): void {

--- a/tests/ids-lookup/ids-lookup.spec.ts
+++ b/tests/ids-lookup/ids-lookup.spec.ts
@@ -496,4 +496,23 @@ test.describe('IdsLookup tests', () => {
       expect(values3[1]).toEqual(false);
     });
   });
+
+  test.describe('reattachment tests', () => {
+    test('should not throw error upon modal open after detach/reattach', async ({ page }) => {
+      page.on('pageerror', (err) => {
+        expect(err).toBeNull();
+      });
+
+      await page.evaluate(() => {
+        const lookupElem = document.querySelector('#lookup-5')!;
+        const parentNode = lookupElem.parentNode!;
+
+        parentNode.removeChild(lookupElem);
+        parentNode.appendChild(lookupElem);
+      });
+
+      await page.locator('#lookup-5 ids-trigger-button').first().click();
+      await page.waitForTimeout(1000);
+    });
+  });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added in a fix that ensures hostNode is set when lookup is rendered.

**Related github/jira issue (required)**:
Closes #2059 

**Steps necessary to review your pull request (required)**:
- Pull branch and run locally
- Go to http://localhost:4300/ids-lookup/example.html
- Open the developer's console
- Type (function() { const container = document.querySelector("#lookup-5"); const parent = container.parentNode; parent.removeChild(container); parent.appendChild(container); })() and enter
- Click the search button inside the Custom Lookup


**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
