### PR TITLE
2338 - IdsTabs Fix fist tab selection when using production build

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Slider]` Converted slider tests to playwright. ([#1971](https://github.com/infor-design/enterprise-wc/issues/1971))
 - `[Step chart]` Converted skiplink tests to playwright. ([#1973](https://github.com/infor-design/enterprise-wc/issues/1973))
 - `[Swappable]` Converted swappable tests to playwright. ([#1975](https://github.com/infor-design/enterprise-wc/issues/1975))
+- `[Tabs]` Fixed an issue where first tab is not being selected when using production build on a html page. ([#2338](https://github.com/infor-design/enterprise-wc/issues/2338))
 - `[Tabs]` Fixed position of more menu in production/angular build. ([#2352](https://github.com/infor-design/enterprise-wc/issues/2352))
 - `[Tabs]` Converted Tabs tests to playwright. ([#1979](https://github.com/infor-design/enterprise-wc/issues/1979))
 - `[Text]` Fixed lifecycle issues with text translation in angular.. ([#2324](https://github.com/infor-design/enterprise-wc/issues/2324))

--- a/src/components/ids-tabs/ids-tabs.ts
+++ b/src/components/ids-tabs/ids-tabs.ts
@@ -54,7 +54,10 @@ export default class IdsTabs extends Base {
     this.#attachEventHandlers();
     this.#ro.observe(this.container as any);
     const selected: any = this.querySelector('[selected]') || this.querySelector('[value]');
-    this.#selectTab(selected);
+    // Defer the initial tab selection until after the initial setup phase
+    requestAnimationFrame(() => {
+      this.#selectTab(selected);
+    });
     this.#attachAfterRenderEvents();
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed an issue where first tab is not being selected when using production build on a html page by deferring fist tab selection until after the initial setup phase of the component. No tests added because everything should work as before for web components and the issue is hard to reproduce in tests.

**Related github/jira issue (required)**:
Closes #2338 

**Steps necessary to review your pull request (required)**:
- pull the branch
- build dist `npm run build:dist:prod`
- https://stackblitz.com/edit/ids-enterprise-wc-100-ntsrkq?file=index.html you need to run this file locally and link enterprise-wc.js file from build folder replacing https://unpkg.com/ids-enterprise-wc@1.1.0/enterprise-wc.js.
- example below shows how to serve that static file with `serve` (any similar tool will work)
- copy html from from https://stackblitz.com/edit/ids-enterprise-wc-100-ntsrkq?file=index.html to `tabs.html` file and place it inside `enterprise-wc` folder
- replace module link in head with `<script type="module" src="build/dist/production/enterprise-wc.js"></script>`
- `npm install --global serve`
- `serve enterprise-wc`
- go to localhost:3000/tabs.html
- see the first tab is selected and can be selected by clicking to another tab and back

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
