### PR TITLE
2505 - IdsColorPicker Remove the initial focus to prevent the page from scrolling

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Accordion]` Fix accordion panel expanded/icon states when inserted dynamically. ([#2406](https://github.com/infor-design/enterprise-wc/issues/2406))
 - `[Accordion]` Added css variables to customization accordion header padding. ([#2529](https://github.com/infor-design/enterprise-wc/issues/2529))
 - `[Button]` Changed `GenAi` Button in dark mode background color. ([#2509](https://github.com/infor-design/enterprise-wc/issues/2509))
+- `[ColorPicker]` Fixed an issue where the picker's swatch focus is causing the page to scroll. ([#2502](https://github.com/infor-design/enterprise-wc/issues/2502))
 - `[Datagrid]` Fixed a bug where when no `id` column or `idColumn` setting remove row removed the wrong row.. ([#2355](https://github.com/infor-design/enterprise-wc/issues/2355))
 - `[Dropdown]` Fix dropdown bug where input is empty when option text is dynamic. ([#2362](https://github.com/infor-design/enterprise-wc/issues/2362))
 - `[Dropdown]` Fix dropdown width when size is `full`. ([#2001](https://github.com/infor-design/enterprise-wc/issues/2001))

--- a/src/components/ids-color-picker/ids-color-picker.ts
+++ b/src/components/ids-color-picker/ids-color-picker.ts
@@ -665,7 +665,6 @@ export default class IdsColorPicker extends Base {
    * @param {boolean} shouldFocus true if a swatch should be focused
    */
   #configureSwatches(shouldFocus = false): void {
-    console.log('shouldFocus', shouldFocus);
     this.swatches.forEach((swatch: IdsColor) => {
       swatch.classList.add('outlined');
       swatch.tooltip = this.suppressLabels ? (this.tooltip || swatch.hex) : (this.tooltip || swatch.label);

--- a/src/components/ids-color-picker/ids-color-picker.ts
+++ b/src/components/ids-color-picker/ids-color-picker.ts
@@ -486,7 +486,7 @@ export default class IdsColorPicker extends Base {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.popup.show();
     this.popup?.addOpenEvents();
-    this.#configureSwatches();
+    this.#configureSwatches(true);
   }
 
   /**
@@ -660,8 +660,12 @@ export default class IdsColorPicker extends Base {
     this.offEvent('input.color-picker-input', this.colorInput);
   }
 
-  /** Configure disabled/labels/tooltips attributes on IdsColor swatches */
-  #configureSwatches(): void {
+  /**
+   * Configure disabled/labels/tooltips attributes on IdsColor swatches
+   * @param {boolean} shouldFocus true if a swatch should be focused
+   */
+  #configureSwatches(shouldFocus = false): void {
+    console.log('shouldFocus', shouldFocus);
     this.swatches.forEach((swatch: IdsColor) => {
       swatch.classList.add('outlined');
       swatch.tooltip = this.suppressLabels ? (this.tooltip || swatch.hex) : (this.tooltip || swatch.label);
@@ -674,7 +678,9 @@ export default class IdsColorPicker extends Base {
       }
     });
 
-    (this.#findColorSwatch(this.value) || this.swatches[0])?.swatch?.focus();
+    if (shouldFocus) {
+      (this.#findColorSwatch(this.value) || this.swatches[0])?.swatch?.focus();
+    }
   }
 
   /**


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added the parameter to not focus a swatch when initializing the color picker, should focus only when opens the popup

**Related github/jira issue (required)**:
Closes #2505

**Steps necessary to review your pull request (required)**:
- pull the branch in Angular examples https://github.com/infor-design/enterprise-wc-examples/pull/81
- pull this branch
- `npm run publish:link`
- go to Angular examples and run `npm link ids-enterprise-wc`
- run Angular examples
- go to http://localhost:4200/ids-color-picker/no-scroll
- the page should not scroll to color pickers

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
