### PR TITLE
2227 - IdsTree redraw when assigning empty array

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[BarChart]` Converted bar chart tests to playwright. ([#1919](https://github.com/infor-design/enterprise-wc/issues/1919))
 - `[BreadCrumb/Hyperlink]` Fix focus state on click bug. ([#2238](https://github.com/infor-design/enterprise-wc/issues/2238))
 - `[Editor]` Converted editor tests to playwright. ([#1931](https://github.com/infor-design/enterprise-wc/issues/1931))
+- `[Tree]` Fixed bug where redraw did not trigger when assigning an empty array. ([#2227](https://github.com/infor-design/enterprise-wc/issues/2227))
 
 ## 1.0.0
 

--- a/src/components/ids-tree/demos/index.yaml
+++ b/src/components/ids-tree/demos/index.yaml
@@ -17,6 +17,9 @@
   - link: load-children.html
     type: Example
     description: Shows loading children with ajax
+  - link: reset.html
+    type: Example
+    description: Shows delete all nodes, set one and reset.
   - link: sandbox.html
     type: Sandbox
     description: Shows other tree scenarios

--- a/src/components/ids-tree/demos/reset.html
+++ b/src/components/ids-tree/demos/reset.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8">
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Ids Tree - Reset</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-button id="delete-all" appearance="primary">
+          <span>Delete all nodes</span>
+        </ids-button>
+        <ids-button id="set-one" appearance="primary">
+          <span>Set one item</span>
+        </ids-button>
+        <ids-button id="reset-nodes" appearance="primary">
+          <span>Reset</span>
+        </ids-button>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto-fit="true" padding-x="md" margin-y="md">
+      <ids-layout-cell>
+        <ids-tree id="tree-demo" label="Tree Demo"></ids-tree>
+      </ids-layout-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-tree/demos/reset.ts
+++ b/src/components/ids-tree/demos/reset.ts
@@ -1,0 +1,43 @@
+import treeBasicJSON from '../../../assets/data/tree-basic.json';
+import IdsTree from '../ids-tree';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const treeElem: any = document.querySelector<IdsTree>('#tree-demo');
+  const deleteAllBtn: any = document.querySelector('#delete-all');
+  const setOneBtn: any = document.querySelector('#set-one');
+  const resetBtn: any = document.querySelector('#reset-nodes');
+
+  if (treeElem) {
+    (async function init() {
+      const res = await fetch(treeBasicJSON as any);
+      const data: any = await res.json();
+
+      treeElem.data = data;
+    }());
+  }
+
+  deleteAllBtn.addEventListener('click', () => {
+    console.info('deleteAll clicked');
+    treeElem.data = [];
+    console.info('treeData: ', treeElem.data);
+  });
+
+  setOneBtn.addEventListener('click', () => {
+    console.info('setOneItem clicked');
+    treeElem.data = [
+      {
+        id: 'home',
+        text: 'Home',
+      },
+    ];
+    console.info('treeData: ', treeElem.data);
+  });
+
+  resetBtn.addEventListener('click', async () => {
+    console.info('reset');
+    const res = await fetch(treeBasicJSON as any);
+    const data: any = await res.json();
+    treeElem.data = data;
+    console.info('treeData: ', treeElem.data);
+  });
+});

--- a/src/components/ids-tree/ids-tree.ts
+++ b/src/components/ids-tree/ids-tree.ts
@@ -1257,6 +1257,7 @@ export default class IdsTree extends Base {
       return;
     }
     this.datasource.data = null;
+    this.redraw();
   }
 
   get data(): Array<IdsTreeData> { return this.datasource?.data || []; }

--- a/src/components/ids-tree/ids-tree.ts
+++ b/src/components/ids-tree/ids-tree.ts
@@ -433,7 +433,7 @@ export default class IdsTree extends Base {
    * @returns {void}
    */
   redraw() {
-    if (this.data.length === 0 || !this.shadowRoot) {
+    if (!this.shadowRoot) {
       return;
     }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR fixes a bug where the tree did not redraw when assigning an empty array

**Related github/jira issue (required)**:
closes #2227 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- go to http://localhost:4300/ids-tree/reset.html
- click on 'Set one item' - see one node left in the tree
- Click 'Reset' to bring back the nodes
- Click 'Delete all nodes' and all nodes will be removed
- Check console for messages to corresponding actions

**Included in this Pull Request**:
~- [ ] Some documentation for the feature.~
~- [ ] A test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
