### PR TITLE
2275 - IdsDataGrid Row expanded/collapsed events when allow one expanded row

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[AxisChart]` Fix `IdsAxisChart` so that it properly reloads when removed from the DOM and then reattached. ([#2111](https://github.com/infor-design/enterprise-wc/issues/2111))
 - `[Button]` Updated focus state on tertiary buttons. ([#2239](https://github.com/infor-design/enterprise-wc/issues/2239))
 - `[Container]` Switch from `vh` to `dvh` units. ([#2268](https://github.com/infor-design/enterprise-wc/issues/2268))
+- `[Datagrid]` Fixed row expanded/collapsed events triggering with the `allowOneExpandedRow` option. ([#2275](https://github.com/infor-design/enterprise-wc/issues/2275))
 - `[Header]` Fixed inconsistency on header background color. ([#2242](https://github.com/infor-design/enterprise-wc/issues/2242))
 - `[BarChart]` Converted bar chart tests to playwright. ([#1919](https://github.com/infor-design/enterprise-wc/issues/1919))
 - `[BreadCrumb/Hyperlink]` Fix focus state on click bug. ([#2238](https://github.com/infor-design/enterprise-wc/issues/2238))

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -548,7 +548,7 @@ The formatter is then linked via the column on the formatter setting. When the g
 - `resetDirtyCells` Clears all dirty cell indicators.
 - `dirtyCells` Gives a list of all currently dirty cells.
 - `exportToExcel(format: 'csv' | 'xlsx', filename: string, keepGridFormatting: boolean)` Export datagrid datasource to an excel file. This keeps grid formatting by default.
-- `collapseAll()` Collapse all expandable or tree rows.
+- `collapseAll(triggerAllRowsEvent: boolean, triggerRowEvent: boolean)` Collapse all expandable or tree rows. Argument `triggerAllRowsEvent` defaults to true, when enabled `rowcollapsed` triggered with once with `allRows` detail param. Argument `triggerRowEvent` defaults to false, when enabled each individual collapsed row event will be triggered
 - `expandAll()` Expand all expandable or tree rows.
 - `toggleAll(opt: boolean)` Toggle collapse/expand all expandable or tree rows. `opt false`: will expand all, `opt: true`: will collapse all
 - `refreshRow` IdsDataGridRow method to refresh row element and its cells.

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -294,13 +294,11 @@ export default class IdsDataGrid extends Base {
 
   /**
    * Collapse all expandable or tree rows.
+   * @param {boolean} triggerAllRowsEvent If true, will trigger the event once for all rows
+   * @param {boolean} triggerRowEvent If true, will trigger row event for each row
    * @returns {void}
    */
-  collapseAll() {
-    this.data.forEach((rowData, rowIndex) => {
-      this.updateDataset(rowIndex, { rowExpanded: false, rowHidden: !!rowData.parentElement });
-    });
-
+  collapseAll(triggerAllRowsEvent = true, triggerRowEvent = false) {
     this.header?.closeExpanderIcons();
 
     const rows: any[] = [];
@@ -308,13 +306,29 @@ export default class IdsDataGrid extends Base {
       .forEach((row: IdsDataGridRow) => {
         const rowIndex = row.rowIndex;
         rows.push({ row: rowIndex, data: this.data[rowIndex] });
+        if (row.isExpanded() && triggerRowEvent) {
+          this.triggerEvent(`rowcollapsed`, this, {
+            bubbles: true,
+            detail: {
+              elem: this,
+              row: rowIndex,
+              data: this.data[rowIndex],
+            }
+          });
+        }
         row.doCollapse();
       });
 
-    this.triggerEvent(`rowcollapsed`, this, {
-      bubbles: true,
-      detail: { elem: this, rows, allRows: true }
+    this.data.forEach((rowData, rowIndex) => {
+      this.updateDataset(rowIndex, { rowExpanded: false, rowHidden: !!rowData.parentElement });
     });
+
+    if (triggerAllRowsEvent) {
+      this.triggerEvent(`rowcollapsed`, this, {
+        bubbles: true,
+        detail: { elem: this, rows, allRows: true }
+      });
+    }
   }
 
   /**
@@ -690,9 +704,10 @@ export default class IdsDataGrid extends Base {
         if (this.allowOneExpandedRow) {
           const isExpanded = row.isExpanded();
           const isCollapsed = !isExpanded;
-          this.collapseAll();
-          if (isExpanded) row.doCollapse();
-          if (isCollapsed) row.doExpand();
+          if (isCollapsed) {
+            this.collapseAll(false, true);
+          }
+          row.toggleExpandCollapse();
         } else {
           row.toggleExpandCollapse();
         }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed row expanded/collapsed events triggering with the `allowOneExpandedRow` option.
I had to add two arguments to `collapseAll` method with default values so if you run it without arguments like `collapseAll()` it will act as before no changes. `collapseAll(false, true)` - fires row collapsed event for each collapsed row. `collapseAll(false, false)` doesn't fire any events at all

**Related github/jira issue (required)**:
Closes #2275

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-data-grid/expandable-row.html
- check `DATA GRID (ALLOW ONE EXPANDABLE-ROW)` example
- expand a row and see `Row Expanded` event in the console
- collapse the row and see `Row Collapsed` event in the console
- expand any row again and expand another row
- see `Row Collapsed` fires first and then `Row Expanded`
- row indexes and row data in the event detail should be correct

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
