### PR TITLE
1763 - IdsLayoutGrid/IdsLayoutFlex Add missing classes for standalone css

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Form]` Converted form tests to playwright. ([#1936](https://github.com/infor-design/enterprise-wc/issues/1936))
 - `[Input]` Fix clearing input value manually. ([#2011](https://github.com/infor-design/enterprise-wc/issues/2011))
 - `[LayoutFlex]` Converted layout flex tests to playwright. ([#1944](https://github.com/infor-design/enterprise-wc/issues/1944))
+- `[LayoutGrid/LayoutFlex]` Added missing classes for standalone css. ([#1763](https://github.com/infor-design/enterprise-wc/issues/1763))
 - `[LayoutGridCell/Attributes]` Corrected the values of `COL_END_*` constants from `col_start_*` to `col_end_*` along with the test coverage of the `IdsLayoutGridCell`. ([#2075](https://github.com/infor-design/enterprise-wc/issues/2075))
 - `[Lookup]` Fix `IdsLookup` (for Angular) so that modal triggers are attached after the modal has been mounted/constructed. ([#1889](https://github.com/infor-design/enterprise-wc/issues/1889))
 - `[Tree|Splitter]` Fixed horizontal scrollbar showing on tree-grid even after tree is collapsed and no longer in need of scrollbar. ([#1836](https://github.com/infor-design/enterprise-wc/issues/1836))

--- a/src/assets/css/ids-layout-grid/grid.css
+++ b/src/assets/css/ids-layout-grid/grid.css
@@ -25,6 +25,10 @@ ids-card::part(card) {
   margin-bottom: 24px;
 }
 
-.ids-layout-grid-cell.height-176 {
+.height-176 {
   height: 176px;
+}
+
+.border {
+  border: 1px solid var(--ids-color-gray-30);
 }

--- a/src/components/ids-layout-flex/ids-layout-flex-item.scss
+++ b/src/components/ids-layout-flex/ids-layout-flex-item.scss
@@ -34,7 +34,8 @@ $flex-shrink-list: 0 1;
 $overflow-list: auto hidden visible scroll;
 
 @each $overflow in $overflow-list {
-  :host([overflow='#{$overflow}']) {
+  :host([overflow='#{$overflow}']),
+  .ids-layout-flex-item-overflow-#{$overflow} {
     overflow: $overflow;
   }
 }

--- a/src/components/ids-layout-flex/ids-layout-flex.scss
+++ b/src/components/ids-layout-flex/ids-layout-flex.scss
@@ -89,11 +89,13 @@ $units: 0 1 2 4 8 12 16 20 24 28 32 36 40;
 }
 
 // Full Height
-:host([full-height]) {
+:host([full-height]),
+.ids-layout-flex-full-height {
   height: 100%;
 }
 
 // Fix icons
-::slotted(ids-icon) {
+::slotted(ids-icon),
+.ids-layout-flex > .ids-icon {
   display: inline-flex;
 }

--- a/src/components/ids-layout-grid/demos/standalone-css.html
+++ b/src/components/ids-layout-grid/demos/standalone-css.html
@@ -75,11 +75,7 @@
     </div>
   </div>
 
-  <div class="ids-layout-grid ids-layout-grid-auto-fit ids-layout-grid-margin-md">
-    <h1 class="ids-text ids-text-12">Layout Grid Align Items (Standalone CSS)</h1>
-  </div>
-
-  <div class="ids-layout-grid ids-layout-grid-cols-2 ids-layout-grid-padding-md ids-layout-grid-align-items-start height-176 border">
+  <div class="ids-layout-grid ids-layout-grid-cols-2 ids-layout-grid-padding-md ids-layout-grid-margin-y-md ids-layout-grid-align-items-start height-176 border">
     <div class="ids-layout-grid-cell fill">
       <h2 class="ids-text ids-text-12">Grid Cell Align Items Start</h2>
     </div>
@@ -88,7 +84,7 @@
     </div>
   </div>
 
-  <div class="ids-layout-grid ids-layout-grid-cols-2 ids-layout-grid-padding-md ids-layout-grid-align-items-center height-176 border">
+  <div class="ids-layout-grid ids-layout-grid-cols-2 ids-layout-grid-padding-md ids-layout-grid-margin-y-md ids-layout-grid-align-items-center height-176 border">
     <div class="ids-layout-grid-cell fill">
       <h2 class="ids-text ids-text-12">Grid Cell Align Items Center</h2>
     </div>

--- a/src/components/ids-layout-grid/demos/standalone-css.html
+++ b/src/components/ids-layout-grid/demos/standalone-css.html
@@ -75,5 +75,36 @@
     </div>
   </div>
 
+  <div class="ids-layout-grid ids-layout-grid-auto-fit ids-layout-grid-margin-md">
+    <h1 class="ids-text ids-text-12">Layout Grid Align Items (Standalone CSS)</h1>
+  </div>
+
+  <div class="ids-layout-grid ids-layout-grid-cols-2 ids-layout-grid-padding-md ids-layout-grid-align-items-start height-176 border">
+    <div class="ids-layout-grid-cell fill">
+      <h2 class="ids-text ids-text-12">Grid Cell Align Items Start</h2>
+    </div>
+    <div class="ids-layout-grid-cell fill">
+      <h2 class="ids-text ids-text-12">Grid Cell Align Items Start</h2>
+    </div>
+  </div>
+
+  <div class="ids-layout-grid ids-layout-grid-cols-2 ids-layout-grid-padding-md ids-layout-grid-align-items-center height-176 border">
+    <div class="ids-layout-grid-cell fill">
+      <h2 class="ids-text ids-text-12">Grid Cell Align Items Center</h2>
+    </div>
+    <div class="ids-layout-grid-cell fill">
+      <h2 class="ids-text ids-text-12">Grid Cell Align Items Center</h2>
+    </div>
+  </div>
+
+  <div class="ids-layout-grid ids-layout-grid-cols-2 ids-layout-grid-padding-md ids-layout-grid-align-items-end height-176 border">
+    <div class="ids-layout-grid-cell fill">
+      <h2 class="ids-text ids-text-12">Grid Cell Align Items End</h2>
+    </div>
+    <div class="ids-layout-grid-cell fill">
+      <h2 class="ids-text ids-text-12">Grid Cell Align Items End</h2>
+    </div>
+  </div>
+
 </body>
 </html>

--- a/src/components/ids-layout-grid/ids-layout-grid.scss
+++ b/src/components/ids-layout-grid/ids-layout-grid.scss
@@ -496,7 +496,8 @@ $max-width: var(--max-width);
 $align-items-list: start end center stretch;
 
 @each $align-items in $align-items-list {
-  :host([align-items='#{$align-items}']) {
+  :host([align-items='#{$align-items}']),
+  .#{$prefix}-align-items-#{$align-items} {
     align-items: $align-items;
   }
 }
@@ -505,7 +506,8 @@ $align-items-list: start end center stretch;
 $align-items-list: start end center stretch;
 
 @each $align-items in $align-items-list {
-  :host([align-items='#{$align-items}']) {
+  :host([align-items='#{$align-items}']),
+  .#{$prefix}-align-items-#{$align-items} {
     align-items: $align-items;
   }
 }
@@ -524,12 +526,14 @@ $align-content-list: start center space-between space-around space-evenly end;
     align-content: $align-content;
   }
 
-  ::slotted([justify-content='#{$align-content}']) {
+  ::slotted([justify-content='#{$align-content}']),
+  .#{$prefix} > .#{$prefix}-justify-#{$align-content} {
     display: grid;
     justify-content: $align-content;
   }
 
-  ::slotted([align-content='#{$align-content}']) {
+  ::slotted([align-content='#{$align-content}']),
+  .#{$prefix} > .#{$prefix}-align-#{$align-content} {
     display: grid;
     align-content: $align-content;
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds missing standalone classes to ids-layout-grid and ids-layout-flex

**Related github/jira issue (required)**:
closes #1763 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- Go to http://localhost:4300/ids-layout-grid/standalone-css.html
- Align items classes should render properly

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
