### PR TITLE
2070 - IdsAppMenu fix menu behavior after reattach

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 1.0.0-beta.23 Fixes
 
+- `[AppMenu]` Fix open/close events after reattach. ([#2070](https://github.com/infor-design/enterprise-wc/issues/2070))
 - `[Button]` Added updated button designs from the tokens. ([#1680](https://github.com/infor-design/enterprise-wc/issues/1680))
 - `[Button]` Fixed layout issues when buttons are next to each other. ([#1999](https://github.com/infor-design/enterprise-wc/issues/1999))
 - `[Datagrid]` Converted datagrid tests to playwright. ([#1845](https://github.com/infor-design/enterprise-wc/issues/1845))

--- a/src/components/ids-app-menu/ids-app-menu.ts
+++ b/src/components/ids-app-menu/ids-app-menu.ts
@@ -108,6 +108,7 @@ export default class IdsAppMenu extends Base {
     this.onEvent('hide.app-menu-hide', this, () => {
       this.#container?.classList.remove(CONTAINER_OPEN_CLASS);
     });
+    this.refreshTriggerEvents();
   }
 
   #detachEventHandlers() {
@@ -121,10 +122,11 @@ export default class IdsAppMenu extends Base {
   #setContainer() {
     this.#container = getClosest(this, 'ids-container');
     this.#container?.classList.add(CONTAINER_CLASS);
+    this.#container?.classList.toggle(CONTAINER_OPEN_CLASS, this.visible);
   }
 
   #clearContainer() {
-    this.#container?.classList.remove(CONTAINER_CLASS, CONTAINER_OPEN_CLASS);
+    this.#container?.classList.remove(CONTAINER_CLASS);
     this.#container = null;
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes open/close app menu behavior after the component is reattached in the DOM

**Related github/jira issue (required)**:
Closes #2070 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-app-menu/example.html
3. Run code snippet below
4. Test that the app menu can still open/close 

**Test reattach when app menu is open**
1. Refresh page
2. Open app menu
3. Run the code snippet below
4. Test that the app menu can still open/close 

Reattach Code Snippet
```
(function() { const container = document.querySelector("ids-container"); const parent = container.parentNode; parent.removeChild(container); parent.appendChild(container); })()
```

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

