### PR TITLE
8502 - Remove isMobile spec

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.2.0 Fixes
 
+- `[About]` Removed mobile info from about page. ([#8502](https://github.com/infor-design/enterprise/issues/8502))
 - `[PopupMenu]` Fix popupmenu truncation bug for menu items with shortcuts. ([#2250](https://github.com/infor-design/enterprise-wc/issues/2250))
 - `[Popupmenu]` Changed the `position-style` default to `fixed` this causes better placement in scroll containers. ([#2289](https://github.com/infor-design/enterprise-wc/issues/2289))
 - `[Toolbar]` Converted toolbar tests to playwright. ([#1984](https://github.com/infor-design/enterprise-wc/issues/1984))

--- a/src/components/ids-about/demos/standalone-css.html
+++ b/src/components/ids-about/demos/standalone-css.html
@@ -18,15 +18,14 @@
             <div class="ids-modal-content" tabindex="0">
               <p class="ids-text">Controls Example Application Version No. XX</p>
               <p class="ids-text">Fashionable components for fashionable applications.</p>
-              <p class="ids-text">Copyright © 2021 Infor. All rights reserved. The word and design marks set forth herein are trademarks and/or registered trademarks of Infor and/or its affiliates and subsidiaries. All other trademarks listed herein are the property of their respective owners <a class="ids-hyperlink" href="https://www.infor.com" target="_blank">www.infor.com</a>.</p>
+              <p class="ids-text">Copyright © 2024 Infor. All rights reserved. The word and design marks set forth herein are trademarks and/or registered trademarks of Infor and/or its affiliates and subsidiaries. All other trademarks listed herein are the property of their respective owners <a class="ids-hyperlink" href="https://www.infor.com" target="_blank">www.infor.com</a>.</p>
               <p class="ids-text"><span>Operating System : Mac OS X 10.15.7</span><br/>
                 <span>Platform : MacIntel</span><br/>
-                <span>Mobile : false</span><br/>
                 <span>Locale : en-US</span><br/>
                 <span>Language : en</span><br/>
                 <span>Browser :   Chrome (92.0.4515.159)</span><br/>
                 <span>Browser language : en-US</span><br/>
-                <span>IDS Version : 1.1.0</span></p>
+                <span>IDS Version : 1.2.0</span></p>
             </div>
           </div>
         </div>

--- a/src/components/ids-about/ids-about.scss
+++ b/src/components/ids-about/ids-about.scss
@@ -5,6 +5,14 @@
   contain: content;
 }
 
+.ids-modal {
+  &.ids-about {
+    .ids-modal-content.has-scrollbar {
+      overflow: auto;
+    }
+  }
+}
+
 .ids-about {
   .ids-modal-container {
     max-width: var(--ids-about-width-max);
@@ -35,7 +43,7 @@
     border-radius: var(--ids-border-radius-xxs);
     max-height: 199px;
     outline: 0;
-    overflow: auto !important;
+    overflow: auto;
     text-align: left;
     scroll-behavior: smooth;
 

--- a/src/components/ids-about/ids-about.scss
+++ b/src/components/ids-about/ids-about.scss
@@ -35,7 +35,7 @@
     border-radius: var(--ids-border-radius-xxs);
     max-height: 199px;
     outline: 0;
-    overflow: auto;
+    overflow: auto !important;
     text-align: left;
     scroll-behavior: smooth;
 

--- a/src/components/ids-about/ids-about.ts
+++ b/src/components/ids-about/ids-about.ts
@@ -193,7 +193,6 @@ export default class IdsAbout extends Base {
       const specs = getSpecs();
       const element = `<ids-text slot="device" type="p">
         <span>${this.localeAPI?.translate('Platform')} : ${specs.platform}</span><br/>
-        <span>${this.localeAPI?.translate('Mobile')} : ${specs.isMobile}</span><br/>
         <span>${this.localeAPI?.translate('Browser')} : ${specs.browser} (${specs.browserVersion})</span><br/>
         <span>${this.localeAPI?.translate('Locale')} : ${this.localeAPI?.locale.name || 'en-US'}</span><br/>
         <span>${this.localeAPI?.translate('Language')} : ${this.localeAPI?.language.name || 'en'}</span><br/>

--- a/tests/ids-about/ids-about.spec.ts
+++ b/tests/ids-about/ids-about.spec.ts
@@ -139,7 +139,6 @@ test.describe('IdsAbout tests', () => {
       // Check that the clipboard contains correct UUID
       expect(clipboardContent).toContain('IDS version');
       expect(clipboardContent).toContain('Controls Example Application Version No. XX');
-      expect(clipboardContent).toContain('Mobile');
       expect(clipboardContent).toContain('Platform');
     });
   });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

This PR removes `isMobile` spec same with the Enterprise.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/8502

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4300/ids-about/standalone-css.html
- There should be no mobile info
- Check the `ts` of about component
- `isMobile` spec should now removed

**Included in this Pull Request**:
~~- [ ] Some documentation for the feature.~~
~~- [ ] A test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
