### PR TITLE
2462 - IdsDropdown tooltip zindex

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Tabs]` Fix tab content visible state when added dynamically. ([#2393](https://github.com/infor-design/enterprise-wc/issues/2393))
 - `[Text]` Properly vertically-align `ids-alert` text when placed inside `ids-text`. ([#2327](https://github.com/infor-design/enterprise-wc/issues/2327))
 - `[Tooltip]` Converted tooltip tests to playwright. ([#1985](https://github.com/infor-design/enterprise-wc/issues/1985))
+- `[Tooltip]` Increase tooltip z-index. ([#2462](https://github.com/infor-design/enterprise-wc/issues/2462))
 - `[TriggerButton]` Fixed style issues. Trigger start spacing, readonly hover, inline border radius. ([#2303](https://github.com/infor-design/enterprise-wc/issues/2303))
 - `[WeekView]` Added more input handling for `startHour`, `endHour`, and `timelineInterval`. ([#2446](https://github.com/infor-design/enterprise-wc/issues/2446))
 - `[WeekView]` Converted week view tests to playwright. ([#1993](https://github.com/infor-design/enterprise-wc/issues/1993))

--- a/src/components/ids-dropdown/demos/in-action-panel.html
+++ b/src/components/ids-dropdown/demos/in-action-panel.html
@@ -31,13 +31,14 @@
       </ids-toolbar>
       <ids-layout-grid auto-fit="true" padding="md">
         <ids-layout-grid-column>
-          <ids-dropdown id="dropdown-1" label="Dropdown with Tooltips on Ellipsis" tooltip="1" value="opt2">
+          <ids-dropdown id="dropdown-2" label="Dropdown with Custom Tooltips" value="opt2">
             <ids-list-box>
-              <ids-list-box-option value="opt1" id="opt1-d1">Chester County established 1682</ids-list-box-option>
-              <ids-list-box-option value="opt2" id="opt2-d1">Montgomery County established 1784</ids-list-box-option>
-              <ids-list-box-option value="opt3" id="opt3-d1">Philadelphia County established 1682, also PA's biggest city</ids-list-box-option>
-              <ids-list-box-option value="opt4" id="opt4-d1">Bucks County established 1682</ids-list-box-option>
-              <ids-list-box-option value="opt5" id="opt5-d1">York County established 1749</ids-list-box-option>
+              <ids-list-box-option value="opt1" id="opt1-d2" tooltip="Additional Info on Option One">Option One</ids-list-box-option>
+              <ids-list-box-option value="opt2" id="opt2-d2" tooltip="Additional Info on Option Two">Option Two</ids-list-box-option>
+              <ids-list-box-option value="opt3" id="opt3-d2" tooltip="Additional Info on Option Three">Option Three</ids-list-box-option>
+              <ids-list-box-option value="opt4" id="opt4-d2" tooltip="Additional Info on Option Four">Option Four</ids-list-box-option>
+              <ids-list-box-option value="opt5" id="opt5-d2" tooltip="Additional Info on Option Five">Option Five</ids-list-box-option>
+              <ids-list-box-option value="opt6" id="opt6-d2" tooltip="Additional Info on Option Six">Option Six</ids-list-box-option>
             </ids-list-box>
           </ids-dropdown>
         </ids-layout-grid-column>

--- a/src/components/ids-dropdown/demos/in-action-panel.html
+++ b/src/components/ids-dropdown/demos/in-action-panel.html
@@ -31,7 +31,7 @@
       </ids-toolbar>
       <ids-layout-grid auto-fit="true" padding="md">
         <ids-layout-grid-column>
-          <ids-dropdown label="Normal Dropdown with Dirty Tracker" value="ca" dirty-tracker="true">
+          <ids-dropdown label="Normal Dropdown with Dirty Tracker" value="ca" dirty-tracker="true" tooltip="Additional Information">
             <ids-list-box>
               <ids-list-box-option id="ca" value="ca">California</ids-list-box-option>
               <ids-list-box-option id="hi" value="hi">Hawaii</ids-list-box-option>

--- a/src/components/ids-dropdown/demos/in-action-panel.html
+++ b/src/components/ids-dropdown/demos/in-action-panel.html
@@ -31,49 +31,13 @@
       </ids-toolbar>
       <ids-layout-grid auto-fit="true" padding="md">
         <ids-layout-grid-column>
-          <ids-dropdown label="Normal Dropdown with Dirty Tracker" value="ca" dirty-tracker="true" tooltip="Additional Information">
+          <ids-dropdown id="dropdown-1" label="Dropdown with Tooltips on Ellipsis" tooltip="1" value="opt2">
             <ids-list-box>
-              <ids-list-box-option id="ca" value="ca">California</ids-list-box-option>
-              <ids-list-box-option id="hi" value="hi">Hawaii</ids-list-box-option>
-              <ids-list-box-option id="id" value="id">Idaho</ids-list-box-option>
-              <ids-list-box-option id="il" value="il">Illinois</ids-list-box-option>
-              <ids-list-box-option id="in" value="in">Indiana</ids-list-box-option>
-              <ids-list-box-option id="ia" value="ia">Iowa</ids-list-box-option>
-              <ids-list-box-option id="ks" value="ks">Kansas</ids-list-box-option>
-              <ids-list-box-option id="ky" value="ky">Kentucky</ids-list-box-option>
-              <ids-list-box-option id="la" value="la">Louisiana</ids-list-box-option>
-              <ids-list-box-option id="me" value="me">Maine</ids-list-box-option>
-              <ids-list-box-option id="md" value="md">Maryland</ids-list-box-option>
-              <ids-list-box-option id="ma" value="ma">Massachusetts</ids-list-box-option>
-              <ids-list-box-option id="mi" value="mi">Michigan</ids-list-box-option>
-              <ids-list-box-option id="mn" value="mn">Minnesota</ids-list-box-option>
-              <ids-list-box-option id="ms" value="ms">Mississippi</ids-list-box-option>
-              <ids-list-box-option id="mo" value="mo">Missouri</ids-list-box-option>
-              <ids-list-box-option id="mt" value="mt">Montana</ids-list-box-option>
-              <ids-list-box-option id="ne" value="ne">Nebraska</ids-list-box-option>
-              <ids-list-box-option id="nv" value="nv">Nevada</ids-list-box-option>
-              <ids-list-box-option id="nh" value="nh">New Hampshire</ids-list-box-option>
-              <ids-list-box-option id="nj" value="nj">New Jersey</ids-list-box-option>
-              <ids-list-box-option id="nm" value="nm">New Mexico</ids-list-box-option>
-              <ids-list-box-option id="ny" value="ny">New York</ids-list-box-option>
-              <ids-list-box-option id="nc" value="nc">North Carolina</ids-list-box-option>
-              <ids-list-box-option id="nd" value="nd">North Dakota</ids-list-box-option>
-              <ids-list-box-option id="oh" value="oh">Ohio</ids-list-box-option>
-              <ids-list-box-option id="ok" value="ok">Oklahoma</ids-list-box-option>
-              <ids-list-box-option id="or" value="or">Oregon</ids-list-box-option>
-              <ids-list-box-option id="pa" value="pa">Pennsylvania</ids-list-box-option>
-              <ids-list-box-option id="ri" value="ri">Rhode Island</ids-list-box-option>
-              <ids-list-box-option id="sc" value="sc">South Carolina</ids-list-box-option>
-              <ids-list-box-option id="sd" value="sd">South Dakota</ids-list-box-option>
-              <ids-list-box-option id="tn" value="tn">Tennessee</ids-list-box-option>
-              <ids-list-box-option id="tx" value="tx">Texas</ids-list-box-option>
-              <ids-list-box-option id="ut" value="ut">Utah</ids-list-box-option>
-              <ids-list-box-option id="vt" value="vt">Vermont</ids-list-box-option>
-              <ids-list-box-option id="va" value="va">Virginia</ids-list-box-option>
-              <ids-list-box-option id="wa" value="wa">Washington</ids-list-box-option>
-              <ids-list-box-option id="wv" value="wv">West Virginia</ids-list-box-option>
-              <ids-list-box-option id="wi" value="wi">Wisconsin</ids-list-box-option>
-              <ids-list-box-option id="wy" value="wy">Wyoming</ids-list-box-option>
+              <ids-list-box-option value="opt1" id="opt1-d1">Chester County established 1682</ids-list-box-option>
+              <ids-list-box-option value="opt2" id="opt2-d1">Montgomery County established 1784</ids-list-box-option>
+              <ids-list-box-option value="opt3" id="opt3-d1">Philadelphia County established 1682, also PA's biggest city</ids-list-box-option>
+              <ids-list-box-option value="opt4" id="opt4-d1">Bucks County established 1682</ids-list-box-option>
+              <ids-list-box-option value="opt5" id="opt5-d1">York County established 1749</ids-list-box-option>
             </ids-list-box>
           </ids-dropdown>
         </ids-layout-grid-column>

--- a/src/components/ids-popup/ids-popup.scss
+++ b/src/components/ids-popup/ids-popup.scss
@@ -8,6 +8,10 @@
   text-align: unset;
 }
 
+:host([type='tooltip']) {
+  z-index: 1022;
+}
+
 :host([position-style='absolute']) {
   position: absolute;
 }

--- a/src/components/ids-popup/ids-popup.scss
+++ b/src/components/ids-popup/ids-popup.scss
@@ -9,7 +9,7 @@
 }
 
 :host([type='tooltip']) {
-  z-index: 1022;
+  z-index: var(--ids-z-index-tooltips);
 }
 
 :host([position-style='absolute']) {

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -127,9 +127,35 @@
   --ids-z-index-90: 500;
   --ids-z-index-100: 600;
   --ids-z-index-110: 700;
+  --ids-z-index-120: 1000;
+  --ids-z-index-130: 1010;
+  --ids-z-index-140: 1015;
+  --ids-z-index-150: 1020;
+  --ids-z-index-160: 3000;
+  --ids-z-index-170: 4000;
+  --ids-z-index-180: 4500;
+  --ids-z-index-190: 6000;
+  --ids-z-index-200: 7000;
+  --ids-z-index-210: 8000;
+  --ids-z-index-220: 9000;
+  --ids-z-index-230: 10000;
+  --ids-z-index-240: 10020;
 
   // Z Indexes (purpose-driven)
   --ids-z-index-top-level-container: var(--ids-z-index-20);
+  --ids-z-index-overlay: var(--ids-z-index-120);
+  --ids-z-index-busy-indicator: var(--ids-z-index-130);
+  --ids-z-index-popdown: var(--ids-z-index-140);
+  --ids-z-index-dialogs: var(--ids-z-index-150);
+  --ids-z-index-popovers : var(--ids-z-index-160);
+  --ids-z-index-lookup: var(--ids-z-index-170);
+  --ids-z-index-dropdown: var(--ids-z-index-180);
+  --ids-z-index-tooltips: var(--ids-z-index-190);
+  --ids-z-index-draggables: var(--ids-z-index-200);
+  --ids-z-index-slide-dialogs: var(--ids-z-index-210);
+  --ids-z-index-context-menu: var(--ids-z-index-220);
+  --ids-z-index-full-page-sticky: var(--ids-z-index-230);
+  --ids-z-index-skip-link: var(--ids-z-index-240);
 
   // @component
   // About


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Update z-index of tooltip popups.
IdsModal z-index is hard coded to `1020` [here](https://github.com/infor-design/enterprise-wc/blob/c1144f4bbafd06137675ba9bbbeb65cc71594754/src/components/ids-modal/ids-modal.ts#L56).
I updated popup[type='tooltip'] css z-index to `1022`

**Related github/jira issue (required)**:
Closes #2462 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-dropdown/in-action-panel.html
3. Open modal, hover over dropdown
4. Check that tooltip appears

**Included in this Pull Request**:
- [x] A note to the change log.

