### PR TITLE
1892 - IdsModal Clicking outside

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Lookup]` Fix error that was thrown upon modal open after detach/reattach of lookup. ([#2059](https://github.com/infor-design/enterprise-wc/issues/2059))
 - `[ListView]` Added support for attributes `tooltip`, `max-width` and `overflow="ellipses"`. ([#1637](https://github.com/infor-design/enterprise-wc/issues/1637))
 - `[Modal]` Converted modal, about, error page, action panel tests. ([#1847](https://github.com/infor-design/enterprise-wc/issues/1847))
+- `[Modal]` Fixed clicking outside the modal does not close the modal. ([#1892](https://github.com/infor-design/enterprise-wc/issues/1892))
 - `[Radio]` Converted radio tests to playwright. ([#1872](https://github.com/infor-design/enterprise-wc/issues/1872))
 - `[Tree]` Fixed selected event returning incorrect node data after adding children through addNodes. ([#1851](https://github.com/infor-design/enterprise-wc/issues/1851))
 - `[Wizard]` Fixed broken wizard component in angular framework. ([#1885](https://github.com/infor-design/enterprise-wc/issues/1885))

--- a/src/components/ids-modal/demos/keep-open.ts
+++ b/src/components/ids-modal/demos/keep-open.ts
@@ -27,15 +27,15 @@ document.addEventListener('DOMContentLoaded', () => {
   // Close behavior
 
   const checkbox: any = document.querySelector('ids-checkbox');
-  const defaultOnOutsideClick = modal.onOutsideClick;
+  const defaultOnOutsideClick = modal.onOutsideClick.bind(modal);
 
   checkbox.addEventListener('change', (e: CustomEvent) => {
     const isChecked = (e.target as any).checked;
     if (isChecked) {
-      modal.onOutsideClick = defaultOnOutsideClick;
+      modal.popup.onOutsideClick = defaultOnOutsideClick;
     } else {
       // Overrides the default `onOutsideClick` to just keep the Modal open
-      modal.onOutsideClick = () => {};
+      modal.popup.onOutsideClick = () => {};
     }
   });
 });

--- a/src/components/ids-modal/ids-modal.ts
+++ b/src/components/ids-modal/ids-modal.ts
@@ -111,8 +111,6 @@ export default class IdsModal extends Base {
       this.popup.setAttribute(attributes.ANIMATED, '');
       this.popup.setAttribute(attributes.ANIMATION_STYLE, 'scale-in');
       this.popup.onOutsideClick = this.onOutsideClick.bind(this);
-      this.popup.addOpenEvents = this.addOpenEvents.bind(this);
-      this.popup.removeOpenEvents = this.removeOpenEvents.bind(this);
     }
 
     // Update ARIA / Sets up the label
@@ -486,7 +484,7 @@ export default class IdsModal extends Base {
       this.setScrollable();
       this.popup.correct3dMatrix();
     }
-
+    if (this.overlay) this.overlay.visible = true;
     this.removeAttribute('aria-hidden');
 
     // Focus the correct element
@@ -536,7 +534,7 @@ export default class IdsModal extends Base {
     if (popupElem) popupElem.animated = true;
 
     this.removeOpenEvents();
-    this.overlay.visible = false;
+    if (this.overlay) this.overlay.visible = false;
     if (popupElem) popupElem.visible = false;
 
     // Animation-out can wait for the opacity transition to end before changing z-index.
@@ -580,6 +578,7 @@ export default class IdsModal extends Base {
 
     // If a Modal Button is clicked, fire an optional callback
     const buttonSlot = this.container?.querySelector('slot[name="buttons"]');
+    this.offEvent('click.buttons');
     this.onEvent('click.buttons', buttonSlot, async (e: MouseEvent) => {
       await this.handleButtonClick(e);
     });
@@ -709,7 +708,7 @@ export default class IdsModal extends Base {
    * @returns {void}
    */
   onOutsideClick(e: MouseEvent): void {
-    if (!e || !e?.target) {
+    if (!e?.target || e.composedPath()?.includes(this.popup as HTMLElement)) {
       return;
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/tests/ids-modal/ids-modal.spec.ts
+++ b/tests/ids-modal/ids-modal.spec.ts
@@ -154,10 +154,6 @@ test.describe('IdsModal tests', () => {
   });
 
   test.describe(('modal functionality'), () => {
-    test.beforeEach(async ({ page }) => {
-      await page.goto(url);
-    });
-
     test('hiding modal via Escape', async ({ page }) => {
       const buttonHandle = page.locator('#modal-trigger-btn');
       const modalHandle = page.locator('#my-modal');
@@ -168,6 +164,32 @@ test.describe('IdsModal tests', () => {
       // Close via escape
       await page.keyboard.press('Escape');
       await page.waitForSelector('ids-modal:not([visible])');
+    });
+
+    test('should hide modal when clicking outside', async ({ page }) => {
+      const modal = await page.locator('ids-modal');
+      await modal.evaluate(async (elem: IdsModal) => {
+        elem.popup!.animated = false;
+        await elem.show();
+      });
+      await expect(modal).toHaveAttribute('visible');
+
+      // Click outside modal
+      await page.evaluate(() => {
+        document.querySelector<any>('ids-container')?.querySelector('ids-theme-switcher')?.click();
+      });
+      await page.waitForSelector('ids-modal:not([visible])');
+
+      // Disable outside click
+      await modal.evaluate(async (elem: IdsModal) => {
+        elem.popup!.onOutsideClick = () => {};
+        await elem.show();
+      });
+      await expect(modal).toHaveAttribute('visible');
+      await page.evaluate(() => {
+        document.querySelector<any>('ids-container')?.querySelector('ids-theme-switcher')?.click();
+      });
+      await page.waitForSelector('ids-modal[visible]');
     });
 
     test('setting custom overlay', async ({ page }) => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added clicking outside functionality to the modal

**Related github/jira issue (required)**:
Closes #1892 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-modal/example.html
- open the modal
- click outside the modal popup and see that it closes the modal
- go to http://localhost:4300/ids-modal/keep-open.html
- uncheck `Allow the modal to close by clicking outside`
- click outside the modal popup and see that it does not close the modal

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
