### PR TITLE
2265 - Fix with of the datagrid input editor

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `[Button]` Updated focus state on tertiary buttons. ([#2239](https://github.com/infor-design/enterprise-wc/issues/2239))
 - `[Container]` Switch from `vh` to `dvh` units. ([#2268](https://github.com/infor-design/enterprise-wc/issues/2268))
 - `[Datagrid]` Fixed row expanded/collapsed events triggering with the `allowOneExpandedRow` option. ([#2275](https://github.com/infor-design/enterprise-wc/issues/2275))
-- `[Datagrid]` Added the ability to dynamically set the `icon` and `text` column options on some formatters. ([#2122](https://github.com/infor-design/enterprise-wc/issues/2122))
+- `[Datagrid]` Fixed internal width of the input element in an editable input cell. ([#2265](https://github.com/infor-design/enterprise-wc/issues/2265))
 - `[Dropdown]` Fixed issues using typeahead in a compiled script. ([#2249](https://github.com/infor-design/enterprise-wc/issues/2249))
 - `[Header]` Fixed inconsistency on header background color. ([#2242](https://github.com/infor-design/enterprise-wc/issues/2242))
 - `[BarChart]` Converted bar chart tests to playwright. ([#1919](https://github.com/infor-design/enterprise-wc/issues/1919))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Button]` Updated focus state on tertiary buttons. ([#2239](https://github.com/infor-design/enterprise-wc/issues/2239))
 - `[Container]` Switch from `vh` to `dvh` units. ([#2268](https://github.com/infor-design/enterprise-wc/issues/2268))
 - `[Datagrid]` Fixed row expanded/collapsed events triggering with the `allowOneExpandedRow` option. ([#2275](https://github.com/infor-design/enterprise-wc/issues/2275))
+- `[Datagrid]` Added the ability to dynamically set the `icon` and `text` column options on some formatters. ([#2122](https://github.com/infor-design/enterprise-wc/issues/2122))
 - `[Dropdown]` Fixed issues using typeahead in a compiled script. ([#2249](https://github.com/infor-design/enterprise-wc/issues/2249))
 - `[Header]` Fixed inconsistency on header background color. ([#2242](https://github.com/infor-design/enterprise-wc/issues/2242))
 - `[BarChart]` Converted bar chart tests to playwright. ([#1919](https://github.com/infor-design/enterprise-wc/issues/1919))

--- a/src/components/ids-data-grid/ids-data-grid-editors.ts
+++ b/src/components/ids-data-grid/ids-data-grid-editors.ts
@@ -105,7 +105,7 @@ export class InputEditor implements IdsDataGridEditor {
     const isInline = cell?.column.editor?.inline;
     this.input = <IdsInput> document.createElement('ids-input');
     this.input.colorVariant = isInline ? 'in-cell' : 'borderless';
-    this.input.size = isInline ? 'full' : '';
+    this.input.size = 'full';
     this.input.fieldHeight = String(cell?.dataGrid?.rowHeight) === 'xxs' ? `xs` : String(cell?.dataGrid?.rowHeight);
     this.input.labelState = 'collapsed';
 

--- a/tests/ids-data-grid/ids-data-grid-editing.spec.ts
+++ b/tests/ids-data-grid/ids-data-grid-editing.spec.ts
@@ -4,7 +4,7 @@ import { test } from '../base-fixture';
 import IdsDataGrid from '../../src/components/ids-data-grid/ids-data-grid';
 import IdsDataGridCell from '../../src/components/ids-data-grid/ids-data-grid-cell';
 import IdsDropdown from '../../src/components/ids-dropdown/ids-dropdown';
-import IdsInput from '../../src/components/ids-input/ids-input';
+import type IdsInput from '../../src/components/ids-input/ids-input';
 import type IdsTriggerField from '../../src/components/ids-trigger-field/ids-trigger-field';
 
 test.describe('IdsDataGrid editing tests', () => {

--- a/tests/ids-data-grid/ids-data-grid-editing.spec.ts
+++ b/tests/ids-data-grid/ids-data-grid-editing.spec.ts
@@ -4,7 +4,7 @@ import { test } from '../base-fixture';
 import IdsDataGrid from '../../src/components/ids-data-grid/ids-data-grid';
 import IdsDataGridCell from '../../src/components/ids-data-grid/ids-data-grid-cell';
 import IdsDropdown from '../../src/components/ids-dropdown/ids-dropdown';
-import type IdsInput from '../../src/components/ids-input/ids-input';
+import IdsInput from '../../src/components/ids-input/ids-input';
 import type IdsTriggerField from '../../src/components/ids-trigger-field/ids-trigger-field';
 
 test.describe('IdsDataGrid editing tests', () => {
@@ -667,5 +667,16 @@ test.describe('IdsDataGrid editing tests', () => {
       // check cell is marked as invalid
       expect(await idCell.evaluate((cell: IdsDataGridCell) => cell.classList.contains('is-invalid'))).toBeTruthy();
     });
+  });
+
+  test('editable IdsInput width is full width', async ({ page }) => {
+    const results = await page.evaluate(() => {
+      const dataGrid = document.querySelector<IdsDataGrid>('ids-data-grid')!;
+      const editableCell = dataGrid.container?.querySelector<IdsDataGridCell>('ids-data-grid-cell.is-editable');
+      editableCell?.click();
+      return editableCell?.querySelector<IdsInput>('ids-input')?.getAttribute('size');
+    });
+
+    expect(results).toBe('full');
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

The internal hidden input element was the default 300px when it needed to be full size. This is needed for wider columns

**Related github/jira issue (required)**:
Fixes #2265 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-data-grid/editable.html
- resize the first column so its wider then 300px
- type in it and ensure the input goes full cell width

**Screen Shots**
![Screenshot 2024-05-15 at 4 27 40 PM](https://github.com/infor-design/enterprise-wc/assets/814283/352afbb3-f086-496e-af64-eedd6798ec05)

**Included in this Pull Request**:
- [x] A test for the bug or feature.
- [x] A note to the change log.
