### PR TITLE
2583 - IdsSplitter fix scrollbar in splitter pane

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Splitter]` Fix issue initializing size and collapsed at the same time. ([#2585](https://github.com/infor-design/enterprise-wc/issues/2585))
 - `[Splitter]` Fix initialization issues when in angular apps. ([#2590](https://github.com/infor-design/enterprise-wc/issues/2590))
 - `[Splitter]` Fix issue where text in closed panes overlapped the other side. ([#2583](https://github.com/infor-design/enterprise-wc/issues/2583))
+- `[Splitter]` Fix issue where pane's scrollbar didn't appear on overflow. ([#2583](https://github.com/infor-design/enterprise-wc/issues/2583))
 - `[Splitter]` Fix issue initializing size and collapsed at the same time. ([#2585](https://github.com/infor-design/enterprise-wc/issues/2585))
 - `[Splitter]` Fix initialization issues when in angular apps. ([#2590](https://github.com/infor-design/enterprise-wc/issues/2590))
 - `[Splitter]` Fix issue where text in closed panes overlapped the other side. ([#2583](https://github.com/infor-design/enterprise-wc/issues/2583))

--- a/src/components/ids-splitter/demos/expand-collapse.html
+++ b/src/components/ids-splitter/demos/expand-collapse.html
@@ -5,49 +5,48 @@
   <%= htmlWebpackPlugin.options.font %>
 </head>
 <body>
-  <ids-container role="main" padding="0" hidden scrollable>
-    <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-layout-grid auto-fit="true" padding="md">
-      <ids-layout-grid-cell>
-        <ids-button id="expand-collapse-btn" appearance="secondary">
-          <ids-icon icon="menu"></ids-icon>
-          <span class="audible">Expand Collapse</span>
-        </ids-button>
-      </ids-layout-grid-cell>
-    </ids-layout-grid>
+  <ids-container role="main" padding="0" hidden>
+    <ids-layout-flex direction="column" gap="8" full-height>
+      <ids-layout-flex-item>
+        <ids-theme-switcher mode="light"></ids-theme-switcher>
+      </ids-layout-flex-item>
 
-    <ids-scroll-container>
-      <ids-layout-grid auto-fit="true" padding-x="md">
-        <ids-layout-grid-cell>
-          <ids-splitter height="calc(100dvh - 128px)">
-            <ids-splitter-pane size="25%" id="left-pane">
-              <ids-layout-grid auto-fit="true">
-                <ids-layout-grid-cell>
-                  <ids-scroll-container>
-                    <ids-tree id="tree" label="Tree"></ids-tree>
-                  </ids-scroll-container>
-                </ids-layout-grid-cell>
-              </ids-layout-grid>
-            </ids-splitter-pane>
+      <ids-layout-flex-item>
+        <ids-layout-grid padding="md">
+          <ids-layout-grid-item>
+            <ids-button id="expand-collapse-btn" appearance="secondary">
+              <ids-icon icon="menu"></ids-icon>
+              <span class="audible">Expand Collapse</span>
+            </ids-button>
+          </ids-layout-grid-item>  
+        </ids-layout-grid>
+      </ids-layout-flex-item>
 
-            <ids-splitter-pane id="right-pane">
-              <ids-list-view item-height="76" selectable="single">
-                <template>
-                  <ids-text font-size="16" type="h2" font-weight="semi-bold">${name}</ids-text>
-                  <ids-layout-grid cols="1" padding-y="xxs">
-                    <ids-layout-grid-cell>
-                      <ids-text font-size="16" type="span">${type}</ids-text>
-                      <ids-text font-size="14" type="span">${location}</ids-text>
-                    </ids-layout-grid-cell>
-                  </ids-layout-grid>
-                </template>
-              </ids-list-view>
-            </ids-splitter-pane>
-
-          </ids-splitter>
-        </ids-layout-grid-cell>
-      </ids-layout-grid>
-    </ids-scroll-container>
+      <ids-layout-flex-item grow="1" overflow="hidden">
+        <ids-splitter height="100%" width="100%">
+          <ids-splitter-pane size="25%" id="left-pane">
+            <ids-layout-grid margin="xs">
+              <ids-layout-grid-cell>
+                <ids-tree id="tree" label="Tree"></ids-tree>
+              </ids-layout-grid-cell>
+            </ids-layout-grid>
+          </ids-splitter-pane>
+          <ids-splitter-pane id="right-pane" no-scroll>
+            <ids-list-view item-height="76" selectable="single">
+              <template>
+                <ids-text font-size="16" type="h2" font-weight="semi-bold">${name}</ids-text>
+                <ids-layout-grid cols="1" padding-y="xxs">
+                  <ids-layout-grid-cell>
+                    <ids-text font-size="16" type="span">${type}</ids-text>
+                    <ids-text font-size="14" type="span">${location}</ids-text>
+                  </ids-layout-grid-cell>
+                </ids-layout-grid>
+              </template>
+            </ids-list-view>
+          </ids-splitter-pane>
+        </ids-splitter>
+      </ids-layout-flex-item>
+    </ids-layout-flex>
   </ids-container>
 </body>
 </html>

--- a/src/components/ids-splitter/demos/expand-collapse.ts
+++ b/src/components/ids-splitter/demos/expand-collapse.ts
@@ -2,6 +2,7 @@ import treeBasicJSON from '../../../assets/data/tree-basic.json';
 import eventsJSON from '../../../assets/data/accounts.json';
 
 import '../../ids-container/ids-container';
+import '../../ids-layout-flex/ids-layout-flex';
 import '../../ids-button/ids-button';
 import '../../ids-list-view/ids-list-view';
 import '../../ids-tree/ids-tree';

--- a/src/components/ids-splitter/ids-splitter-pane.scss
+++ b/src/components/ids-splitter/ids-splitter-pane.scss
@@ -1,4 +1,6 @@
 /* Ids Splitter Pane Component */
 .ids-splitter-pane {
-  overflow: hidden;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
 }

--- a/src/components/ids-splitter/ids-splitter-pane.ts
+++ b/src/components/ids-splitter/ids-splitter-pane.ts
@@ -39,7 +39,8 @@ export default class IdsSplitterPane extends Base {
       attributes.COLLAPSED,
       attributes.SIZE,
       attributes.MIN_SIZE,
-      attributes.MAX_SIZE
+      attributes.MAX_SIZE,
+      attributes.NO_SCROLL
     ];
   }
 
@@ -165,5 +166,15 @@ export default class IdsSplitterPane extends Base {
    */
   get maxSize(): number | string | null {
     return this.getAttribute(attributes.MAX_SIZE);
+  }
+
+  set noScroll(val: boolean) {
+    const hideScroll = stringToBool(val);
+    this.toggleAttribute(attributes.NO_SCROLL, hideScroll);
+    this.container?.style.setProperty('overflow', hideScroll ? 'hidden' : 'auto');
+  }
+
+  get noScroll(): boolean {
+    return stringToBool(attributes.NO_SCROLL);
   }
 }

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -318,6 +318,7 @@ export const attributes = {
   NO_HEADER: 'no-header',
   NO_MARGINS: 'no-margins',
   NO_PADDING: 'no-padding',
+  NO_SCROLL: 'no-scroll',
   OFFSET_CONTAINER: 'offset-container',
   OFFSET_CONTENT: 'offset-content',
   OPACITY: 'opacity',


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Amends issue #2583 to readd the scrollbar

**Related github/jira issue (required)**:
Closes #2583 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-splitter/expand-collapse.html
3. Expand tree component nodes to create an overflow inside left splitter pane
4. Check that a scrollbar appears and looks correct
5. Resize viewport and check that scrollbar for listview component in right pane is correct

**Included in this Pull Request**:
- [x] A note to the change log.
