### PR TITLE
2261 - IdsEditor html editor persist text

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[BreadCrumb/Hyperlink]` Fix focus state on click bug. ([#2238](https://github.com/infor-design/enterprise-wc/issues/2238))
 - `[Dropdown]` Fixed dropdown positioning logic so it works on modals and popups, and better opens up if it does not fit. ([#2165](https://github.com/infor-design/enterprise-wc/issues/2165))
 - `[Editor]` Converted editor tests to playwright. ([#1931](https://github.com/infor-design/enterprise-wc/issues/1931))
+- `[Editor]` Fix bug where html editor edits weren't being stored. ([#2261](https://github.com/infor-design/enterprise-wc/issues/2261))
 - `[Input]` Fixed required validation triggered when assigning an empty value on initial component mount in React and Angular examples. ([#2233](https://github.com/infor-design/enterprise-wc/issues/2233))
 - `[Menu]` Converted menu tests to playwright. ([#1953](https://github.com/infor-design/enterprise-wc/issues/1953))
 - `[Modal]` Removed zoom in animation on modal based on design feedback and technical constraints. ([#2165](https://github.com/infor-design/enterprise-wc/issues/2165))

--- a/src/components/ids-editor/ids-editor.ts
+++ b/src/components/ids-editor/ids-editor.ts
@@ -1260,6 +1260,18 @@ export default class IdsEditor extends Base {
       this.#unActiveToolbarButtons();
     });
 
+    // Textarea
+    this.onEvent('input.editor-textarea', this.#elems.textarea, (evt) => {
+      evt.stopPropagation();
+      this.#adjustSourceLineNumbers();
+      (debounce(() => {
+        if (!this.#elems.reqviewchange) this.#triggerEvent('change', this.#elems.textarea);
+      }, 400) as any)();
+    });
+    this.onEvent('change.editor-textarea', this.#elems.textarea, () => {
+      this.#triggerEvent('change');
+    });
+
     // Editor container
     this.onEvent('input.editor-editcontainer', this, debounce(() => {
       if (!this.#elems.reqviewchange) {
@@ -1272,17 +1284,6 @@ export default class IdsEditor extends Base {
     });
     this.onEvent('paste.editor-editcontainer', this, (e: ClipboardEvent) => {
       this.#onPasteEditorContainer(e);
-    });
-
-    // Textarea
-    this.onEvent('input.editor-textarea', this.#elems.textarea, () => {
-      this.#adjustSourceLineNumbers();
-      (debounce(() => {
-        if (!this.#elems.reqviewchange) this.#triggerEvent('change', this.#elems.textarea);
-      }, 400) as any)();
-    });
-    this.onEvent('change.editor-textarea', this.#elems.textarea, () => {
-      this.#triggerEvent('change');
     });
 
     // Other events

--- a/tests/ids-editor/ids-editor.spec.ts
+++ b/tests/ids-editor/ids-editor.spec.ts
@@ -547,5 +547,22 @@ test.describe('IdsEditor tests', () => {
       await idsEditor.locator('#editor-container').first().fill('another test');
       await expect(idsEditor.locator('ids-icon.icon-dirty')).toBeAttached();
     });
+
+    test('setting text in textarea', async ({ page }) => {
+      const htmlTextareaHandle = await page.locator('ids-editor #source-textarea').first();
+
+      // switch to html editor
+      await page.locator('ids-editor ids-button[editor-action="sourcemode"]').first().click();
+
+      // set html text value
+      await htmlTextareaHandle.evaluate((textarea: HTMLTextAreaElement) => {
+        textarea.value = '<p>Test this is stored</p>';
+      });
+
+      // switch to visual editor
+      await page.locator('ids-editor ids-button[editor-action="editormode"]').first().click();
+
+      await expect(await page.getByText('Test this is stored')).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes bug where html added in html source editor mode was not persisting in editor mode

**Related github/jira issue (required)**:
Closes #2261 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-editor/example.html
3. Switch to `sourcemode` (click `HTML` button in toolbar)
4. Add this HTML snippet `<p>Test this persists</p>` to textarea
5. Switch back to `editormode` (click `Visual` button in toolbar)
6. Check that the added text persists

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.

