### PR TITLE
2023: IdsDropdown validate attribute not working in React and Angular

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.0-beta.22 Features
 
 - `[Datagrid]` Add ability (and example) to set editor's column settings from server. ([#1714](https://github.com/infor-design/enterprise-wc/issues/1714))
+- `[Dropdown]` Fix issue where required dropdowns were note rendering asterisk in React and Angular examples. ([#2023](https://github.com/infor-design/enterprise-wc/issues/2023))
 - `[Input]` Added `checkOverflow()` check to `IdsInput` to ensure only showing tooltip when text-overflow ellipses. ([#1755](https://github.com/infor-design/enterprise-wc/issues/1755))
 - `[ProcessIndicator]` Style fix prevent labels and icons from overlapping on initial page-load. ([#1730](https://github.com/infor-design/enterprise-wc/issues/1730))
 - `[PopupMenu]` Added ability to load menu data in a callback with `beforeShow`. ([#1804](https://github.com/infor-design/enterprise-wc/issues/1804))

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -155,6 +155,7 @@ export default class IdsDropdown extends Base {
     return [
       ...super.attributes,
       attributes.MAX_HEIGHT,
+      attributes.VALIDATE
     ];
   }
 

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -163,7 +163,7 @@ export default class IdsInput extends Base {
       attributes.TEXT_ELLIPSIS,
       attributes.TYPE,
       attributes.UPPERCASE,
-      attributes.VALUE
+      attributes.VALUE,
     ];
   }
 

--- a/src/components/ids-input/ids-input.ts
+++ b/src/components/ids-input/ids-input.ts
@@ -163,7 +163,7 @@ export default class IdsInput extends Base {
       attributes.TEXT_ELLIPSIS,
       attributes.TYPE,
       attributes.UPPERCASE,
-      attributes.VALUE,
+      attributes.VALUE
     ];
   }
 

--- a/src/components/ids-trigger-field/ids-trigger-field.ts
+++ b/src/components/ids-trigger-field/ids-trigger-field.ts
@@ -61,7 +61,8 @@ export default class IdsTriggerField extends IdsInput {
     return [
       ...super.attributes,
       attributes.FORMAT,
-      attributes.TABBABLE
+      attributes.TABBABLE,
+      attributes.VALIDATE
     ];
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds a fix for the required asterisk did not show when ids-dropdown validate attribute is set to required in React TS and Angular examples.

**Related github/jira issue (required)**:
closes #2023

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- `npm run build:dist:prod`
- copy build to local React ts examples node_modules
- run the React ts examples
- go to http://localhost:3000/ids-dropdown
- see required dropdown is showing the asterisk

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
