### PR TITLE
2325 - IdsModal String interpolation for the modal title in Angular

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,10 +9,11 @@
 ### 1.3.0 Fixes
 
 - `[Message]` Converted message tests to playwright. ([#1954](https://github.com/infor-design/enterprise-wc/issues/1954))
+- `[Modal]` Fixed an issue where string interpolation didn't work for the modal title in Angular examples. ([#2325](https://github.com/infor-design/enterprise-wc/issues/2325))
+- `[MonthView]` Converted month view tests to playwright. ([#1956](https://github.com/infor-design/enterprise-wc/issues/1956))
 - `[Tabs]` Fix tab content visible state when added dynamically. ([#2393](https://github.com/infor-design/enterprise-wc/issues/2393))
 - `[WeekView]` Added more input handling for `startHour`, `endHour`, and `timelineInterval`. ([#2446](https://github.com/infor-design/enterprise-wc/issues/2446))
 - `[WeekView]` Converted week view tests to playwright. ([#1993](https://github.com/infor-design/enterprise-wc/issues/1993))
-- `[MonthView]` Converted month view tests to playwright. ([#1956](https://github.com/infor-design/enterprise-wc/issues/1956))
 
 ## 1.2.0
 

--- a/src/components/ids-modal/ids-modal.ts
+++ b/src/components/ids-modal/ids-modal.ts
@@ -115,7 +115,9 @@ export default class IdsModal extends Base {
     }
 
     // Update ARIA / Sets up the label
-    this.messageTitle = this.querySelector('[slot="title"]')?.textContent ?? '';
+    requestAnimationFrame(() => {
+      this.messageTitle = this.querySelector('[slot="title"]')?.textContent ?? '';
+    });
     this.setAttribute('role', 'dialog');
     this.refreshAriaLabel();
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed an issue where string interpolation didn't work for the modal title in Angular examples by deferring `messageTitle` assignment until after the initial setup phase

**Related github/jira issue (required)**:
Closes #2325 

**Steps necessary to review your pull request (required)**:
- pull the branch
- `npm run publish:link`
- pull this branch https://github.com/infor-design/enterprise-wc-examples/pull/73 in the examples
- `npm link ids-enterprise-wc` in Angular examples
- build Angular examples
- go to http://localhost:4200/ids-modal/example
- trigger the modal and see `Active IDS Modal` title is there

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
