### PR TITLE
2096 - IdsDropdown fix safari click handler

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Datagrid]` Fix datagrid bugs found in converted tests. ([#2115](https://github.com/infor-design/enterprise-wc/issues/2115))
 - `[Draggable]` Converted draggable tests to playwright. ([#1929](https://github.com/infor-design/enterprise-wc/issues/1929))
 - `[Dropdown]` Fix issue where required dropdowns were note rendering asterisk in React and Angular examples. ([#2023](https://github.com/infor-design/enterprise-wc/issues/2023))
+- `[Dropdown]` Fix issue where dropdown wouldn't open in safari via click. ([#2096](https://github.com/infor-design/enterprise-wc/issues/2096))
 - `[Dropdown]` Fix issue where tooltips were not shown if options were lazy loaded. ([#2051](https://github.com/infor-design/enterprise-wc/issues/2051))
 - `[Dropdown]` Fix displaying preselected value in angular. ([#1880](https://github.com/infor-design/enterprise-wc/issues/1880))
 - `[Dropdown]` Prevent Enter key (and other meta keys) from opening the `IdsDropdown`. ([#1878](https://github.com/infor-design/enterprise-wc/issues/1878))

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -843,7 +843,7 @@ export default class IdsDropdown extends Base {
     if (!this.list) {
       this.offEvent('click.dropdown-input');
       this.onEvent('click.dropdown-input', this.input, (e) => {
-        if (e instanceof PointerEvent) {
+        if (e instanceof MouseEvent) {
           this.dropdownList?.onTriggerClick?.(e);
         }
       });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes issue where dropdown would not open via click in Safari.
Changed click handler condition to check if `click` event is instance of `MouseEvent` instead of `PointerEvent`.

**Related github/jira issue (required)**:
Closes #2096 
Closes #2159 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-dropdown/example.html
3. Check that dropdowns open via click in all major browsers

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
