### PR TITLE
2296 - ids-list-view-item focus search

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 1.3.0 Fixes
 
+- `[ListView]` Fix bug where, after a list-view-item is selected, search-field keeps losing focus while typing. ([#2296](https://github.com/infor-design/enterprise-wc/issues/2296))
 - `[Message]` Converted message tests to playwright. ([#1954](https://github.com/infor-design/enterprise-wc/issues/1954))
 - `[Tabs]` Fix tab content visible state when added dynamically. ([#2393](https://github.com/infor-design/enterprise-wc/issues/2393))
 - `[WeekView]` Added more input handling for `startHour`, `endHour`, and `timelineInterval`. ([#2446](https://github.com/infor-design/enterprise-wc/issues/2446))

--- a/src/components/ids-list-view/ids-list-view-item.ts
+++ b/src/components/ids-list-view/ids-list-view-item.ts
@@ -548,7 +548,11 @@ export default class IdsListViewItem extends Base {
       this.setAttribute('tabindex', '0');
 
       this.listView?.body?.setAttribute('aria-activedescendant', String(this.id));
-      this.focus();
+
+      const searchField = this.listView?.searchField;
+      if (searchField !== document.activeElement) {
+        this.focus();
+      }
     }
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix bug where, after a list-view-item is selected, search-field keeps losing focus while typing.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #2296 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Go to: http://localhost:4300/ids-list-view/search.html
2. select any item
3. start searching
4. Ensure that search-field does not lose focus every time a key is pressed
5. Check against: https://main.wc.design.infor.com/ids-list-view/search.html

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
