### PR TITLE
2216 - IdsPopupMenu Fix the position of the submenu when using the prod build on an HTML page

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[Input]` Fixed required validation triggered when assigning an empty value on initial component mount in React and Angular examples. ([#2233](https://github.com/infor-design/enterprise-wc/issues/2233))
 - `[Menu]` Converted menu tests to playwright. ([#1953](https://github.com/infor-design/enterprise-wc/issues/1953))
 - `[Modal]` Removed zoom in animation on modal based on design feedback and technical constraints. ([#2165](https://github.com/infor-design/enterprise-wc/issues/2165))
+- `[PopupMenu]` Fixed an issue where a submenu is in the wrong position when using production build on a html page ([#2216](https://github.com/infor-design/enterprise-wc/issues/2216))
 - `[Tree]` Add ability to have expandIcon and toggleIcon display together. ([#2151](https://github.com/infor-design/enterprise-wc/issues/2151))
 - `[Tree]` Fixed bug where redraw did not trigger when assigning an empty array. ([#2227](https://github.com/infor-design/enterprise-wc/issues/2227))
 - `[Tree]` Converted tree tests to playwright. ([#1986](https://github.com/infor-design/enterprise-wc/issues/1986))

--- a/src/components/ids-popup-menu/ids-popup-menu.ts
+++ b/src/components/ids-popup-menu/ids-popup-menu.ts
@@ -80,7 +80,10 @@ export default class IdsPopupMenu extends Base {
     if (this.hasAttribute(attributes.WIDTH)) {
       this.#setMenuWidth(this.getAttribute(attributes.WIDTH));
     }
-    this.#configurePopup();
+    // Defer the popup placement until after the initial setup phase
+    requestAnimationFrame(() => {
+      this.#configurePopup();
+    });
   }
 
   #configurePopup() {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed an issue where a submenu is in the wrong position when using production build on a html page by deferring popup configuration until after the initial setup phase of the component. No tests added because everything should work as before for web components and the issue is hard to reproduce in tests.

**Related github/jira issue (required)**:
Closes #2216 

**Steps necessary to review your pull request (required)**:
- pull the branch
- build dist `npm run build:dist:prod`
- https://stackblitz.com/edit/ids-enterprise-wc-100-shbkbg?file=index.html you need to run this file locally and link `enterprise-wc.js` file from `build` folder replacing `https://unpkg.com/ids-enterprise-wc@1.0.0/enterprise-wc.js`. Example below shows how to serve that static file with `serve` (any similar tool will work)
  - copy html from from https://stackblitz.com/edit/ids-enterprise-wc-100-shbkbg?file=index.html to `menu-button.html` file  and place it inside `enterprise-wc` folder
  - replace module link in head with `<script type="module" src="build/dist/production/enterprise-wc.js"></script>`
  - `npm install --global serve`
  - `serve enterprise-wc`
  - go to localhost:3000/menu-button.html
  - click on the button, hover over the menu and see the submenu has correct position

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.