### PR TITLE
1603 - Fix expand button layout

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 1.0.0 Fixes
 
+- `[DataGrid]` Fixed placement of tree expand buttons in the tree grid. ([#1603](https://github.com/infor-design/enterprise-wc/issues/1603))
 - `[Forms]` Fixed issues with tabbing and layout issues in compact mode on forms. ([#2128](https://github.com/infor-design/enterprise-wc/issues/2128))
 - `[Editor]` Fixed style of some buttons and the height of the toolbar. ([#2188](https://github.com/infor-design/enterprise-wc/issues/2188))
 - `[LayoutGrid]` Added fixes for background fill color in contrast mode. ([#2189](https://github.com/infor-design/enterprise-wc/issues/2189))

--- a/src/components/ids-data-grid/ids-data-grid-cell.scss
+++ b/src/components/ids-data-grid/ids-data-grid-cell.scss
@@ -238,6 +238,7 @@
   }
 
   &.frozen-left {
+    background-color: var(--ids-data-grid-color-background);
     position: sticky;
     left: 0;
 

--- a/src/components/ids-data-grid/ids-data-grid-header.scss
+++ b/src/components/ids-data-grid/ids-data-grid-header.scss
@@ -231,6 +231,10 @@
   }
 }
 
+[data-row-height='xxs'] .header-expander {
+  top: 2px;
+}
+
 :host([show-header-expander]) .header-expander,
 .column-header-expander .header-expander {
   display: unset;

--- a/src/components/ids-data-grid/ids-data-grid.scss
+++ b/src/components/ids-data-grid/ids-data-grid.scss
@@ -155,6 +155,13 @@
       padding-inline-end: 0;
     }
 
+    ids-button.expand-button {
+      --ids-button-tertiary-color-background-hover: transparent;
+      --ids-button-tertiary-color-border-hover: transparent;
+      --ids-button-tertiary-color-background-pressed: transparent;
+      --ids-button-tertiary-color-border-pressed: transparent;
+    }
+
     .text-ellipsis {
       // No Ellipsis on tree columns, let links be focusable
       overflow: initial;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Fixes placement of the +/- button in xxs mode. Also noticed and fixed:

- frozen scroll background color
- button hover effect didnt really work on grid buttons so took it off for now.

**Related github/jira issue (required)**:
Fixes #1603 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-data-grid/tree-grid-expand-collapse.html
- go to xxs row height *try all of them) andthe + in the header should be aligned
- scroll the grid right on the frozen section (should look good now)

**Included in this Pull Request**:
- [x] A note to the change log.
