### PR TITLE
2656 - IdsTabs Fixed full width overflow menu in module tabs

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 1.5.0 Fixes
 
 - `[General]` Updated readme docs to remove redundant usage, updated readme titles for all components, copyedits for some settings.([#2482]https://github.com/infor-design/enterprise-wc/issues/2482)
+- `[Tabs]` Fixed an issue where overflow menu group popup is full width. ([#2656](https://github.com/infor-design/enterprise-wc/issues/2656))
 
 ## 1.4.1
 

--- a/src/components/ids-tabs/ids-tab-more.ts
+++ b/src/components/ids-tabs/ids-tab-more.ts
@@ -369,7 +369,7 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
       this.menu.popup.y = 4;
     } else if (this.menu?.popup) {
       this.menu.popup.align = 'bottom, left';
-      this.menu.popup.y = -10;
+      this.menu.popup.y = 0;
     }
   }
 

--- a/src/components/ids-tabs/ids-tab-more.ts
+++ b/src/components/ids-tabs/ids-tab-more.ts
@@ -369,7 +369,6 @@ export default class IdsTabMore extends IdsLocaleMixin(IdsTab) {
       this.menu.popup.y = 4;
     } else if (this.menu?.popup) {
       this.menu.popup.align = 'bottom, left';
-      this.menu.width = '100%';
       this.menu.popup.y = -10;
     }
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Removed the setting of the width to 100% for module tabs

**Related github/jira issue (required)**:
Closes #2656 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-tabs/module.html
- click on '+' to make a few tabs
- resize the page
- click on tab more button
- see the menu if not full width

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
