### PR TITLE
2041 - IdsLayoutGridCell minHeight/height default to px

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -69,7 +69,7 @@
 - `[LayoutFlex]` Converted layout flex tests to playwright. ([#1944](https://github.com/infor-design/enterprise-wc/issues/1944))
 - `[LayoutGrid/LayoutFlex]` Added missing classes for standalone css. ([#1763](https://github.com/infor-design/enterprise-wc/issues/1763))
 - `[LayoutGridCell/Attributes]` Corrected the values of `COL_END_*` constants from `col_start_*` to `col_end_*` along with the test coverage of the `IdsLayoutGridCell`. ([#2075](https://github.com/infor-design/enterprise-wc/issues/2075))
-- `[LayoutGrid]` Fix the minHeight and height attributes to default to px units. ([#2041](https://github.com/infor-design/enterprise-wc/issues/2041))
+- `[LayoutGridCell]` Fix the minHeight and height attributes to default to px units. ([#2041](https://github.com/infor-design/enterprise-wc/issues/2041))
 - `[Lookup]` Fix `IdsLookup` (for Angular) so that modal triggers are attached after the modal has been mounted/constructed. ([#1889](https://github.com/infor-design/enterprise-wc/issues/1889))
 - `[Lookup]` Fixed single row selection behavior. ([#1808](https://github.com/infor-design/enterprise-wc/issues/1808))
 - `[Modal]` Enable scroll support for content on initial load if scrollable. ([#2049](https://github.com/infor-design/enterprise-wc/issues/2049))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -69,6 +69,7 @@
 - `[LayoutFlex]` Converted layout flex tests to playwright. ([#1944](https://github.com/infor-design/enterprise-wc/issues/1944))
 - `[LayoutGrid/LayoutFlex]` Added missing classes for standalone css. ([#1763](https://github.com/infor-design/enterprise-wc/issues/1763))
 - `[LayoutGridCell/Attributes]` Corrected the values of `COL_END_*` constants from `col_start_*` to `col_end_*` along with the test coverage of the `IdsLayoutGridCell`. ([#2075](https://github.com/infor-design/enterprise-wc/issues/2075))
+- `[LayoutGrid]` Fix the minHeight and height attributes to default to px units. ([#2041](https://github.com/infor-design/enterprise-wc/issues/2041))
 - `[Lookup]` Fix `IdsLookup` (for Angular) so that modal triggers are attached after the modal has been mounted/constructed. ([#1889](https://github.com/infor-design/enterprise-wc/issues/1889))
 - `[Lookup]` Fixed single row selection behavior. ([#1808](https://github.com/infor-design/enterprise-wc/issues/1808))
 - `[Modal]` Enable scroll support for content on initial load if scrollable. ([#2049](https://github.com/infor-design/enterprise-wc/issues/2049))

--- a/src/components/ids-layout-grid/README.md
+++ b/src/components/ids-layout-grid/README.md
@@ -68,8 +68,8 @@ The Ids Layout Grid is comprised of 2 web components, IdsLayoutGrid and IdsLayou
 - **ColEndXxl**: Specifies the ending column for a cell on extra-extra large screens.
 - **Editable**: Specifies whether the content of an element can be edited by the user.
 - **Fill**: Specifies whether an element should fill the available space in its container.
-- **Height**: Specifies the height of an element.
-- **MinHeight**: Specifies the minimum height of an element.
+- **Height**: Specifies the height of an element. If no unit is specified in the attribute the value will default to px.
+- **MinHeight**: Specifies the minimum height of an element. If no unit is specified in the attribute the value will default to px.
 - **Order**: Specifies the order in which an element should appear by default in a container.
 - **OrderXs**: Specifies the order in which an element should appear on extra small screens.
 - **OrderSm**: Specifies the order in which an element should appear on small screens.

--- a/src/components/ids-layout-grid/demos/index.yaml
+++ b/src/components/ids-layout-grid/demos/index.yaml
@@ -32,3 +32,6 @@
   - link: example-flow.html
     type: Flow Example
     description: Showing an example with different grid flows.
+  - link: min-height.html
+    type: Test the min-height and height attributes
+    description: Showing an example with min-height and height attributes on the layout grid cells

--- a/src/components/ids-layout-grid/demos/min-height.html
+++ b/src/components/ids-layout-grid/demos/min-height.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <%= htmlWebpackPlugin.options.font %>
+  </head>
+  <body>
+    <ids-container role="main" padding="8" hidden>
+      <ids-theme-switcher mode="light"></ids-theme-switcher>
+      <ids-layout-grid
+        auto-fit="true"
+        padding="md"
+      >
+        <ids-layout-grid-cell>
+          <ids-text font-size="12" type="h1">Min-Height/Height examples</ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+
+      <ids-layout-grid
+        cols="2"
+        padding="md"
+        margin="auto"
+        justify-content="center"
+      >
+        <ids-layout-grid-cell fill min-height="200">
+          <ids-text font-size="12">min-height</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell fill height="100">
+          <ids-text font-size="12">height</ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+    </ids-container>
+  </body>
+</html>

--- a/src/components/ids-layout-grid/ids-layout-grid-cell.ts
+++ b/src/components/ids-layout-grid/ids-layout-grid-cell.ts
@@ -516,7 +516,7 @@ export default class IdsLayoutGridCell extends Base {
   set height(value: string | null) {
     if (value !== null) {
       // Check if the value contains a unit, if not, default to 'px'
-      const newValue = /^\d+(\.\d+)?$/g.test(value) ? value + 'px' : value;
+      const newValue = /^\d+(\.\d+)?$/g.test(value) ? `${value}px` : value;
       this.setAttribute(attributes.HEIGHT, newValue);
       this.style.setProperty(attributes.HEIGHT, newValue);
     } else {
@@ -558,7 +558,7 @@ export default class IdsLayoutGridCell extends Base {
   set minHeight(value: string | null | any) {
     if (value !== null) {
       // Check if the value contains a unit, if not, default to 'px'
-      const newValue = /^\d+(\.\d+)?$/g.test(value) ? value + 'px' : value;
+      const newValue = /^\d+(\.\d+)?$/g.test(value) ? `${value}px` : value;
       this.setAttribute(attributes.MIN_HEIGHT, newValue);
       this.style.setProperty(attributes.MIN_HEIGHT, newValue);
     } else {

--- a/src/components/ids-layout-grid/ids-layout-grid-cell.ts
+++ b/src/components/ids-layout-grid/ids-layout-grid-cell.ts
@@ -515,8 +515,10 @@ export default class IdsLayoutGridCell extends Base {
    */
   set height(value: string | null) {
     if (value !== null) {
-      this.setAttribute(attributes.HEIGHT, value);
-      this.style.setProperty(attributes.HEIGHT, value);
+      // Check if the value contains a unit, if not, default to 'px'
+      const newValue = /^\d+(\.\d+)?$/g.test(value) ? value + 'px' : value;
+      this.setAttribute(attributes.HEIGHT, newValue);
+      this.style.setProperty(attributes.HEIGHT, newValue);
     } else {
       this.removeAttribute(attributes.HEIGHT);
       this.style.removeProperty(attributes.HEIGHT);
@@ -555,8 +557,10 @@ export default class IdsLayoutGridCell extends Base {
    */
   set minHeight(value: string | null | any) {
     if (value !== null) {
-      this.setAttribute(attributes.MIN_HEIGHT, value);
-      this.style.setProperty(attributes.MIN_HEIGHT, value);
+      // Check if the value contains a unit, if not, default to 'px'
+      const newValue = /^\d+(\.\d+)?$/g.test(value) ? value + 'px' : value;
+      this.setAttribute(attributes.MIN_HEIGHT, newValue);
+      this.style.setProperty(attributes.MIN_HEIGHT, newValue);
     } else {
       this.removeAttribute(attributes.MIN_HEIGHT);
       this.style.removeProperty(attributes.MIN_HEIGHT);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR addresses a bug found in the minHeight and height attribute values. If no unit is specified in the attribute, the value will now default to pixels (px).

**Related github/jira issue (required)**:
closes #2041 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- go to http://localhost:4300/ids-layout-grid/min-height.html
- check the min-height.html and see the values don't include units, but still display the correct height in pixels.


**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
