### PR TITLE
2565 - IdsListView Trigger events on both list view and list view item

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[ListView|VirtualScroll]` Fix scroll-behavior of `ids-list-view` when used within `ids-virtual-scroll`. ([#2322](https://github.com/infor-design/enterprise-wc/issues/2322))
 - `[ListView]` Fix bug where, after a list-view-item is selected, search-field keeps losing focus while typing. ([#2296](https://github.com/infor-design/enterprise-wc/issues/2296))
 - `[ListView|VirtualScroll]` Fix scroll-behavior of `ids-list-view` when used within `ids-virtual-scroll`. ([#2322](https://github.com/infor-design/enterprise-wc/issues/2322))
+- `[ListView]` Fixed an issue where selected event is not being triggered on `ids-list-view-item`. ([#2565](https://github.com/infor-design/enterprise-wc/issues/2565))
 - `[LoadingIndicator]` Added fixes to some properties that could not be set on the fly. ([#2429](https://github.com/infor-design/enterprise-wc/issues/2429))
 - `[Message]` Converted message tests to playwright. ([#1954](https://github.com/infor-design/enterprise-wc/issues/1954))
 - `[Modal]` Fixed an issue where string interpolation didn't work for the modal title in Angular examples. ([#2325](https://github.com/infor-design/enterprise-wc/issues/2325))

--- a/src/components/ids-list-view/ids-list-view-item.ts
+++ b/src/components/ids-list-view/ids-list-view-item.ts
@@ -611,7 +611,8 @@ export default class IdsListViewItem extends Base {
 
   #trigger(eventName: 'selected' | 'deselected' | 'itemSelect' | 'activated' | 'deactivated' | 'afteractivated' | 'afterdeactivated') {
     const detail = { elem: this, data: this.rowData, index: this.rowIndex };
-    this.triggerEvent(eventName, this.listView ?? this, { bubbles: true, detail });
+    this.triggerEvent(eventName, this, { bubbles: true, detail });
+    this.triggerEvent(eventName, this.listView, { bubbles: true, detail });
   }
 
   #veto(eventName: 'beforeactivated' | 'beforedeactivated' | 'beforeselected' | 'beforedeselected') {

--- a/tests/ids-list-view/ids-list-view.spec.ts
+++ b/tests/ids-list-view/ids-list-view.spec.ts
@@ -173,6 +173,21 @@ test.describe('IdsListView tests', () => {
       expect(await noOfCalls[0]).toBe(1);
       expect(await noOfCalls[1]).toBe(1);
     });
+
+    test('should fire selected event on a list view item', async ({ page }) => {
+      await page.goto('/ids-list-view/list-view-items.html');
+      const noOfCalls = await page.evaluate(() => {
+        let calls = 0;
+        const comp = document.querySelector<IdsListView>('ids-list-view-item');
+        comp?.addEventListener('selected', () => { calls++; });
+
+        const event = new MouseEvent('click', { bubbles: true });
+        const item = document.querySelector<IdsListView>('ids-list-view-item');
+        item?.dispatchEvent(event);
+        return calls;
+      });
+      expect(await noOfCalls).toBe(1);
+    });
   });
 
   test.describe('functionality tests', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
We don't trigger events on `ids-list-view-item` if `ids-list-view` root exists. Changed that so now it triggers on both list view and list view item so you can listen to the events on list view item even if it's in the list view

**Related github/jira issue (required)**:
Closes #2565

**Steps necessary to review your pull request (required)**:
- pull the branch in Angular examples https://github.com/infor-design/enterprise-wc-examples/pull/80
- pull this branch
- `npm run publish:link`
- go to Angular examples and run `npm link ids-enterprise-wc`
- run Angular examples
- go to http://localhost:4200/ids-list-view/selected-event
- click on an item
- see the `Row selected` event is logged in the console

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
