### PR TITLE
1793 - Add multiline header text

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 1.0.1 Features
 
 - `[Datagrid]` Added the ability to dynamically set the `icon` and `text` column options on some formatters. ([#2122](https://github.com/infor-design/enterprise-wc/issues/2122))
+- `[Datagrid]` Added the ability to create multiline header text [see docs](https://github.com/infor-design/enterprise-wc/tree/main/src/components/ids-data-grid#multiline-header-code-examples) for details. ([#1793](https://github.com/infor-design/enterprise-wc/issues/1793))
 - `[Splitter]` If the panel is resized to 0, it will have `collapsed` attribute, enabling it to expand to its original position. ([#2083](https://github.com/infor-design/enterprise-wc/issues/2083))
 
 ### 1.0.1 Fixes

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -364,7 +364,7 @@ When used as an attribute in the DOM the settings are kebab case, when used in J
 |Setting|Type|Description|
 |---|---|---|
 |`id` | {string} | The unique id of the column. Each column in the grid should have some unique id.|
-|`name` | {string} | The text to show on the header.|
+|`name` | {string |  Array<IdsDataGridHeaderTextName> } | The text to show on the header. For multiline header can take an object with text and an emphasis option. See Multi line header example. |
 |`field` | {string} | The name of the field (column) in the data array attached to the grid for example `description`. This can also be nested in an object for example `children.name`. |
 |`showHeaderExpander` | {boolean} | If true, an expand/collapse icon will appear on the column's header.|
 |`sortable` | {boolean} | If false, the column cannot be sorted. When completed a `sorted` event will fire.|
@@ -1160,7 +1160,7 @@ ids-data-grid::part(red-tooltip-popup) {
 }
 ```
 
-## context menu Code Examples
+## Context Menu Code Examples
 
 The context menus can be set via the dataset.
 
@@ -1290,7 +1290,7 @@ columns.push({
 
 Then just add an `<ids-popup-menu id="actions-menu"></ids-popup-menu>` with any structure you like to the page and it will open when pressing the button. When an item is selected the callback will fire for `selected`
 
-## Empty Message
+## Empty Message Code Examples
 
 Set empty message thru slot (markup).
 
@@ -1329,7 +1329,7 @@ dataGrid.emptyMessageLabel = 'No Data';
 dataGrid.emptyMessageDescription = 'There is No data available.';
 ```
 
-## Row Height
+## Row Height Code Examples
 
 As mentioned in the settings section you can change the row height by setting the rowHeight option.
 
@@ -1344,6 +1344,35 @@ Medium (`row-height="md"`) - Row Height is 40. Header is 16px and body cells are
 Small (`row-height="sm"`) - Row Height is 35. Header is 16px and body cells are 16px. 8px padding on cells and header. This is the smallest option that is recommended for readability and spacing.
 Extra Small (`row-height="xs"`) - Row Height is 30. Header is 14px and body cells are 14px. 8px padding on cells and header. If you need a very compressed data grid with a lot of data you can use this option. But there is a trade off of bad readability and spacing.
 Extra Extra Small (`row-height="xxs"`) - Row Height is 25. Header is 14px and body cells are 14px. 2px padding on cells and header. Avoid this option as it is very crowded but it is included for edge cases.
+
+## Multiline Header Code Examples
+
+As mentioned in the settings columns section you can have a two line header in two variations. The first variation is simply to use it as a way to extend the text over two lines. To do this setup the column like this.
+
+```js
+name: [
+  { text: 'Product Name' },
+  { text: 'with long description' },
+],
+```
+
+The second way to setup the text so the second line is de-emphasized a use case might be to show a unit or related info thats not part of the above name.
+
+```js
+name: [
+  { text: 'Product Name' },
+  { text: 'String', emphasis: 'subtle' },
+],
+```
+
+Technically this is also possible but not sure if there is a use case.
+
+```js
+name: [
+  { text: 'Something subtle', emphasis: 'subtle' },
+  { text: 'Name', emphasis: 'subtle' },
+],
+```
 
 ## States and Variations
 

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -1347,7 +1347,7 @@ Extra Extra Small (`row-height="xxs"`) - Row Height is 25. Header is 14px and bo
 
 ## Multiline Header Code Examples
 
-As mentioned in the settings columns section you can have a two line header in two variations. The first variation is simply to use it as a way to extend the text over two lines. To do this setup the column like this.
+As mentioned in the settings columns section you can have a two line header in two variations. The first variation is simply to use it as a way to extend the text over two lines. To do this setup the column like the following examples.
 
 ```js
 name: [

--- a/src/components/ids-data-grid/demos/header-multiline.html
+++ b/src/components/ids-data-grid/demos/header-multiline.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid (multiline header)</ids-text>
+    </ids-layout-grid>
+
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-toolbar>
+          <ids-toolbar-section align="end" favor>
+            <ids-toggle-button
+            id="hide-filter-row"
+            icon-on="filter"
+            icon-off="filter"
+            text-off="Hide filter row"
+            text-on="Show filter row"></ids-toggle-button>
+          </ids-toolbar-section>
+        </ids-toolbar>
+        <ids-data-grid
+          id="data-grid-filter"
+          row-selection="multiple"
+          label="Books"
+          row-height="md"
+          pagination="client-side"
+          page-number="1"
+          page-size="10"
+        >
+        </ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/header-multiline.ts
+++ b/src/components/ids-data-grid/demos/header-multiline.ts
@@ -1,0 +1,146 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+import type { IdsDataGridColumn } from '../ids-data-grid-column';
+import '../../ids-container/ids-container';
+import productsJSON from '../../../assets/data/products.json';
+import IdsToggleButton from '../../ids-toggle-button/ids-toggle-button';
+
+// Example for populating the DataGrid
+const dataGrid = document.querySelector<IdsDataGrid>('#data-grid-filter')!;
+
+(async function init() {
+  const columns: IdsDataGridColumn[] = [];
+
+  // Set up columns
+  columns.push({
+    id: 'selectionCheckbox',
+    name: 'selection',
+    sortable: false,
+    resizable: false,
+    formatter: dataGrid.formatters.selectionCheckbox,
+    align: 'center'
+  });
+  columns.push({
+    id: 'id',
+    name: [
+      { text: 'Row ID' },
+      { text: 'Numeric', emphasis: 'subtle' },
+    ],
+    field: 'id',
+    width: 120,
+    resizable: true,
+    reorderable: true,
+    sortable: true,
+    formatter: dataGrid.formatters.text,
+  });
+  columns.push({
+    id: 'color',
+    name: [
+      { text: 'Color' },
+      { text: 'String', emphasis: 'subtle' },
+    ],
+    field: 'color',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    formatter: dataGrid.formatters.text,
+    filterType: dataGrid.filters.text
+  });
+  columns.push({
+    id: 'productId',
+    name: [
+      { text: 'Product Id' },
+      { text: 'Numeric', emphasis: 'subtle' },
+    ],
+    field: 'productId',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    filterType: dataGrid.filters.integer,
+    formatter: dataGrid.formatters.integer
+  });
+  columns.push({
+    id: 'productName',
+    name: [
+      { text: 'Product Name' },
+      { text: 'with long description' },
+    ],
+    field: 'productName',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    formatter: dataGrid.formatters.text,
+    filterType: dataGrid.filters.text,
+    filterConditions: [{
+      value: 'contains',
+      label: 'Contains',
+      icon: 'filter-contains'
+    },
+    {
+      value: 'equals',
+      label: 'Equals',
+      icon: 'filter-equals',
+      selected: true
+    }]
+  });
+  columns.push({
+    id: 'inStock',
+    name: [
+      { text: 'In Stock' },
+      { text: 'Boolean', emphasis: 'subtle' },
+    ],
+    field: 'inStock',
+    sortable: false,
+    resizable: true,
+    reorderable: true,
+    align: 'center',
+    formatter: dataGrid.formatters.text,
+    filterType: dataGrid.filters.checkbox
+  });
+  columns.push({
+    id: 'unitPrice',
+    name: [
+      { text: 'Unit Price' },
+      { text: 'Number', emphasis: 'subtle' },
+    ],
+    field: 'unitPrice',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    formatter: dataGrid.formatters.integer,
+    filterType: dataGrid.filters.integer
+  });
+  columns.push({
+    id: 'units',
+    name: [
+      { text: 'Units' },
+      { text: 'Number', emphasis: 'subtle' },
+    ],
+    field: 'units',
+    sortable: true,
+    resizable: true,
+    reorderable: true,
+    align: 'right',
+    filterAlign: 'left',
+    formatter: dataGrid.formatters.text,
+    filterType: dataGrid.filters.text
+  });
+
+  // Do an ajax request
+  const url: any = productsJSON;
+
+  dataGrid.columns = columns;
+  const setData = async () => {
+    const res = await fetch(url);
+    const data = await res.json();
+    dataGrid.data = data;
+    dataGrid.pageTotal = data.length;
+  };
+  await setData();
+
+  // Toggle Filter Row
+  document.querySelector<IdsToggleButton>('#hide-filter-row')!.addEventListener('click', (e: any) => {
+    e.target.toggle();
+    dataGrid.filterable = !dataGrid.filterable;
+  });
+}());

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -134,6 +134,9 @@
   - link: filter.html
     type: Example
     description: Shows a filter row
+  - link: header-multiline.html
+    type: Example
+    description: Shows a two line header
   - link: in-modal.html
     type: Example
     description: Shows a data grid in a modal

--- a/src/components/ids-data-grid/ids-data-grid-column.ts
+++ b/src/components/ids-data-grid/ids-data-grid-column.ts
@@ -101,11 +101,18 @@ export interface IdsDataGridEditorValidation {
   id: string;
 }
 
+export interface IdsDataGridHeaderTextName {
+  /** The header text for one line */
+  text: string;
+  /** The font style to use */
+  emphasis?: 'normal' | 'subtle';
+}
+
 export interface IdsDataGridColumn {
   /** The columns unique id */
   id: string;
   /** The columns name */
-  name?: string;
+  name?: string | Array<IdsDataGridHeaderTextName>;
   /** The columns field in the array to use */
   field?: string;
   /** The subsitute text to use (for hyperlink and some formatters) */

--- a/src/components/ids-data-grid/ids-data-grid-header.scss
+++ b/src/components/ids-data-grid/ids-data-grid-header.scss
@@ -173,6 +173,11 @@
   text-overflow: ellipsis;
   user-select: none;
   white-space: nowrap;
+
+  small {
+    font-weight: var(--ids-font-weight-normal);
+    font-size: var(--ids-data-grid-font-size-sm);
+  }
 }
 
 .ids-data-grid-header-icon {

--- a/src/components/ids-data-grid/ids-data-grid-header.ts
+++ b/src/components/ids-data-grid/ids-data-grid-header.ts
@@ -445,7 +445,17 @@ export default class IdsDataGridHeader extends IdsEventsMixin(IdsElement) {
     const expander = showHeaderExpander ? expanderTemplate : '';
 
     const selectionCheckbox = column.id !== 'selectionRadio' && column.id === 'selectionCheckbox';
-    const colName = escapeHTML(column.name);
+    let colName = '';
+    if (Array.isArray(column.name)) {
+      colName = `
+        ${escapeHTML(column.name[0].text)}
+        <br>
+        ${column.name[1].emphasis === 'subtle' ? '<small>' : ''}
+        ${escapeHTML(column.name[1].text)}
+        ${column.name[1].emphasis === 'subtle' ? '</small>' : ''}
+      `;
+    } else { colName = escapeHTML(column.name); }
+
     const headerContentTemplate = `
       ${selectionCheckbox ? selectionCheckBoxTemplate : ''}
       ${(column.id !== 'selectionRadio' && column.id !== 'selectionCheckbox' && colName) ? colName : ''}

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -3135,7 +3135,7 @@ export default class IdsDataGrid extends Base {
         xlColumns[gridCol.id] = {
           id: gridCol.id,
           field: gridCol.field,
-          name: gridCol.name,
+          name: Array.isArray(gridCol.name) ? `${gridCol.name[0]} ${gridCol.name[0].emphasis === 'subtle' ? '(' : ''}${gridCol.name[0]}${gridCol.name[0].emphasis === 'subtle' ? ')' : ''}` : gridCol.name,
           type: keepGridFormatting ? 'string' : this.determineColType(gridCol)
         };
       }

--- a/tests/ids-data-grid/ids-data-grid.spec.ts
+++ b/tests/ids-data-grid/ids-data-grid.spec.ts
@@ -163,6 +163,12 @@ test.describe('IdsDataGrid tests', () => {
       await page.goto('/ids-data-grid/loading-indicator.html');
       await percySnapshot(page, 'ids-data-grid-loading-indicator-light');
     });
+
+    test('should not have visual regressions in percy (header-multiline)', async ({ page, browserName }) => {
+      if (browserName !== 'chromium') return;
+      await page.goto('/ids-data-grid/header-multiline.html');
+      await percySnapshot(page, 'ids-data-grid-header-multiline-light');
+    });
   });
 
   test.describe('event tests', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds an api to do multiline header text

**Related github/jira issue (required)**:
Fixes #1793 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-data-grid/export-excel.html
- notice the headers on two lines
- note some are deemphasized (for no related data)
- one is "normal" this is for  the"wrapping" use case

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
