### PR TITLE
2183 - IdsMessage mobile behavior

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -55,6 +55,7 @@
 - `[LayoutGridCell/Attributes]` Corrected the values of `COL_END_*` constants from `col_start_*` to `col_end_*` along with the test coverage of the `IdsLayoutGridCell`. ([#2075](https://github.com/infor-design/enterprise-wc/issues/2075))
 - `[Lookup]` Fix `IdsLookup` (for Angular) so that modal triggers are attached after the modal has been mounted/constructed. ([#1889](https://github.com/infor-design/enterprise-wc/issues/1889))
 - `[Lookup]` Fixed single row selection behavior. ([#1808](https://github.com/infor-design/enterprise-wc/issues/1808))
+- `[Message]` Fixed mobile IdsMessage behavior. ([#2183](https://github.com/infor-design/enterprise-wc/issues/2183))
 - `[Modal]` Enable scroll support for content on initial load if scrollable. ([#2049](https://github.com/infor-design/enterprise-wc/issues/2049))
 - `[ModuleNav]` Fix icons on `IdsModuleNav` for Angular. ([#1881](https://github.com/infor-design/enterprise-wc/issues/1881))
 - `[Personalization]` Fixed infinite loop on using personalization via an import. ([#2046](https://github.com/infor-design/enterprise-wc/issues/2046))

--- a/src/assets/css/ids-message/standalone-css.css
+++ b/src/assets/css/ids-message/standalone-css.css
@@ -1,10 +1,10 @@
 #my-message {
-  position: absolute;
-  left: calc(50% - 220px);
-  top: calc(50% - 110px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
 }
 
 #my-message-contents {
   display: block;
-  max-width: 400px;
 }

--- a/src/components/ids-message/ids-message.scss
+++ b/src/components/ids-message/ids-message.scss
@@ -4,7 +4,7 @@
   display: block;
 
   &::part(popup) {
-    width: calc(100% - 32px);
+    width: calc(100% - var(--ids-space-lg));
   }
 }
 

--- a/src/components/ids-message/ids-message.scss
+++ b/src/components/ids-message/ids-message.scss
@@ -2,6 +2,10 @@
 
 :host {
   display: block;
+
+  &::part(popup) {
+    width: calc(100% - 32px);
+  }
 }
 
 .ids-message-status {

--- a/src/components/ids-message/ids-message.ts
+++ b/src/components/ids-message/ids-message.ts
@@ -50,6 +50,9 @@ export default class IdsMessage extends IdsModal {
     // Update opacity and correct
     this.opacity = this.getAttribute(attributes.OPACITY);
 
+    // Remove fullsize setting
+    this.fullsize = null;
+
     // Sanitizes the HTML in the component
     const currentContentEl = this.querySelector('*:not([slot])');
     if (currentContentEl) {

--- a/tests/ids-editor/snapshots/editor-shadow.snap
+++ b/tests/ids-editor/snapshots/editor-shadow.snap
@@ -23,7 +23,7 @@
   
   
   
-  <ids-message id="errormessage-modal" status="error" message-title="No Selection!" aria-label="error: No Selection!" role="dialog" fullsize="sm" respond-down="sm">
+  <ids-message id="errormessage-modal" status="error" message-title="No Selection!" aria-label="error: No Selection!" role="dialog">
     <ids-text slot="title" font-size="24" type="h2" id="errormessage-modal-title">No Selection!</ids-text>
     <ids-text class="demo-contents" align="left">Please make some selection to complete this task.</ids-text>
     <ids-modal-button slot="buttons" appearance="primary" id="errormessage-modal-ok">OK</ids-modal-button>

--- a/tests/ids-message/snapshots/message-html.snap
+++ b/tests/ids-message/snapshots/message-html.snap
@@ -1,4 +1,4 @@
-<ids-message id="message-example-error" status="error" message-title="Lost connection" aria-label="error: Lost connection" role="dialog" fullsize="sm" respond-down="sm">
+<ids-message id="message-example-error" status="error" message-title="Lost connection" aria-label="error: Lost connection" role="dialog">
       <ids-text slot="title" font-size="24" type="h2" id="my-message-title">Lost connection</ids-text>
       <ids-text id="my-message-contents" align="left">This application has experienced a system error due to the lack of internet access. Please restart the
         application in order to proceed.</ids-text>

--- a/tests/ids-message/snapshots/message-shadow.snap
+++ b/tests/ids-message/snapshots/message-shadow.snap
@@ -1,4 +1,4 @@
-<ids-overlay></ids-overlay><ids-popup part="modal" class="ids-modal can-fullsize" type="modal" position-style="viewport" animation-style="scale-in" animated="" align="center" width="" height="">
+<ids-overlay></ids-overlay><ids-popup part="modal" class="ids-modal" type="modal" position-style="viewport" animation-style="scale-in" animated="" align="center" width="" height="">
       <div class="ids-modal-container" slot="content">
         <div class="ids-modal-header ids-message-header"><ids-icon slot="icon" icon="error" class="ids-icon ids-message-status error"></ids-icon>
           <slot name="title"></slot>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds a fix to make the mobile IdsMessage appear as a centered popup instead of a fullscreen. 

**Related github/jira issue (required)**:
closes #2183 

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- go to http://localhost:4300/ids-message/example.html
- enter mobile view
- click the Error Example button
- See message appear as a centered popup

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
