### PR TITLE
1838 - ids-dropdown allow empty string value

### DIFF
--- a/src/components/ids-dropdown/demos/example.html
+++ b/src/components/ids-dropdown/demos/example.html
@@ -138,12 +138,24 @@
           </ids-list-box>
         </ids-dropdown>
 
-        <ids-dropdown id="dropdown-8" label="Dropdown with Allow Blank" allow-blank>
+        <ids-dropdown id="dropdown-8" label="Dropdown with allow-blank attribute" allow-blank>
           <ids-list-box>
             <ids-list-box-option value="opt1" id="opt1-d8">
               <span>Option One</span>
             </ids-list-box-option>
             <ids-list-box-option value="opt2" id="opt2-d8">
+              <span>Option Two</span>
+          </ids-list-box>
+        </ids-dropdown>
+        <ids-dropdown id="dropdown-9" label="Dropdown with blank value">
+          <ids-list-box>
+            <ids-list-box-option value="" id="opt0-d9">
+              <span>--- Blank ---</span>
+            </ids-list-box-option>
+            <ids-list-box-option value="opt1" id="opt1-d9">
+              <span>Option One</span>
+            </ids-list-box-option>
+            <ids-list-box-option value="opt2" id="opt2-d9">
               <span>Option Two</span>
           </ids-list-box>
         </ids-dropdown>

--- a/src/components/ids-dropdown/ids-dropdown-list.ts
+++ b/src/components/ids-dropdown/ids-dropdown-list.ts
@@ -110,7 +110,8 @@ export default class IdsDropdownList extends Base {
     this.configureListBox();
     this.configurePopup();
     this.setAriaOnMenuOpen();
-    if (this.value) this.selectOption(this.value);
+
+    if (this.value || typeof this.value === 'string') this.selectOption(this.value);
   }
 
   onTargetChange() {
@@ -418,7 +419,7 @@ export default class IdsDropdownList extends Base {
    */
   set value(value: string | null) {
     let selector = `ids-list-box-option[value="${value}"]`;
-    if (value === ' ' || !value) selector = `ids-list-box-option:not([value])`;
+    if (value === ' ' || value === null) selector = `ids-list-box-option:not([value])`;
     const elem = this.listBox?.querySelector<IdsListBoxOption>(selector);
     if (!elem) return;
 

--- a/tests/ids-dropdown/ids-dropdown.spec.ts
+++ b/tests/ids-dropdown/ids-dropdown.spec.ts
@@ -179,6 +179,33 @@ test.describe('IdsDropdown tests', () => {
       expect(values2[1]).toBeNull();
     });
 
+    test('can have blank value=""', async ({ page }) => {
+      const values = await page.evaluate(() => {
+        const dropdown = document.querySelector<IdsDropdown>('ids-dropdown#dropdown-9')!;
+        return [dropdown?.allowBlank, dropdown.value];
+      });
+
+      const [allowBlank, value] = values;
+      expect(allowBlank).toBeFalsy();
+      expect(value).toEqual(null);
+
+      const newValue = await page.evaluate(() => {
+        const dropdown = document.querySelector<IdsDropdown>('ids-dropdown#dropdown-9')!;
+        dropdown.options[2].click();
+        return dropdown.value;
+      });
+
+      expect(newValue).toBe('opt2');
+
+      const blankValue = await page.evaluate(() => {
+        const dropdown = document.querySelector<IdsDropdown>('ids-dropdown#dropdown-9')!;
+        dropdown.options[0].click();
+        return dropdown.value;
+      });
+
+      expect(blankValue).toEqual('');
+    });
+
     test('can view tooltips on dropdown and options', async ({ page }) => {
       const dropdownLocator: Locator = await page.locator('#dropdown-6');
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix that allows `ids-dropdown` to have empty value `value=""`.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1838 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. Check out this branch and run: `nvm use && npm i && npm run start`
2. Go to http://localhost:4300/ids-dropdown/example.html
3. Select a value in the last dropdown called "Dropdown with blank value"
4. Enter this in dev console: `$('ids-dropdown#dropdown-9').value` 
5. Select the "--- Blank ---" value in the dropdown
6. Ensure you get empty-string when you try this in dev console: `$('ids-dropdown#dropdown-9').value`

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
