### PR TITLE
1889 - ids-lookup trigger button not working in Angular

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Add ability (and example) to set editor's column settings from server. ([#1714](https://github.com/infor-design/enterprise-wc/issues/1714))
 - `[Input]` Added `checkOverflow()` check to `IdsInput` to ensure only showing tooltip when text-overflow ellipses. ([#1755](https://github.com/infor-design/enterprise-wc/issues/1755))
+- `[Lookup]` Fix `IdsLookup` (for Angular) so that modal triggers are attached after the modal has been mounted/constructed. ([#1889](https://github.com/infor-design/enterprise-wc/issues/1889))
 - `[ProcessIndicator]` Style fix prevent labels and icons from overlapping on initial page-load. ([#1730](https://github.com/infor-design/enterprise-wc/issues/1730))
 - `[PopupMenu]` Added ability to load menu data in a callback with `beforeShow`. ([#1804](https://github.com/infor-design/enterprise-wc/issues/1804))
 - `[TagList]` Added a new `ids-tag-list` layout and eventing component. ([#1903](https://github.com/infor-design/enterprise-wc/issues/1903))

--- a/src/components/ids-lookup/ids-lookup.ts
+++ b/src/components/ids-lookup/ids-lookup.ts
@@ -71,8 +71,6 @@ export default class IdsLookup extends Base {
 
   dataGrid?: IdsDataGrid | null;
 
-  modal?: IdsModal | null;
-
   listBox?: any;
 
   state = {
@@ -81,6 +79,10 @@ export default class IdsLookup extends Base {
     value: '',
     title: ''
   };
+
+  get modal(): IdsModal | null {
+    return this.querySelector('[slot="lookup-modal"]') || this.shadowRoot?.querySelector('ids-modal') || null;
+  }
 
   constructor() {
     super();
@@ -110,11 +112,8 @@ export default class IdsLookup extends Base {
     this.dataGrid = this.shadowRoot?.querySelector('ids-data-grid');
     this.dataGrid?.setAttribute(attributes.LIST_STYLE, 'true');
 
-    // Link the Modal to its trigger button (sets up click/focus events)
-    this.modal = this.querySelector('[slot="lookup-modal"]') || this.shadowRoot?.querySelector('ids-modal');
-    if (this.modal) {
-      this.modal.target = this.triggerButton as IdsPopupElementRef;
-      this.modal.triggerType = 'click';
+    if (this.state.dataGridSettings) {
+      this.dataGridSettings = this.state.dataGridSettings;
     }
 
     this
@@ -122,11 +121,18 @@ export default class IdsLookup extends Base {
       .#handleKeys();
   }
 
+  mountedCallback(): void {
+    if (this.modal) {
+      // Link the Modal to its trigger button (sets up click/focus events)
+      this.modal.target = this.triggerButton as IdsPopupElementRef;
+      this.modal.triggerType = 'click';
+    }
+  }
+
   disconnectedCallback(): void {
     super.disconnectedCallback?.();
 
     this.dataGrid = undefined;
-    this.modal = undefined;
     this.triggerField = undefined;
     this.triggerButton = undefined;
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
`IdsLookup` trigger button not working in Angular because `IdsModal` is operated on in IdsLookup.connectedCallback() before its constructor/connectedCallback is called (i.e. a race-condition).  The solution is to move the ids-modal logic from `IdsLookup.connectedCallback()` to `IdsLookup.mountedCallback()`;

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1889 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. Check out this branch and run: `nvm use && npm install && npm run start`
2. In another terminal window, and run `npm run publish:link`
3. Then check out https://github.com/infor-design/enterprise-wc-examples
4. Then run: `npm install && npm link ids-enterprise-wc`
5. Then run: `rm -fr .angular/cache && npm run build && npm run start`
6. Then confirm trigger button works here: http://localhost:4200/ids-lookup/example 

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
