### PR TITLE
2069 - IdsDataGrid keep cell text white spaces

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Button]` Added updated button designs from the tokens. ([#1680](https://github.com/infor-design/enterprise-wc/issues/1680))
 - `[Button]` Fixed layout issues when buttons are next to each other. ([#1999](https://github.com/infor-design/enterprise-wc/issues/1999))
 - `[Datagrid]` Converted datagrid tests to playwright. ([#1845](https://github.com/infor-design/enterprise-wc/issues/1845))
+- `[Datagrid]` Fix maintaining editable cell text spaces. ([#2069](https://github.com/infor-design/enterprise-wc/issues/2069))
 - `[Draggable] Converted draggable tests to playwright. ([#1929](https://github.com/infor-design/enterprise-wc/issues/1929))
 - `[Dropdown]` Fix issue where required dropdowns were note rendering asterisk in React and Angular examples. ([#2023](https://github.com/infor-design/enterprise-wc/issues/2023))
 - `[Dropdown]` Fix issue where tooltips were not shown if options were lazy loaded. ([#2051](https://github.com/infor-design/enterprise-wc/issues/2051))

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -40,6 +40,7 @@
     height: auto;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: pre;
   }
 
   // Text Alignment


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added style rule `white-space: pre` to editable datagrid cells of `formatType: text` to maintain user input spaces.

**Related github/jira issue (required)**:
Closes #2069 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/editable.html
3. In an editable Description column cell, copy/paste text below
```
   1   4   1
```
5. Cell text should maintain spaces when done editing

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

