### PR TITLE
2529 - Add css variables for accordion header padding

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,8 +11,9 @@
 ### 1.3.0 Fixes
 
 - `[Accordion]` Fix accordion panel expanded/icon states when inserted dynamically. ([#2406](https://github.com/infor-design/enterprise-wc/issues/2406))
-- `[Accordion]` Fix nested accordion fires common event between all headers. ([#2408](https://github.com/infor-design/enterprise-wc/issues/2408))
-- `[Button]` Changed GenAi Button in dark mode background color. ([#2509](https://github.com/infor-design/enterprise-wc/issues/2509))
+- `[Accordion]` Added css variables to customization accordion header padding. ([#2529](https://github.com/infor-design/enterprise-wc/issues/2529))
+- `[Accordion]` Changed `GenAi` Button in dark mode background color. ([#2509](https://github.com/infor-design/enterprise-wc/issues/2509))
+- `[Button]` Changed `GenAi` Button in dark mode background color. ([#2509](https://github.com/infor-design/enterprise-wc/issues/2509))
 - `[Dropdown]` Fix dropdown bug where input is empty when option text is dynamic. ([#2362](https://github.com/infor-design/enterprise-wc/issues/2362))
 - `[Dropdown]` Fix dropdown width when size is `full`. ([#2001](https://github.com/infor-design/enterprise-wc/issues/2001))
 - `[Dropdown]` Fix dropdown in expandable header. ([#2441](https://github.com/infor-design/enterprise-wc/issues/2441))

--- a/src/components/ids-accordion/ids-accordion-header.scss
+++ b/src/components/ids-accordion/ids-accordion-header.scss
@@ -137,7 +137,7 @@
   &:not([class*="color-variant-"]) {
     @include accordion-header-standard-colors();
 
-    padding: 12px 16px;
+    padding: var(--ids-accordion-header-padding);
 
     &:not(.disabled) {
       @include accordion-header-focus-colors();
@@ -164,7 +164,7 @@
   &.color-variant-app-menu {
     @include accordion-header-app-menu-colors();
 
-    padding: 12px 16px;
+    padding: var(--ids-accordion-header-app-menu-padding);
   }
 
   // Sub-level App Menu Accordions
@@ -172,7 +172,7 @@
     @include accordion-header-app-menu-colors();
     @include accordion-header-nested-app-menu-colors();
 
-    padding: 8px 20px;
+    padding: var(--ids-accordion-header-sub-app-menu-padding);
   }
 
   // =========================================

--- a/src/components/ids-accordion/ids-accordion-panel.scss
+++ b/src/components/ids-accordion/ids-accordion-panel.scss
@@ -84,8 +84,8 @@
 
 @mixin accordion-pane-in-page-standard-size() {
   .ids-accordion-pane-content {
-    padding-block: 8px;
-    padding-inline-start: 18px;
+    padding-block: var(--ids-accordion-pane-content-padding-block);
+    padding-inline-start: var(--ids-accordion-pane-content-padding-inline);
   }
 
   &.nested {
@@ -96,7 +96,7 @@
 
   &.has-icon {
     .ids-accordion-pane-content {
-      padding-inline-start: 30px;
+      padding-inline-start: var(--ids-accordion-pane-content-padding-icon);
     }
   }
 }

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -148,6 +148,9 @@
   --ids-accordion-header-shadow-focus: var(--ids-shadow-20);
   --ids-accordion-header-color-border-disabled: var(--ids-color-text-disabled);
   --ids-accordion-header-color-text-disabled: var(--ids-color-text-disabled);
+  --ids-accordion-header-padding:  12px 16px;
+  --ids-accordion-header-app-menu-padding:  12px 16px;
+  --ids-accordion-header-sub-app-menu-padding:  8px 20px;
 
   // Action Panel
   --ids-action-panel-header-height: 50px;

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -148,9 +148,12 @@
   --ids-accordion-header-shadow-focus: var(--ids-shadow-20);
   --ids-accordion-header-color-border-disabled: var(--ids-color-text-disabled);
   --ids-accordion-header-color-text-disabled: var(--ids-color-text-disabled);
-  --ids-accordion-header-padding:  12px 16px;
-  --ids-accordion-header-app-menu-padding:  12px 16px;
-  --ids-accordion-header-sub-app-menu-padding:  8px 20px;
+  --ids-accordion-header-padding: 12px 16px;
+  --ids-accordion-header-app-menu-padding: 12px 16px;
+  --ids-accordion-header-sub-app-menu-padding: 8px 20px;
+  --ids-accordion-pane-content-padding-block: 8px;
+  --ids-accordion-pane-content-padding-inline: 18px;
+  --ids-accordion-pane-content-padding-icon: 30px;
 
   // Action Panel
   --ids-action-panel-header-height: 50px;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Changed some hardcode padding to a css variable so it can be used for customization

**Related github/jira issue (required)**:
Fixes #2529


**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-accordion/example.html
- should look same as before
- inspect an accordion-header and add a variable to change padding like: `    --ids-accordion-header-padding: 10px 10px;`

**Screen shots**
![Screenshot 2024-07-05 at 2 39 59 PM](https://github.com/infor-design/enterprise-wc/assets/814283/c6675b95-cfa1-4aab-9366-e41a7da673fb)

**Included in this Pull Request**:
- [x] A note to the change log.
