### PR TITLE
2248 - IdsDropdown fix size setting for angular

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Accordion]` Added css variables to customization accordion header padding. ([#2529](https://github.com/infor-design/enterprise-wc/issues/2529))
 - `[Button]` Changed `GenAi` Button in dark mode background color. ([#2509](https://github.com/infor-design/enterprise-wc/issues/2509))
 - `[Datagrid]` Fixed a bug where when no `id` column or `idColumn` setting remove row removed the wrong row.. ([#2355](https://github.com/infor-design/enterprise-wc/issues/2355))
+- `[Dropdown]` Fix dropdown size setting for angular. ([#2248](https://github.com/infor-design/enterprise-wc/issues/2248))
 - `[Dropdown]` Fix dropdown bug where input is empty when option text is dynamic. ([#2362](https://github.com/infor-design/enterprise-wc/issues/2362))
 - `[Dropdown]` Fix dropdown width when size is `full`. ([#2001](https://github.com/infor-design/enterprise-wc/issues/2001))
 - `[Dropdown]` Fix dropdown in expandable header. ([#2441](https://github.com/infor-design/enterprise-wc/issues/2441))

--- a/src/components/ids-dropdown/ids-dropdown-attributes-mixin.ts
+++ b/src/components/ids-dropdown/ids-dropdown-attributes-mixin.ts
@@ -133,7 +133,7 @@ const IdsDropdownAttributeMixin = <T extends Constraints>(superclass: T) => clas
   set size(value: string) {
     if (value) {
       this.setAttribute(attributes.SIZE, value);
-      if (value === 'full') this.container?.classList.add('full');
+      this.container?.classList.toggle('full', value === 'full');
     } else {
       this.removeAttribute(attributes.SIZE);
       this.container?.classList.remove('full');

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -1327,6 +1327,9 @@ export default class IdsDropdown extends Base {
       this.dropdownList.setAttribute(attributes.VALUE, this.value);
     }
 
+    // sync size setting
+    this.onSizeChange(this.size);
+
     // set dropdown list's popup to `fixed` if dropdown exists in popup component
     if (getClosest(this, 'ids-modal, ids-popup, ids-action-panel')) {
       this.dropdownList?.setAttribute(attributes.POSITION_STYLE, 'fixed');


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed dropdown size setting for angular templating.
DropdownList needed to be configured on `slotchange` for dynamic content projection

**Related github/jira issue (required)**:
Closes #2248 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-dropdown/sizes.html
3. Check that size `full` and `large` still work

**Test in angular**
1. `npm link` this branch's build to the angular wc examples repo
2. Run angular example project
3. Go to http://localhost:4200/ids-dropdown/sizes
4. Check that dropdown size are correct
5. Go to http://localhost:4200/ids-multiselect/example
6. Run both `$('#multiselect-2').size = 'full';` `$('#multiselect-2').size = 'lg';` in console
7. Check that the multiselect dropdown are properly sized

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
