### PR TITLE
2408 - IdsAccordion Selected event in nested accordion

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 1.3.0 Fixes
 
 - `[Accordion]` Fix accordion panel expanded/icon states when inserted dynamically. ([#2406](https://github.com/infor-design/enterprise-wc/issues/2406))
+- `[Accordion]` Fix nested accordion fires common event between all headers. ([#2408](https://github.com/infor-design/enterprise-wc/issues/2408))
 - `[Dropdown]` Fix dropdown bug where input is empty when option text is dynamic. ([#2362](https://github.com/infor-design/enterprise-wc/issues/2362))
 - `[Datagrid]` Fix `save-user-settings` so that it works in Angular. ([#2383](https://github.com/infor-design/enterprise-wc/issues/2383))
 - `[ListView|VirtualScroll]` Fix scroll-behavior of `ids-list-view` when used within `ids-virtual-scroll`. ([#2322](https://github.com/infor-design/enterprise-wc/issues/2322))

--- a/src/components/ids-accordion/ids-accordion-header.ts
+++ b/src/components/ids-accordion/ids-accordion-header.ts
@@ -300,6 +300,12 @@ export default class IdsAccordionHeader extends Base {
             elem: this,
           }
         });
+        this.triggerEvent('deselect', this, {
+          bubbles: true,
+          detail: {
+            elem: this,
+          }
+        });
       }
     }
   }

--- a/src/components/ids-accordion/ids-accordion-panel.ts
+++ b/src/components/ids-accordion/ids-accordion-panel.ts
@@ -450,6 +450,12 @@ export default class IdsAccordionPanel extends Base {
     this.onEvent('slotchange.content-slotchange', this.container?.querySelector('slot[name="content"]'), () => {
       this.#toggleExpanded(this.expanded);
     });
+
+    // Stops the selected event from bubbling up to the accordion
+    this.offEvent('selected.accordion-panel-selected', this);
+    this.onEvent('selected.accordion-panel-selected', this, (e: { stopPropagation: () => void; }) => {
+      e.stopPropagation();
+    });
   }
 
   /**

--- a/src/components/ids-accordion/ids-accordion.ts
+++ b/src/components/ids-accordion/ids-accordion.ts
@@ -341,8 +341,9 @@ export default class IdsAccordion extends Base {
    * @returns {void}
    */
   #handleEvents() {
-    // Responds to `selected` events triggered by children
-    this.onEvent('selected', this, (e: CustomEvent) => {
+    // Responds to `deselect` event triggered by children
+    this.offEvent('deselect.accordion-deselect', this);
+    this.onEvent('deselect.accordion-deselect', this, (e: CustomEvent) => {
       const el = e.detail.elem as IdsAccordionHeader;
       this.previouslySelected = el;
       this.#deselectOtherHeaders(el);

--- a/tests/ids-accordion/ids-accordion.spec.ts
+++ b/tests/ids-accordion/ids-accordion.spec.ts
@@ -366,5 +366,16 @@ test.describe('IdsAccordion tests', () => {
       await employeePanel.evaluate((panel: IdsAccordionPanel) => { panel.expanded = true; });
       expect(await benefitsPanel.evaluate((panel: IdsAccordionPanel) => panel.parentExpanded)).toBeTruthy();
     });
+
+    test('it should not fire selected event on the root accordion', async ({ page, eventsTest }) => {
+      const id = '#keep-expander-placement-nested';
+      const accordionRoot = await page.locator(id);
+      await eventsTest.onEvent(id, 'selected');
+      await eventsTest.onEvent(id, 'deselect');
+      const nestedHeader = await accordionRoot.locator('ids-accordion-header').last();
+      await nestedHeader.dispatchEvent('click');
+      expect(await eventsTest.isEventTriggered(id, 'selected')).toBeFalsy();
+      expect(await eventsTest.isEventTriggered(id, 'deselect')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added stop for propagated selected event in the accordion panel and added another `deselect` event to deselect selected panels in the root accordion component

**Related github/jira issue (required)**:
Closes #2408 

**Steps necessary to review your pull request (required)**:
- pull the branch
- `npm run publish:link`
- pull the branch https://github.com/infor-design/enterprise-wc-examples/pull/75 in Angular examples
- `npm link ids-enterprise-wc` in Angular examples
- `npm start` in Angular examples
- go to http://localhost:4200/ids-accordion/nested-selected-event
- select any nested accordion panel
- see the log in the console runs once for the selected panel

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.