### PR TITLE
2586 -  Added new method `resetDirtyRow` allowing to reset dirty state for an specific row

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Dates]` Added a new `twoDigitYear` setting to set the locale system to set the dates cut over for two digit years, note that two digit years should be avoided. ([#8061](https://github.com/infor-design/enterprise-wc/issues/2425))
 - `[LayoutGrid]` Adds an example of a responsive grid layout inside a splitter component. ([#2411](https://github.com/infor-design/enterprise-wc/issues/2411))
 - `[Switch]` Updated switch design. ([#2347](https://github.com/infor-design/enterprise-wc/issues/2347))
+- `[Datagrid]` Added new method `resetDirtyRow` allowing to reset dirty state for an specific row. ([#2586](https://github.com/infor-design/enterprise-wc/issues/2586))
 
 ### 1.3.0 Fixes
 

--- a/src/components/ids-data-grid/ids-data-grid.ts
+++ b/src/components/ids-data-grid/ids-data-grid.ts
@@ -3135,14 +3135,27 @@ export default class IdsDataGrid extends Base {
    * Reset any currently dirty cells
    */
   resetDirtyCells() {
-    this.data.forEach((row) => {
-      if (row?.dirtyCells) {
-        delete row.dirtyCells;
-      }
+    this.data.forEach((row, idx) => {
+      this.resetDirtyRow(idx);
     });
-    this.container?.querySelectorAll('ids-data-grid-cell.is-dirty').forEach((elem) => {
-      elem.classList.remove('is-dirty');
+  }
+
+  /**
+   * Reset any currently dirty cells for a specific row
+   * @param {number} rowIndex The row index to reset the dirty state
+   */
+  resetDirtyRow(rowIndex: number) {
+    const row = this.rowByIndex(rowIndex);
+    const rowData = this.data[rowIndex];
+
+    row?.querySelectorAll('ids-data-grid-cell.is-dirty').forEach((cell) => {
+      cell.classList.remove('is-dirty');
     });
+
+    // Reset the dirty cell state in the data as well
+    if (rowData?.dirtyCells) {
+      delete rowData.dirtyCells;
+    }
   }
 
   /**

--- a/tests/ids-data-grid/ids-data-grid-editing.spec.ts
+++ b/tests/ids-data-grid/ids-data-grid-editing.spec.ts
@@ -293,7 +293,7 @@ test.describe('IdsDataGrid editing tests', () => {
       dataGrid.resetDirtyRow(1);
 
       const isRow0Dirty = editableCellRow0?.classList.contains('is-dirty');
-      const isRow1Dirty = editableCellRow0?.classList.contains('is-dirty');
+      const isRow1Dirty = editableCellRow1?.classList.contains('is-dirty');
 
       return {
         isRow0Dirty,

--- a/tests/ids-data-grid/ids-data-grid-editing.spec.ts
+++ b/tests/ids-data-grid/ids-data-grid-editing.spec.ts
@@ -275,6 +275,36 @@ test.describe('IdsDataGrid editing tests', () => {
     expect(results.isDirty3).toBeFalsy();
   });
 
+  test('revert dirty indicators on cells for a specific row', async ({ page }) => {
+    const results = await page.evaluate(() => {
+      const dataGrid = document.querySelector<IdsDataGrid>('ids-data-grid')!;
+      const row0 = dataGrid.rowByIndex(0);
+      const row1 = dataGrid.rowByIndex(1);
+      const editableCellRow0 = row0?.querySelector<IdsDataGridCell>('ids-data-grid-cell.is-editable');
+      const editableCellRow1 = row1?.querySelector<IdsDataGridCell>('ids-data-grid-cell.is-editable');
+
+      editableCellRow0?.startCellEdit();
+      editableCellRow0?.querySelector('ids-input')?.setAttribute('value', 'test0');
+      editableCellRow0?.endCellEdit();
+
+      editableCellRow1?.startCellEdit();
+      editableCellRow1?.querySelector('ids-input')?.setAttribute('value', 'test1');
+      editableCellRow1?.endCellEdit();
+      dataGrid.resetDirtyRow(1);
+
+      const isRow0Dirty = editableCellRow0?.classList.contains('is-dirty');
+      const isRow1Dirty = editableCellRow0?.classList.contains('is-dirty');
+
+      return {
+        isRow0Dirty,
+        isRow1Dirty
+      };
+    });
+
+    expect(results.isRow0Dirty).toBeTruthy();
+    expect(results.isRow1Dirty).toBeFalsy();
+  });
+
   test('show and revert validation indicators on cells', async ({ page }) => {
     const results = await page.evaluate(() => {
       const dataGrid = document.querySelector<IdsDataGrid>('ids-data-grid')!;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
When adding the method `resetDirtyRow` it allows to reset dirty state on cells only for a specific row instead of the whole grid. This is interesting when is editing a single record and sync with the server by saving the specific row only. When the server return success, we want to deal with that record only.

**Related github/jira issue (required)**:
Closes #2586

**Steps necessary to review your pull request (required)**:
- Run grid editable example
- Change some records line row 1, 2 and 3
- Call the method `grid.resetDirtyRow(1)`
- It will reset only the second row of the grid and other records will keep the dirty state.

**Included in this Pull Request**:
- [X] Some documentation for the feature.
- [X] A test for the bug or feature.
- [X] A note to the change log.
