### PR TITLE
2662 - IdsDropdown Typeahead adjustments

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Checkbox]` Fixed an issue where native events were triggered multiple times in single selection. ([#2385](https://github.com/infor-design/enterprise-wc/issues/2385))
 - `[Datagrid]` If no options the datagrid will still show the value, defaulting the options that may load later. ([#2386](https://github.com/infor-design/enterprise-wc/issues/2386))
 - `[Dropdown]` Converted dropdown tests to playwright. ([#1846](https://github.com/infor-design/enterprise-wc/issues/1846))
+- `[Dropdown]` Fixed an issue where disabling typeahead allowed typing in the input. ([#2662](https://github.com/infor-design/enterprise-wc/issues/2662))
 - `[Editor]` Removed internal hard coded id since it was causing duplicate ids if multiple editors are used. ([#2630](https://github.com/infor-design/enterprise-wc/issues/2630))
 - `[Editor]` Updated docs around `labels`. ([#2649](https://github.com/infor-design/enterprise-wc/issues/2649))
 - `[General]` Updated readme docs to remove redundant usage, updated readme titles for all components, copyedits for some settings.([#2482]https://github.com/infor-design/enterprise-wc/issues/2482)

--- a/src/components/ids-dropdown/demos/example.ts
+++ b/src/components/ids-dropdown/demos/example.ts
@@ -3,7 +3,7 @@ import statesJSON from '../../../assets/data/states.json';
 
 const dropdown: any = document.querySelector('#dropdown-1');
 dropdown?.addEventListener('change', (e: any) => {
-  console.info(`Value Changed to ${e.target.value}: ${e.target.selectedOption.textContent}`);
+  console.info(`Value Changed to ${e.target.value}: ${e.target.selectedOption?.textContent || ''}`);
 });
 
 dropdown?.addEventListener('focus', (e: any) => {

--- a/src/components/ids-dropdown/demos/typeahead.html
+++ b/src/components/ids-dropdown/demos/typeahead.html
@@ -110,27 +110,22 @@
         <ids-dropdown typeahead="true" clearable="true" label="Typeahead with icons">
           <ids-list-box>
             <ids-list-box-option value="opt1">
-              <ids-icon icon="user-profile"></ids-icon>
-              Option One
+              <ids-icon icon="user-profile"></ids-icon>Option One
             </ids-list-box-option>
             <ids-list-box-option value="opt2">
-              <ids-icon icon="project"></ids-icon>
-              Option Two
+              <ids-icon icon="project"></ids-icon>Option Two
             </ids-list-box-option>
             <ids-list-box-option value="opt3">
-              <ids-icon icon="purchasing"></ids-icon>
-              Option Three
+              <ids-icon icon="purchasing"></ids-icon>Option Three
             </ids-list-box-option>
             <ids-list-box-option value="opt4">
-              <ids-icon icon="quality"></ids-icon>
-              Option Four</ids-list-box-option>
+              <ids-icon icon="quality"></ids-icon>Option Four
+            </ids-list-box-option>
             <ids-list-box-option value="opt5">
-              <ids-icon icon="rocket"></ids-icon>
-              Option Five
+              <ids-icon icon="rocket"></ids-icon>Option Five
             </ids-list-box-option>
             <ids-list-box-option value="opt6">
-              <ids-icon icon="roles"></ids-icon>
-              Option Six
+              <ids-icon icon="roles"></ids-icon>Option Six
             </ids-list-box-option>
           </ids-list-box>
         </ids-dropdown>

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -1183,6 +1183,7 @@ export default class IdsDropdown extends Base {
   #templateListBoxOption(option: IdsDropdownOption): string {
     return `<ids-list-box-option
       ${this.#isMultiSelect ? 'class="multiselect-option multiselect-loaded"' : ''}
+      ${!this.#isMultiSelect && option.icon ? 'class="icon-option"' : ''}
       ${option.id ? `id=${option.id}` : ''}
       ${option.value ? `value="${option.value}"` : ''}
       ${option.tooltip ? `tooltip="${option.tooltip}"` : ''}
@@ -1407,6 +1408,7 @@ export default class IdsDropdown extends Base {
       this.setOptionsData();
     } else {
       this.removeAttribute(attributes.TYPEAHEAD);
+      this.input?.setAttribute(attributes.READONLY, 'true');
     }
 
     this.container?.classList.toggle('typeahead', val);

--- a/src/components/ids-list-box/ids-list-box-option.scss
+++ b/src/components/ids-list-box/ids-list-box-option.scss
@@ -17,7 +17,8 @@
   white-space: nowrap;
 }
 
-:host(.multiselect-option) {
+:host(.multiselect-option),
+:host(.icon-option) {
   display: flex;
 
   ::slotted(ids-icon) {

--- a/tests/ids-dropdown/ids-dropdown.spec.ts
+++ b/tests/ids-dropdown/ids-dropdown.spec.ts
@@ -1064,6 +1064,28 @@ test.describe('IdsDropdown tests', () => {
       await expect(dropdown.locator('#grpB')).not.toHaveClass(/is-selected/);
       await expect(dropdown.locator('ids-list-box-option[value="AZ"]')).toHaveClass(/is-selected/);
     });
+
+    test('should set typeahead', async ({ page }) => {
+      const dropdown = await page.locator('#dropdown-1');
+      expect(await dropdown.evaluate((element: IdsDropdown) => element.typeahead)).toBeFalsy();
+      await expect(dropdown.locator('ids-trigger-field')).toHaveAttribute('readonly');
+      await dropdown.evaluate((element: IdsDropdown) => { element.typeahead = true; });
+      expect(await dropdown.evaluate((element: IdsDropdown) => element.typeahead)).toBeTruthy();
+      expect(await dropdown.evaluate((element: IdsDropdown) => element.container?.classList.contains('typeahead'))).toBeTruthy();
+      await dropdown.locator('ids-trigger-button').click();
+      await expect(dropdown.locator('ids-trigger-field')).not.toHaveAttribute('readonly');
+    });
+
+    test('should unset typeahead', async ({ page }) => {
+      await page.goto('/ids-dropdown/typeahead.html');
+      const dropdown = await page.locator('ids-dropdown').first();
+      expect(await dropdown.evaluate((element: IdsDropdown) => element.typeahead)).toBeTruthy();
+      await expect(dropdown.locator('ids-trigger-field')).not.toHaveAttribute('readonly');
+      await dropdown.evaluate((element: IdsDropdown) => { element.typeahead = false; });
+      expect(await dropdown.evaluate((element: IdsDropdown) => element.typeahead)).toBeFalsy();
+      expect(await dropdown.evaluate((element: IdsDropdown) => element.container?.classList.contains('typeahead'))).toBeFalsy();
+      await expect(dropdown.locator('ids-trigger-field')).toHaveAttribute('readonly');
+    });
   });
 
   test.describe('reattachment tests', () => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed an issue on the main example where setting typeahead caused errors (the fix is in the example itself)
Fixed disabling typeahead allowed typing in the input (readonly was not being added to the input)
Fixed broken list box option layout in typeahead with icons

**Related github/jira issue (required)**:
Closes #2662 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4300/ids-dropdown/example.html
- run `document.querySelector('ids-dropdown').typeahead = true` in the dev tools console
- should not be any errors in the console
- go to http://localhost:4300/ids-dropdown/typeahead.html
- run `document.querySelector('ids-dropdown').typeahead = false` in the dev tools console
- click on the first dropdown and type something
- input should not be editable
- test Typeahead with icons on the same page
- icons should be aligned with text after you type something

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.