### PR TITLE
2300 - IdsImage fix src 

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Dropdown]` Fix dropdown in action panel. ([#2431](https://github.com/infor-design/enterprise-wc/issues/2431))
 - `[Multiselect]` Fix multiselect width when size is `full`. ([#2248](https://github.com/infor-design/enterprise-wc/issues/2248))
 - `[Datagrid]` Fix `save-user-settings` so that it works in Angular. ([#2383](https://github.com/infor-design/enterprise-wc/issues/2383))
+- `[Image]` Fix `src` setting in example. ([#2300](https://github.com/infor-design/enterprise-wc/issues/2300))
 - `[ListView|VirtualScroll]` Fix scroll-behavior of `ids-list-view` when used within `ids-virtual-scroll`. ([#2322](https://github.com/infor-design/enterprise-wc/issues/2322))
 - `[ListView]` Fix bug where, after a list-view-item is selected, search-field keeps losing focus while typing. ([#2296](https://github.com/infor-design/enterprise-wc/issues/2296))
 - `[ListView|VirtualScroll]` Fix scroll-behavior of `ids-list-view` when used within `ids-virtual-scroll`. ([#2322](https://github.com/infor-design/enterprise-wc/issues/2322))

--- a/src/components/ids-image/demos/example.ts
+++ b/src/components/ids-image/demos/example.ts
@@ -1,6 +1,8 @@
 import IdsImg10 from '../../../assets/images/10.jpg';
 
-const idsImgClass11 = window.document.getElementsByClassName('ids-img-10');
-[...idsImgClass11].forEach((element: any) => {
-  element.src = IdsImg10;
+document.addEventListener('DOMContentLoaded', () => {
+  const idsImgClass11 = window.document.getElementsByClassName('ids-img-10');
+  [...idsImgClass11].forEach((element: any) => {
+    element.src = IdsImg10;
+  });
 });

--- a/src/components/ids-image/ids-image.ts
+++ b/src/components/ids-image/ids-image.ts
@@ -134,7 +134,7 @@ export default class IdsImage extends Base {
         img.setAttribute(attributes.SRC, val);
       } else {
         // Removing placeholder
-        this.shadowRoot?.querySelector('.placeholder')?.remove();
+        this.shadowRoot?.querySelector('.placeholder, .initials')?.remove();
         // Adding image element
         img = this.#getImgEl(val, this.alt);
         this.shadowRoot?.appendChild(img);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes IdsImage example.html. 
example.ts was overriding `src` setter, needs to wait for `DOMContentLoaded`

**Related github/jira issue (required)**:
Closes #2300 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-image/example.html
3. Run in console
```
document.querySelectorAll('ids-image').forEach((img) => img.src = 'https://www.w3schools.com/tags/img_girl.jpg');
```
4. Check that url image is set in all IdsImages

**Included in this Pull Request**:
- [x] A note to the change log.
