### PR TITLE
2386 - Add default for dropdown columns

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 1.5.0 Fixes
 
 - `[Button]` Fixed a bug in the lifecycle where inner classes where not refreshed in some frameworks.([#2627]https://github.com/infor-design/enterprise-wc/issues/2627)
+- `[Datagrid]` If no options the datagrid will still show the value, defaulting the options that may load later. ([#2386](https://github.com/infor-design/enterprise-wc/issues/2386))
 - `[Dropdown]` Converted dropdown tests to playwright. ([#1846](https://github.com/infor-design/enterprise-wc/issues/1846))
 - `[General]` Updated readme docs to remove redundant usage, updated readme titles for all components, copyedits for some settings.([#2482]https://github.com/infor-design/enterprise-wc/issues/2482)
 - `[MenuButton]` Fixed an issue where the popup menu was not placed correctly in Angular/production build. ([#2669](https://github.com/infor-design/enterprise-wc/issues/2669))
@@ -62,7 +63,7 @@
 - `[Splitter]` Fix issue where text in closed panes overlapped the other side. ([#2583](https://github.com/infor-design/enterprise-wc/issues/2583))
 - `[SwapList]` Made the search portion of the swaplist sticky when scrolling. ([#2559](https://github.com/infor-design/enterprise-wc/issues/2559))
 - `[Themes]` Fixed path for `esbuild` script to include `themes/` in `dist` development/production builds. ([#2641](https://github.com/infor-design/enterprise-wc/issues/2641))
-- `[Tooltip]` Increase tooltip z-index. ([#2462](https://github.com/infor-design/enterprise-wc/issues/2462)) 
+- `[Tooltip]` Increase tooltip z-index. ([#2462](https://github.com/infor-design/enterprise-wc/issues/2462))
 
 ## 1.3.0
 

--- a/src/components/ids-data-grid/README.md
+++ b/src/components/ids-data-grid/README.md
@@ -286,7 +286,7 @@ The following settings are available on editors.
 `editorSettings.validate` Text will be selected when entering edit mode
 `editorSettings.mask` Will pass mask settings to the input (if supported).
 `editorSettings.maskOptions` Will pass maskOptions settings to the input (if supported).
-`editorSettings.options` Dataset used for dropdown editor's list box options.
+`editorSettings.options` Dataset used for dropdown editor's list box options. If none are specified the value in the data will be applied as the only options.
 `editorSettings.maxlength` Sets the input editor's `maxlength` property to the max characters you can type
 `editorSettings.uppercase` Sets the input editor's to all uppercase
 `editorValidation` Optional property to set custom validation rule

--- a/src/components/ids-data-grid/demos/editable-empty-options.html
+++ b/src/components/ids-data-grid/demos/editable-empty-options.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="md">
+      <ids-text font-size="12" type="h1">Data Grid (Editable)</ids-text>
+    </ids-layout-grid>
+    <ids-layout-grid auto-fit="true" padding-x="md">
+      <ids-layout-grid-cell>
+        <ids-data-grid id="data-grid-1" editable="true" row-selection="false"></ids-data-grid>
+      </ids-layout-grid-cell>
+    </ids-layout-grid>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-data-grid/demos/editable-empty-options.ts
+++ b/src/components/ids-data-grid/demos/editable-empty-options.ts
@@ -1,0 +1,47 @@
+import type IdsDataGrid from '../ids-data-grid';
+import '../ids-data-grid';
+
+const grid = document.querySelector<IdsDataGrid>('#data-grid-1')!;
+
+grid.columns = [{
+  id: 'id',
+  name: 'ID',
+  field: 'id'
+},
+{
+  id: 'role',
+  name: 'Role',
+  field: 'role',
+  formatter: grid.formatters.dropdown,
+  editor: {
+    type: 'dropdown',
+    editorSettings: {
+      autoselect: true,
+      dirtyTracker: true,
+      options: [] // will be set later with the server
+    }
+  }
+}];
+
+grid.data = [{
+  id: 1,
+  role: 'Administration'
+},
+{
+  id: 2,
+  role: 'Manager'
+}];
+
+// Applying options later, simulating server side gave options later
+grid.columns[1]!.editor!.editorSettings!.options = [{
+  value: 'Administration',
+  label: 'Administration'
+},
+{
+  value: 'Manager',
+  label: 'Manager'
+},
+{
+  value: 'Developer',
+  label: 'Developer'
+}];

--- a/src/components/ids-data-grid/demos/index.yaml
+++ b/src/components/ids-data-grid/demos/index.yaml
@@ -103,6 +103,9 @@
     description: Shows a data grid with ability to add rows
   - link: editable.html
     type: Example
+    description: Shows a data grid with an empty dropdown
+  - link: editable-empty-options.html
+    type: Example
     description: Shows a data grid with editable cells
   - link: editable-lookup.html
     type: Example

--- a/src/components/ids-data-grid/ids-data-grid-formatters.ts
+++ b/src/components/ids-data-grid/ids-data-grid-formatters.ts
@@ -246,10 +246,15 @@ export default class IdsDataGridFormatters {
     const field = columnData.field ?? '';
     const options = <any[]>columnData.editor?.editorSettings?.options || [];
     const value = rowData[field];
-    const valueOpt = options.find((opt) => opt.value === value);
+    let valueOpt = options.find((opt) => opt.value === value);
 
-    return `
-      <span
+    if (!options || options.length === 0) {
+      valueOpt = {
+        value: rowData[field], id: rowData[field], label: rowData[field]
+      };
+    }
+
+    return `<span
         class="text-ellipsis dropdown-cell-value"
         data-value="${valueOpt?.value ?? ''}"
         data-id="${valueOpt?.id ?? ''}">
@@ -258,8 +263,7 @@ export default class IdsDataGridFormatters {
       <ids-icon
         icon="dropdown"
         class="editor-cell-icon">
-      </ids-icon>
-    `;
+      </ids-icon>`;
   }
 
   /* Shows ids-alert, and the field value will appear in a tooltip. An `icon` option can be provided as an override. */

--- a/src/components/ids-locale/ids-locale-number-options.ts
+++ b/src/components/ids-locale/ids-locale-number-options.ts
@@ -1,6 +1,6 @@
 export type IdsLocaleNumberOptions = Intl.NumberFormatOptions & {
   locale?: string,
-  style?: string,
+  style?: string | any,
   minimumFractionDigits?: number,
   maximumFractionDigits?: number,
   group?: string,

--- a/src/components/ids-locale/ids-locale.ts
+++ b/src/components/ids-locale/ids-locale.ts
@@ -375,7 +375,7 @@ class IdsLocale {
    * @param {object} [options] the objects to use for formatting
    * @returns {string} the formatted number
    */
-  formatNumber(value: any, options?: IdsLocaleNumberOptions): string {
+  formatNumber(value: any, options?: IdsLocaleNumberOptions | any): string {
     // Set some options to map it closer to our old defaults
     let opts = options;
     let val = value;

--- a/tests/ids-data-grid/ids-data-grid-formatters.spec.ts
+++ b/tests/ids-data-grid/ids-data-grid-formatters.spec.ts
@@ -1218,5 +1218,11 @@ test.describe('IdsDataGrid formatters tests', () => {
 
       expect(rendered).toMatchSnapshot();
     });
+
+    test('can render dropdown values with no options', async ({ page }) => {
+      await page.goto('/ids-data-grid/editable-empty-options.html');
+      expect(await page.locator('ids-data-grid ids-data-grid-cell').nth(1).textContent()).toContain('Administration');
+      expect(await page.locator('ids-data-grid ids-data-grid-cell').nth(3).textContent()).toContain('Manager');
+    });
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

When there is no options data the dropdown formatter will not show any value. Instead defaulting the data to what is passed in the cell value

**Related github/jira issue (required)**:
Fixes #2386 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4300/ids-data-grid/editable-empty-options.html

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
