### PR TITLE
2562 - Fix IdsAccordion collapsing on child keyboard events

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 1.5.0 Fixes
 
+- `[Accordion]` Fixed a bug where triggering a child component event would cause the accordion pane to collapse.([#2562]https://github.com/infor-design/enterprise-wc/issues/2562)
 - `[Button]` Fixed a bug in the lifecycle where inner classes where not refreshed in some frameworks.([#2627]https://github.com/infor-design/enterprise-wc/issues/2627)
 - `[General]` Updated readme docs to remove redundant usage, updated readme titles for all components, copyedits for some settings.([#2482]https://github.com/infor-design/enterprise-wc/issues/2482)
 - `[MenuButton]` Fixed an issue where the popup menu was not placed correctly in Angular/production build. ([#2669](https://github.com/infor-design/enterprise-wc/issues/2669))
@@ -61,7 +62,7 @@
 - `[Splitter]` Fix issue where text in closed panes overlapped the other side. ([#2583](https://github.com/infor-design/enterprise-wc/issues/2583))
 - `[SwapList]` Made the search portion of the swaplist sticky when scrolling. ([#2559](https://github.com/infor-design/enterprise-wc/issues/2559))
 - `[Themes]` Fixed path for `esbuild` script to include `themes/` in `dist` development/production builds. ([#2641](https://github.com/infor-design/enterprise-wc/issues/2641))
-- `[Tooltip]` Increase tooltip z-index. ([#2462](https://github.com/infor-design/enterprise-wc/issues/2462)) 
+- `[Tooltip]` Increase tooltip z-index. ([#2462](https://github.com/infor-design/enterprise-wc/issues/2462))
 
 ## 1.3.0
 

--- a/src/components/ids-accordion/ids-accordion-panel.ts
+++ b/src/components/ids-accordion/ids-accordion-panel.ts
@@ -415,16 +415,16 @@ export default class IdsAccordionPanel extends Base {
       }
     });
 
-    this.listen('Enter', this.expander, (e: { stopPropagation: () => void; }) => {
+    this.listen('Enter', this.expander, (e: KeyboardEvent) => {
       e.stopPropagation();
-      if (!this.disabled) {
+      if (!this.disabled && e.target === this.header) {
         this.#selectAndToggle();
       }
     });
 
-    this.listen(' ', this.expander, (e: { stopPropagation: () => void; }) => {
+    this.listen(' ', this.expander, (e: KeyboardEvent) => {
       e.stopPropagation();
-      if (!this.disabled) {
+      if (!this.disabled && e.target === this.header) {
         this.#selectAndToggle();
       }
     });

--- a/tests/ids-accordion/ids-accordion.spec.ts
+++ b/tests/ids-accordion/ids-accordion.spec.ts
@@ -95,30 +95,76 @@ test.describe('IdsAccordion tests', () => {
 
     test('expanding/collapsing pane when pressing Enter', async ({ page }) => {
       const panelHandle = await page.locator('ids-accordion ids-accordion-panel').first();
+      const headerHandle = await page.locator('ids-accordion ids-accordion-header').first();
 
-      // press Enter to expand pane and check
-      await panelHandle.evaluate((panel: IdsAccordionPanel) => { panel.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })); });
+      // Ensure the header is focusable
+      await headerHandle.evaluate((header) => {
+        header.setAttribute('tabindex', '0');
+      });
+
+      // Ensure the header is focused before dispatching the keydown event
+      await headerHandle.focus();
+
+      // Check if the focus is on the correct element
+      const isFocused = await headerHandle.evaluate((header) => document.activeElement === header);
+      if (!isFocused) {
+        throw new Error('Header element is not focused');
+      }
+
+      // Press Enter to expand pane
+      await headerHandle.evaluate((header) => {
+        const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+        header.dispatchEvent(event);
+      });
       await expect(panelHandle.locator('.ids-accordion-pane')).toBeVisible();
-      expect(await panelHandle.evaluate((panel: IdsAccordionPanel) => panel.expanded)).toBeTruthy();
+      const isExpandedAfterEnter = await panelHandle.evaluate((panel: any) => panel.expanded);
+      expect(isExpandedAfterEnter).toBeTruthy();
 
-      // press Enter to collapse pane and check
-      await panelHandle.evaluate((panel: IdsAccordionPanel) => { panel.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })); });
+      // Press Enter to collapse pane
+      await headerHandle.evaluate((header) => {
+        const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+        header.dispatchEvent(event);
+      });
       await expect(panelHandle.locator('.ids-accordion-pane')).not.toBeVisible();
-      expect(await panelHandle.evaluate((panel: IdsAccordionPanel) => panel.expanded)).toBeFalsy();
+      const isExpandedAfterSecondEnter = await panelHandle.evaluate((panel: any) => panel.expanded);
+      expect(isExpandedAfterSecondEnter).toBeFalsy();
     });
 
     test('expanding/collapsing pane when pressing Space', async ({ page }) => {
       const panelHandle = await page.locator('ids-accordion ids-accordion-panel').first();
+      const headerHandle = await page.locator('ids-accordion ids-accordion-header').first();
 
-      // press Space to expand pane and check
-      await panelHandle.evaluate((panel: IdsAccordionPanel) => { panel.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' })); });
+      // Ensure the header is focusable
+      await headerHandle.evaluate((header) => {
+        header.setAttribute('tabindex', '0');
+      });
+
+      // Ensure the header is focused before dispatching the keydown event
+      await headerHandle.focus();
+
+      // Check if the focus is on the correct element
+      const isFocused = await headerHandle.evaluate((header) => document.activeElement === header);
+      if (!isFocused) {
+        throw new Error('Header element is not focused');
+      }
+
+      // Press Space to expand pane and check
+      await headerHandle.evaluate((header) => {
+        const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true });
+        header.dispatchEvent(event);
+      });
       await expect(panelHandle.locator('.ids-accordion-pane')).toBeVisible();
-      expect(await panelHandle.evaluate((panel: IdsAccordionPanel) => panel.expanded)).toBeTruthy();
+      const isExpandedAfterSpace = await panelHandle.evaluate((panel: any) => panel.expanded);
+      expect(isExpandedAfterSpace).toBeTruthy();
 
-      // press Space to collapse pane and check
-      await panelHandle.evaluate((panel: IdsAccordionPanel) => { panel.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' })); });
+      // Press Space to collapse pane and check
+      await headerHandle.evaluate((header) => {
+        const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true });
+        header.dispatchEvent(event);
+      });
       await expect(panelHandle.locator('.ids-accordion-pane')).not.toBeVisible();
-      expect(await panelHandle.evaluate((panel: IdsAccordionPanel) => panel.expanded)).toBeFalsy();
+      const isExpandedAfterSecondSpace = await panelHandle.evaluate((panel: any) => panel.expanded);
+      expect(isExpandedAfterSecondSpace).toBeFalsy();
     });
 
     test('expanding/collapsing pane programatically', async ({ page }) => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR resolves an issue where the `ids-accordion-panel` would collapse when a child component's event is triggered.

**Related github/jira issue (required)**:
closes #2562 

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- go to http://localhost:4300/ids-accordion/lookup.html
- click into the lookup field and begin typing
- press "Enter"
- the accordion panel should stay open
- click the lookup trigger button
- tab to the Cancel or Submit button and press "Enter"
- the accordion panel should stay open

**Included in this Pull Request**:
~- [ ] Some documentation for the feature.~
- [x] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
