### PR TITLE
2285 - IdsPopup open edge position

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Hierarchy]` Converted hierarchy tests to playwright. ([#1939](https://github.com/infor-design/enterprise-wc/issues/1939))
 - `[Hyperlink]` Converted hyperlink tests to playwright. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
 - `[Masthead]` Converted masthead tests to playwright. ([#1951](https://github.com/infor-design/enterprise-wc/issues/1951))
+- `[MenuButton]` Fix popup aligned edge position on open. ([#2285](https://github.com/infor-design/enterprise-wc/issues/2285))
 - `[Multiselect]` Fix so that options with long text will now show tooltip and also fit properly inside input-field. ([#2264](https://github.com/infor-design/enterprise-wc/issues/2264))
 - `[Pager]` Fix `ids-pager-button` so that it can be enabled if `page-total` is unknown or not provided. ([#1506](https://github.com/infor-design/enterprise-wc/issues/1506))
 - `[Pie Chart]` Converted pie chart tests to playwright. ([#1960](https://github.com/infor-design/enterprise-wc/issues/1960))

--- a/src/components/ids-menu-button/ids-menu-button.ts
+++ b/src/components/ids-menu-button/ids-menu-button.ts
@@ -220,7 +220,6 @@ export default class IdsMenuButton extends IdsButton {
 
     if (this.menuEl.popup) {
       this.menuEl.popup.align = 'bottom, left';
-      this.menuEl.popup.alignEdge = 'top';
       this.menuEl.popup.y = 8;
       this.setPopupArrow();
     }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fix IdsMenuButton bug where popup menu opens on incorrect edge.

**Related github/jira issue (required)**:
Closes #2285 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/export-excel.html
3. Open `Export Excel` popup
4. It should open below button by default
5. Decrease browser height to about `140px`
6. Open popup
7. It should open above menu button because it doesn't fit below


**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
