### PR TITLE
2293 - IdsDropdown fix hover color in dark mode

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Container]` Switch from `vh` to `dvh` units. ([#2268](https://github.com/infor-design/enterprise-wc/issues/2268))
 - `[Datagrid]` Fixed row expanded/collapsed events triggering with the `allowOneExpandedRow` option. ([#2275](https://github.com/infor-design/enterprise-wc/issues/2275))
 - `[Dropdown]` Fixed issues using typeahead in a compiled script. ([#2249](https://github.com/infor-design/enterprise-wc/issues/2249))
+- `[Dropdown]` Fixed hover color on items in dark mode. ([#2293](https://github.com/infor-design/enterprise-wc/issues/2293))
 - `[Header]` Fixed inconsistency on header background color. ([#2242](https://github.com/infor-design/enterprise-wc/issues/2242))
 - `[BarChart]` Converted bar chart tests to playwright. ([#1919](https://github.com/infor-design/enterprise-wc/issues/1919))
 - `[BreadCrumb/Hyperlink]` Fix focus state on click bug. ([#2238](https://github.com/infor-design/enterprise-wc/issues/2238))

--- a/src/themes/default/ids-theme-default-dark.scss
+++ b/src/themes/default/ids-theme-default-dark.scss
@@ -202,7 +202,7 @@
   --ids-dropdown-color-icon: var(--ids-color-gray-10);
   --ids-dropdown-typeahead-color-background: var(--ids-color-gray-30);
   --ids-dropdown-color-text-default: var(--ids-color-white-100);
-  --ids-dropdown-color-background-hover: var(--ids-color-gray-90);
+  --ids-dropdown-color-background-hover: var(--ids-color-gray-80);
   --ids-dropdown-group-color-text: var(--ids-color-gray-20);
   --ids-dropdown-group-color-border: var(--ids-color-gray-50);
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR updates the `--ids-dropdown-color-background-hover` variable to fix the hover color on dropdown items in dark mode.

**Related github/jira issue (required)**:
closes #2293 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- go to http://localhost:4300/ids-dropdown/example.html
- change to dark mode
- open any of the dropdown
- hover items
- see the the hover color appears

**Included in this Pull Request**:
~- [ ] Some documentation for the feature.~
~- [ ] A test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
