### PR TITLE
2517 - IdsModuleNav Dynamic nav items

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Dropdown]` Fix dropdown position in datagrid in tabs. ([#2582](https://github.com/infor-design/enterprise-wc/issues/2582))
 - `[Empty Message]` Converted empty message tests to playwright. ([#2337](https://github.com/infor-design/enterprise-wc/issues/2337))
 - `[ListView]` Fixed an issue where selected event is not being triggered on `ids-list-view-item`. ([#2565](https://github.com/infor-design/enterprise-wc/issues/2565))
+- `[ModuleNav]` Fixed an issue where the text in the nav bar is not visible when added dynamically. ([#2517](https://github.com/infor-design/enterprise-wc/issues/2517))
 - `[Splitter]` Fix issue where text in closed panes overlapped the other side. ([#2583](https://github.com/infor-design/enterprise-wc/issues/2583))
 - `[Tooltip]` Increase tooltip z-index. ([#2462](https://github.com/infor-design/enterprise-wc/issues/2462))
 

--- a/src/components/ids-module-nav/ids-module-nav-bar.ts
+++ b/src/components/ids-module-nav/ids-module-nav-bar.ts
@@ -89,6 +89,7 @@ export default class IdsModuleNavBar extends Base {
     this.setScrollable();
     this.#attachEventHandlers();
     this.#observeMutations();
+    this.#toggleSeparator();
   }
 
   disconnectedCallback(): void {
@@ -362,6 +363,13 @@ export default class IdsModuleNavBar extends Base {
       }
       e.detail.response(allowed);
     });
+
+    // Check the footer slot for content and conditionally render the separator
+    const footerSlot = this.container?.querySelector('slot[name="footer"]') as HTMLSlotElement;
+    this.offEvent('slotchange.module-nav-footer');
+    this.onEvent('slotchange.module-nav-footer', footerSlot, () => {
+      this.#toggleSeparator();
+    });
   }
 
   #detachEventHandlers() {
@@ -371,6 +379,7 @@ export default class IdsModuleNavBar extends Base {
     this.offEvent('cleared.search');
     this.offEvent('mouseover.tooltip');
     this.offEvent('beforeshow.tooltip');
+    this.offEvent('slotchange.module-nav-footer');
   }
 
   #clearContainer() {
@@ -714,4 +723,23 @@ export default class IdsModuleNavBar extends Base {
       popup.setAttribute(attributes.ALIGN, attr);
     }
   };
+
+  /**
+   * Toggle the separator based on the footer slot content
+   * @returns {void}
+   */
+  #toggleSeparator() {
+    const footerSlot = this.container?.querySelector('slot[name="footer"]') as HTMLSlotElement;
+    const footerContent = footerSlot?.assignedElements()?.length > 0;
+    const separator = this.container?.querySelector('.ids-module-nav-separator');
+
+    if (footerContent && !separator) {
+      const separatorElement = document.createElement('ids-separator');
+      separatorElement.classList.add('ids-module-nav-separator');
+      separatorElement.setAttribute('color-variant', 'module-nav');
+      footerSlot?.insertAdjacentElement('beforebegin', separatorElement);
+    } else if (!footerContent && separator) {
+      separator?.remove();
+    }
+  }
 }

--- a/src/components/ids-popup/ids-popup.ts
+++ b/src/components/ids-popup/ids-popup.ts
@@ -1380,14 +1380,6 @@ export default class IdsPopup extends Base {
       popupRect = this.onPlace(popupRect, this);
     }
 
-    if (this.containingElem?.classList?.contains('app-menu-is-open')) {
-      const appMenu = this.containingElem?.querySelector('.app-menu');
-      const appMenuRect = appMenu?.getBoundingClientRect();
-      if (navigator.userAgent.indexOf('Firefox') === -1) {
-        popupRect.x -= appMenuRect?.width || 300;
-      }
-    }
-
     // Correct for RTL Position
     popupRect = this.#correctRTL(popupRect);
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed the issue where `display-mode="expanded"` was not being added for newly added navigation items, so they were in a collapsed state where only the icon was visible. Added mutation observer to module nav bar to detect changes and re-apply current display mode for added nav items

**Related github/jira issue (required)**:
Closes #2517 
Fixes #2543

**Steps necessary to review your pull request (required)**:
- pull the branch in Angular examples https://github.com/infor-design/enterprise-wc-examples/pull/82
- pull this branch
- `npm run publish:link`
- go to Angular examples and run `npm link ids-enterprise-wc`
- run Angular examples
- go to http://localhost:4200/ids-app-menu/dynamic-content
- see the Delayed menu item is visible and selectable
- go to http://localhost:4200/ids-module-nav/dynamic-content
- see the Delayed menu item is visible and selectable

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
