### PR TITLE
2176 - Add copy button to about page

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.0.0
+
+### 1.0.0 Features
+
+- `[About]` Added the ability to copy stats to the clipboard with a button. ([#2176](https://github.com/infor-design/enterprise-wc/issues/2176))
+
 ## 1.0.0-beta.23
 
 ### 1.0.0-beta.23 Ui Changes

--- a/src/components/ids-about/ids-about.scss
+++ b/src/components/ids-about/ids-about.scss
@@ -101,3 +101,9 @@ div.ids-modal {
     max-height: 400px;
   }
 }
+
+#copy-to-clipboard {
+  position: absolute;
+  right: 20px;
+  bottom: 6px;
+}

--- a/src/components/ids-about/ids-about.ts
+++ b/src/components/ids-about/ids-about.ts
@@ -2,6 +2,7 @@ import { attributes } from '../../core/ids-attributes';
 import { customElement, scss } from '../../core/ids-decorators';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 import { getSpecs } from '../../utils/ids-device-env-specs-utils/ids-device-env-specs-utils';
+import { copyHtmlToClipboard } from '../../utils/ids-copy-utils/ids-copy-utils';
 
 import IdsLocaleMixin from '../../mixins/ids-locale-mixin/ids-locale-mixin';
 import IdsModal from '../ids-modal/ids-modal';
@@ -62,6 +63,10 @@ export default class IdsAbout extends Base {
             <slot name="copyright"></slot>
             <slot name="device"></slot>
           </div>
+          <ids-button id="copy-to-clipboard">
+            <ids-icon icon="copy"></ids-icon>
+            <span class="audible">${this.localeAPI?.translate('CopyToClipboard')}</span>
+          </ids-button>
         </div>
       </div>
     </ids-popup>`;
@@ -87,6 +92,12 @@ export default class IdsAbout extends Base {
       this.#refreshDeviceSpecs();
       this.#refreshCopyright();
     };
+
+    this.onEvent('click', this.container?.querySelector('#copy-to-clipboard'), async () => {
+      let specs = `${this.querySelector<HTMLSlotElement>('[slot="product"]')?.innerText}\r\n`;
+      specs += `${this.querySelector<HTMLSlotElement>('[slot="device"]')?.innerText}\r\n`;
+      await copyHtmlToClipboard(specs);
+    });
     return this;
   }
 

--- a/src/components/ids-locale/data/en-messages.json
+++ b/src/components/ids-locale/data/en-messages.json
@@ -84,6 +84,7 @@
   "Contrast": { "id": "Contrast", "value": "Contrast", "comment": "Name of the high contrast theme" },
   "CookiesEnabled": { "id": "CookiesEnabled", "value": "Cookies enabled", "comment": "Returns if browser cookies are enabled or not." },
   "Copy": { "id": "Copy", "value": "Copy", "comment": "Copy tooltip" },
+  "CopyToClipboard": { "id": "CopyToClipboard", "value": "Copy to clipboard", "comment": "Copy text" },
   "Croatian": { "id": "Croatian", "value": "Croatian", "comment": "Croatian (Croatia) language" },
   "CssClass": { "id": "CssClass", "value": "Css class", "comment": "Label for entering a Css Class name" },
   "Cut": { "id": "Cut", "value": "Cut", "comment": "Cut tooltip" },

--- a/src/utils/ids-copy-utils/ids-copy-utils.ts
+++ b/src/utils/ids-copy-utils/ids-copy-utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Copies a HTML section to the clipboard
+ * @param {string} html element to copy
+ * @returns {void}
+ */
+export async function copyHtmlToClipboard(html: string) {
+  await navigator.clipboard.writeText(html.trim());
+}

--- a/tests/ids-about/ids-about.spec.ts
+++ b/tests/ids-about/ids-about.spec.ts
@@ -125,5 +125,22 @@ test.describe('IdsAbout tests', () => {
       // check that translation took place for the word 'Platform'
       expect(await page.locator('ids-text[slot="device"]').textContent()).toContain(platformInSpanish);
     });
+
+    test('should be be possible to copy to clipboard ', async ({ page, context }) => {
+      await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+      await page.locator('#about-example-trigger').click();
+      await page.locator('#copy-to-clipboard').click();
+
+      // Get clipboard content after the link/button has been clicked
+      const handle = await page.evaluateHandle(() => navigator.clipboard.readText());
+      const clipboardContent = await handle.jsonValue();
+
+      // Check that the clipboard contains correct UUID
+      expect(clipboardContent).toContain('IDS version');
+      expect(clipboardContent).toContain('Controls Example Application Version No. XX');
+      expect(clipboardContent).toContain('Mobile');
+      expect(clipboardContent).toContain('Platform');
+    });
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds requested copy to clipboard button to copy stats/specs.

**Related github/jira issue (required)**:
Fixes #2176 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-about/example.html
- open the modal
- click copy button at bottom
- check output in clipboard by pasting

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.