### PR TITLE
2566 - IdsPopupMenu fix position in container-type

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 1.4.0 Fixes
 
 - `[Datagrid]` Fixed problem with `searchable` datagrid where eraser button was not persisting on search-filtered rows. ([#2449](https://github.com/infor-design/enterprise-wc/issues/2449))
+- `[PopupMenu]` Added `offset-container` setting to allow adjustment to container types that affect fixed positioned popups. ([#2566](https://github.com/infor-design/enterprise-wc/issues/2566))
 
 ## 1.3.1
 

--- a/src/assets/css/ids-popup/sandbox.css
+++ b/src/assets/css/ids-popup/sandbox.css
@@ -62,3 +62,16 @@ Contains the controls for the sandbox
   right: 60%;
   padding: 10px;
 }
+
+.box {
+  width: 50vw;
+  position: absolute;
+  inset-inline: 100px;
+  inset-block: 100px;
+  container-type: size;
+  container-name: box;
+}
+
+@container box (width < 500px) .hide-small {
+  display: none;
+}

--- a/src/components/ids-popup-menu/README.md
+++ b/src/components/ids-popup-menu/README.md
@@ -40,6 +40,7 @@ The Ids Popup Menu is a complex component that combines an [`IdsMenu`](../ids-me
 - `target` {HTMLElement} if defined, creates a link between this Popup Menu and another element in the DOM.
 - `trigger` {string} the action on which to activate the Popupmenu. This defaults to `contextmenu`, but can also be `click` or `immediate`.
 - `arrow` {string} If defined overrides the default arrow position. The typical use case is to set this to `none` to not show any arrow.
+- `offset-container` {string} CSS Selector for container element from which a popup with position-style `fixed` should adjust itself from. Such as when a parent container has `container-type: size`, which affects the popup's fixed position calculation.
 
 ### Menu Group
 

--- a/src/components/ids-popup-menu/demos/in-offset-container.html
+++ b/src/components/ids-popup-menu/demos/in-offset-container.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <%= htmlWebpackPlugin.options.font %>
+  </head>
+  <body>
+    <ids-container>
+      <ids-theme-switcher mode="light"></ids-theme-switcher>
+      <article class="box">
+        <ids-card>
+          <ids-toolbar slot="card-header">
+            <ids-toolbar-section type="buttonset">
+              <ids-menu-button
+                id="menu-button"
+                icon="settings"
+                appearance="tertiary"
+                menu="my-menu"
+                dropdown-icon>
+                <span>Menu</span>
+              </ids-menu-button>
+              <ids-popup-menu
+                id="my-menu"
+                target="menu-button"
+                trigger-type="click"
+                offset-container=".box">
+                <ids-menu-group>
+                  <ids-menu-item>Item One</ids-menu-item>
+                  <ids-menu-item>Item Two</ids-menu-item>
+                  <ids-menu-item>Item Three</ids-menu-item>
+                  <ids-menu-item>Item Four</ids-menu-item>
+                  <ids-separator></ids-separator>
+                  <ids-menu-item id="item-five">
+                    More Actions
+                    <ids-popup-menu>
+                      <ids-menu-group>
+                        <ids-menu-item>Sub-item One</ids-menu-item>
+                        <ids-menu-item>Sub-item Two</ids-menu-item>
+                        <ids-menu-item>Sub-item Three</ids-menu-item>
+                      </ids-menu-group>
+                    </ids-popup-menu>
+                  </ids-menu-item>
+                  <ids-menu-item id="item-six">
+                    Even More Actions
+                    <ids-popup-menu>
+                      <ids-menu-group>
+                        <ids-menu-item icon="settings">
+                          Change Settings
+                          <ids-popup-menu>
+                            <ids-menu-group>
+                              <ids-menu-item>Setting One</ids-menu-item>
+                              <ids-menu-item>Setting Two</ids-menu-item>
+                              <ids-menu-item>Setting Three</ids-menu-item>
+                              <ids-menu-item>REAAAAALLLLY Long Setting Number Four</ids-menu-item>
+                            </ids-menu-group>
+                          </ids-popup-menu>
+                        </ids-menu-item>
+                        <ids-menu-item icon="mail">Send Mail</ids-menu-item>
+                        <ids-menu-item icon="filter">Filter Content</ids-menu-item>
+                      </ids-menu-group>
+                    </ids-popup-menu>
+                  </ids-menu-item>
+                  <ids-menu-item id="contains-submenu">
+                    Shortcut Options
+                    <ids-popup-menu>
+                      <ids-menu-group>
+                        <ids-menu-item shortcut-keys="CTRL+6">
+                          <span slot="shortcuts" class="shortcuts">CTRL+6</span>
+                          Print
+                        </ids-menu-item>
+                        <ids-menu-item id="related-option-panel-11" shortcut-keys="CTRL+11" value="relatedOptionsPanel;11;CTRL+11">
+                          <span slot="shortcuts" class="shortcuts">CTRL+11</span>
+                          Lines
+                        </ids-menu-item>
+                        <ids-menu-item id="related-option-panel-10" shortcut-keys="CTRL+11" value="relatedOptionsPanel;11;CTRL+11">
+                          <span slot="shortcuts" class="shortcuts">CTRL+11</span>
+                          Drill
+                        </ids-menu-item>     
+                      </ids-menu-group>
+                    </ids-popup-menu>
+                  </ids-menu-item>
+                </ids-menu-group>
+              </ids-popup-menu>
+          
+            </ids-toolbar-section>
+          </ids-toolbar>
+          <article slot="card-content">
+            <ids-layout-grid margin="md">
+              <ids-text>
+                Testing popup menu placement when a parent has a
+                "container-type" property (or the "container" shorthand), used
+                for @container queries.
+              </ids-text>
+            </ids-layout-grid>
+          </article>
+        </ids-card>
+      </article>
+    </ids-container>
+  </body>
+</html>

--- a/src/components/ids-popup-menu/demos/in-offset-container.ts
+++ b/src/components/ids-popup-menu/demos/in-offset-container.ts
@@ -1,0 +1,9 @@
+import '../ids-popup-menu';
+import '../../ids-button/ids-button';
+import '../../ids-fieldset/ids-fieldset';
+import '../../ids-input/ids-input';
+import '../../ids-toolbar/ids-toolbar';
+import css from '../../../assets/css/ids-popup/sandbox.css';
+
+const cssLink = `<link href="${css}" rel="stylesheet">`;
+document.querySelector('head')?.insertAdjacentHTML('afterbegin', cssLink);

--- a/src/components/ids-popup-menu/demos/index.yaml
+++ b/src/components/ids-popup-menu/demos/index.yaml
@@ -29,6 +29,9 @@
   - link: position-style.html
     type: Test
     description: Shows the effect of changing position style
+  - link: in-offset-container.html
+    type: Test
+    description: Shows the effect of setting `offset-container` to adjust popup's fixed position
   - link: side-by-side.html
     type: Side-by-Side
     description: Showing a Popup Menu side by side with 4.x

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -317,6 +317,7 @@ export const attributes = {
   NO_HEADER: 'no-header',
   NO_MARGINS: 'no-margins',
   NO_PADDING: 'no-padding',
+  OFFSET_CONTAINER: 'offset-container',
   OFFSET_CONTENT: 'offset-content',
   OPACITY: 'opacity',
   OPERATOR: 'operator',


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes issue where fixed popups placements are off when a container is styled with `container-type`.
Added a setting `offset-container` which lets the user provide a css selector for the affecting container to adjust
popups placement calculations from.

**Related github/jira issue (required)**:
Closes #2566

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-popup-menu/in-offset-container.html
3. Check the DOM for `<article class="box">` element and make sure it is styled with `container-type: size`
4. Open popup and check that placement is ok
5. Try in RTL

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
