### PR TITLE
2385 - IdsCheckbox Fixed multiple native events triggering

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 1.4.2 Fixes
 
 - `[Button]` Fixed a bug in the lifecycle where inner classes where not refreshed in some frameworks.([#2627]https://github.com/infor-design/enterprise-wc/issues/2627)
+- `[Checkbox]` Fixed an issue where native events were triggered multiple times in single selection. ([#2385](https://github.com/infor-design/enterprise-wc/issues/2385))
 - `[Datagrid]` If no options the datagrid will still show the value, defaulting the options that may load later. ([#2386](https://github.com/infor-design/enterprise-wc/issues/2386))
 - `[Dropdown]` Converted dropdown tests to playwright. ([#1846](https://github.com/infor-design/enterprise-wc/issues/1846))
 - `[Editor]` Removed internal hard coded id since it was causing duplicate ids if multiple editors are used. ([#2630](https://github.com/infor-design/enterprise-wc/issues/2630))

--- a/src/components/ids-checkbox/ids-checkbox.ts
+++ b/src/components/ids-checkbox/ids-checkbox.ts
@@ -147,14 +147,8 @@ export default class IdsCheckbox extends Base {
     const events = ['focus', 'keydown', 'keypress', 'keyup', 'click', 'dbclick'];
     events.forEach((evt) => {
       this.onEvent(evt, this.input, (e: Event) => {
-        this.triggerEvent(e.type, this, {
-          detail: {
-            elem: this,
-            nativeEvent: e,
-            value: this.value,
-            checked: !!this.input?.checked
-          }
-        });
+        e.stopPropagation();
+        e.stopImmediatePropagation();
       });
     });
   }

--- a/tests/ids-checkbox/ids-checkbox.spec.ts
+++ b/tests/ids-checkbox/ids-checkbox.spec.ts
@@ -387,6 +387,14 @@ test.describe('IdsCheckbox tests', () => {
       expect(response).not.toEqual('triggered');
     });
 
+    test('should trigger click event once', async ({ eventsTest }) => {
+      const handle = (await checkbox.elementHandle())!;
+      await eventsTest.onEvent('ids-checkbox', 'click', handle);
+      await checkbox.click();
+      expect(await eventsTest.isEventTriggered('ids-checkbox', 'click')).toBeTruthy();
+      expect(await eventsTest.getEventsCountByElement('ids-checkbox', 'click')).toEqual(1);
+    });
+
     test('can render template', async ({ page }) => {
       const rootEl = await checkbox.locator('.ids-checkbox');
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Removed triggering of custom event, stopped internal input native events propagation. 
So the only event that is being triggered is the one that is being listened to, which allows to handle cases where you can change checkbox checked status by `click` event like in the #2385

**Related github/jira issue (required)**:
Closes #2385 

**Steps necessary to review your pull request (required)**:
- pull and build
- `npm run publish:link `
- merge or pull the Angular examples branch https://github.com/infor-design/enterprise-wc-examples/pull/88
- go to Angular examples folder and `npm link ids-enterprise-wc`
- run Angular examples `npm start`
- go to http://localhost:4200/ids-checkbox/data-driven
- check `Checked controlled by click event` example in the last column
- click on the checkbox and see that event is being logged once per click

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
