### PR TITLE
2138 - IdsNotificationBanner add line-clamp setting

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Datagrid]` Added search feature to datagrid via `searchable` and `search-term-min-size` attributes. ([#2449](https://github.com/infor-design/enterprise-wc/issues/2449))
 - `[Datagrid]` Added a new `grouped` rows setting to group rows. Also added the personalization dialog feature. ([#2271](https://github.com/infor-design/enterprise-wc/issues/2271))
 - `[ListView]` Added grouped headers and a `appendToBottom` method. ([#2626](https://github.com/infor-design/enterprise-wc/issues/2626))
+- `[NotificationBanner]` Added `line-clamp` setting to notication banner to allow custom message truncation. ([#2138](https://github.com/infor-design/enterprise-wc/issues/2138))
 
 ### 1.4.0 Fixes
 

--- a/src/components/ids-notification-banner/README.md
+++ b/src/components/ids-notification-banner/README.md
@@ -74,6 +74,7 @@ notificationBanner.add({
 
 - `type` `{string}` can be 1 of 4 types (success, warning, info, error)
 - `message-text` `{string}` text shown inside the banner
+- `line-clamp` `{number}` sets number of message text rows to display before truncating
 - `link` `{string | null}` url for the call to action in the banner
 - `link-text` `{string | null}` custom text for the call to action (if `null` will display "Click to view")
 

--- a/src/components/ids-notification-banner/ids-notification-banner.ts
+++ b/src/components/ids-notification-banner/ids-notification-banner.ts
@@ -58,6 +58,7 @@ export default class IdsNotificationBanner extends Base {
     return [
       attributes.MESSAGE,
       attributes.MESSAGE_TEXT,
+      attributes.LINE_CLAMP,
       attributes.LINK,
       attributes.LINK_TEXT,
       attributes.TYPE,
@@ -178,6 +179,26 @@ export default class IdsNotificationBanner extends Base {
   get link(): string | null { return this.getAttribute(attributes.LINK); }
 
   /**
+   * Sets line clamp value to truncate message text
+   * @param {number|null} val number of displayed before truncating
+   */
+  set lineClamp(val: number | null) {
+    const rows = Number(val);
+
+    if (!Number.isNaN(rows) && rows > 0) {
+      this.setAttribute(attributes.LINE_CLAMP, String(rows));
+      this.messageElem?.setAttribute(attributes.LINE_CLAMP, String(rows));
+    } else {
+      this.removeAttribute(attributes.LINE_CLAMP);
+      this.messageElem?.removeAttribute(attributes.LINE_CLAMP);
+    }
+  }
+
+  get lineClamp(): number | null {
+    return Number(this.getAttribute(attributes.LINE_CLAMP)) || null;
+  }
+
+  /**
    * Set the custom link text of the Notification Banner
    * @param {string | null} value the link-text value
    */
@@ -221,6 +242,10 @@ export default class IdsNotificationBanner extends Base {
   }
 
   get message() { return this.getAttribute(attributes.MESSAGE); }
+
+  get messageElem(): IdsText | null {
+    return this.container?.querySelector<IdsText>('ids-text.message') ?? null;
+  }
 
   /**
    * Establish Internal Event Handlers

--- a/tests/ids-notification-banner/ids-notification-banner.spec.ts
+++ b/tests/ids-notification-banner/ids-notification-banner.spec.ts
@@ -131,5 +131,15 @@ test.describe('IdsNotificationBanner tests', () => {
         (elem: IdsNotificationBanner) => elem.container?.querySelector<HTMLElement>('.ids-notification-banner-link')?.hasAttribute('hidden')
       )).toBeTruthy();
     });
+
+    test('should handle line clamp setting', async ({ page }) => {
+      const notificationBanner = await page.locator('ids-notification-banner').first();
+      const lineClampValue = await notificationBanner.evaluate((banner: IdsNotificationBanner) => {
+        banner.lineClamp = 2;
+        return banner.lineClamp;
+      });
+
+      expect(lineClampValue).toEqual(2);
+    });
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added `line-clamp` setting to notification banner.
Updated component to relay line clamp value to IdsText's existing line-clamp setting

**Related github/jira issue (required)**:
Closes #2138 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2.  Go to http://localhost:4300/ids-notification-banner/example.html
3. Run `$('ids-notification-banner').lineClamp = 2;` in console
4. Decrease viewport size and check that line clamp setting works at truncating text

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
