### PR TITLE
1836 - ids-tree with ids-splitter shows horizontal-scrollbar after collapsed

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[LayoutFlex]` Converted layout flex tests to playwright. ([#1944](https://github.com/infor-design/enterprise-wc/issues/1944))
 - `[LayoutGridCell/Attributes]` Corrected the values of `COL_END_*` constants from `col_start_*` to `col_end_*` along with the test coverage of the `IdsLayoutGridCell`. ([#2075](https://github.com/infor-design/enterprise-wc/issues/2075))
 - `[Lookup]` Fix `IdsLookup` (for Angular) so that modal triggers are attached after the modal has been mounted/constructed. ([#1889](https://github.com/infor-design/enterprise-wc/issues/1889))
+- `[Tree|Splitter]` Fixed horizontal scrollbar showing on tree-grid even after tree is collapsed and no longer in need of scrollbar. ([#1836](https://github.com/infor-design/enterprise-wc/issues/1836))
 - `[Tree]` Re-Fixed selected event returning incorrect node data after adding children through addNodes. ([#1851](https://github.com/infor-design/enterprise-wc/issues/1851))
 - `[Draggable] Converted draggable tests to playwright. ([#1929](https://github.com/infor-design/enterprise-wc/issues/1929))
 

--- a/src/components/ids-splitter/demos/index.yaml
+++ b/src/components/ids-splitter/demos/index.yaml
@@ -17,3 +17,6 @@
   - link: side-by-side.html
     type: Side by Side
     description: Shows the splitter component side by side with 4.x
+  - link: tree-detail.html
+    type: Tree Detail
+    description: Shows the splitter component side by side with tree view

--- a/src/components/ids-splitter/demos/tree-detail.html
+++ b/src/components/ids-splitter/demos/tree-detail.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="0" hidden>
+    <ids-splitter>
+
+      <ids-splitter-pane size="25%">
+        <ids-tree id="tree" label="Tree"></ids-tree>
+      </ids-splitter-pane>
+
+      <ids-splitter-pane>
+        <ids-list-view item-height="76" selectable="single">
+          <template>
+            <ids-text font-size="16" type="h2" font-weight="semi-bold">${name}</ids-text>
+            <ids-layout-grid cols="1" padding-y="xxs">
+              <ids-layout-grid-cell>
+                <ids-text font-size="16" type="span">${type}</ids-text>
+                <ids-text font-size="14" type="span">${location}</ids-text>
+              </ids-layout-grid-cell>
+            </ids-layout-grid>
+          </template>
+        </ids-list-view>
+      </ids-splitter-pane>
+
+    </ids-splitter>
+
+    <!--<ids-text align="left">This is an active IDS Modal component</ids-text>-->
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-splitter/demos/tree-detail.ts
+++ b/src/components/ids-splitter/demos/tree-detail.ts
@@ -1,0 +1,38 @@
+import treeBasicJSON from '../../../assets/data/tree-basic.json';
+import eventsJSON from '../../../assets/data/accounts.json';
+
+import '../../ids-container/ids-container';
+import '../../ids-button/ids-button';
+import '../../ids-list-view/ids-list-view';
+import '../ids-splitter';
+import '../ids-splitter-pane';
+import '../../ids-tree/ids-tree';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const tree: any = document.querySelector('ids-tree');
+  const listView = document.querySelector('ids-list-view:not([id])');
+
+  // get tree data
+  if (tree) {
+    (async function init() {
+      // Do an ajax request
+      const res = await fetch(treeBasicJSON as any);
+      const data: any = await res.json();
+      tree.data = data;
+    }());
+  }
+
+  // get listView data
+  if (listView) {
+    // Do an ajax request and apply the data to the list
+    const url: any = eventsJSON;
+
+    const setData = async () => {
+      const res = await fetch(url);
+      const data = await res.json();
+      (listView as any).data = data;
+    };
+
+    await setData();
+  }
+});

--- a/src/components/ids-tree/ids-tree-node.ts
+++ b/src/components/ids-tree/ids-tree-node.ts
@@ -197,7 +197,7 @@ export default class IdsTreeNode extends Base {
     if (this.groupNodesEl) {
       if (this.expanded) {
         // Expand
-        this.groupNodesEl.style.visibility = '';
+        this.groupNodesEl.style.display = '';
         this.groupNodesEl.style.maxHeight = `${this.groupNodesEl.scrollHeight}px`;
         this.offEvent('transitionend.expanded.tree', this.groupNodesEl);
         this.onEvent('transitionend.expanded.tree', this.groupNodesEl, () => {
@@ -211,7 +211,7 @@ export default class IdsTreeNode extends Base {
         this.groupNodesEl.style.transition = '';
         requestAnimationFrame(() => {
           this.groupNodesEl?.style.setProperty('max-height', '0');
-          this.groupNodesEl?.style.setProperty('visibility', 'hidden');
+          this.groupNodesEl?.style.setProperty('display', 'none');
         });
       }
     }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed horizontal scrollbar showing on tree-grid even after tree is collapsed and no longer in need of scrollbar.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1836 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out this PRs' branch and run: `nvm use && npm install && npm run start`
2. Go to: http://localhost:4300/ids-splitter/tree-detail.html
  3. Move the splitter to the left until it covers 3rd-level nodes, and the tree shows horizontal scrollbar at bottom of it's pane.
4. Collapse top-most tree node called "Public Folders" so that it's children are no longer visible
5. Ensure scrollbar goes away


**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
