### PR TITLE
1392 - ids-data-grid-row custom-selection

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 1.4.3 Fixes
 
+- `[Datagrid]` Fixed bug where the custom select-color is lost during row-recycling/virtual-scrolling. ([#1392](https://github.com/infor-design/enterprise-wc/issues/1392))
 - `[Homepage]` Converted home page tests to playwright. ([#1940](https://github.com/infor-design/enterprise-wc/issues/1940))
 - `[Listbuilder]` Fixed buggy builder styles. ([#2701]https://github.com/infor-design/enterprise-wc/issues/2701)
 - `[Listbuilder]` Fixed an issue where clicking the row in the wrong spot would edit the wrong row. ([#2701]https://github.com/infor-design/enterprise-wc/issues/2701)

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -437,7 +437,13 @@ export default class IdsDataGridRow extends IdsElement {
     }
 
     const cssPart = (column: IdsDataGridColumn, rowIndex: number, cellIndex: number) => {
-      const part = column.cssPart || 'cell';
+      let part = column.cssPart || 'cell';
+      const isSelectable = this.dataGrid?.rowSelection === 'mixed' || this.dataGrid?.rowSelection === 'single' || this.dataGrid?.rowSelection === 'multiple';
+      if (isSelectable && row.rowSelected) {
+        if (column.cellSelectedCssPart) part = column.cellSelectedCssPart;
+        else part = 'cell-selected';
+      }
+
       if (typeof part === 'function') {
         return part(rowIndex, cellIndex);
       }

--- a/src/components/ids-data-grid/ids-data-grid-row.ts
+++ b/src/components/ids-data-grid/ids-data-grid-row.ts
@@ -438,7 +438,8 @@ export default class IdsDataGridRow extends IdsElement {
 
     const cssPart = (column: IdsDataGridColumn, rowIndex: number, cellIndex: number) => {
       let part = column.cssPart || 'cell';
-      const isSelectable = this.dataGrid?.rowSelection === 'mixed' || this.dataGrid?.rowSelection === 'single' || this.dataGrid?.rowSelection === 'multiple';
+      const rowSelection = this.dataGrid?.rowSelection;
+      const isSelectable = rowSelection === 'mixed' || rowSelection === 'single' || rowSelection === 'multiple';
       if (isSelectable && row.rowSelected) {
         if (column.cellSelectedCssPart) part = column.cellSelectedCssPart;
         else part = 'cell-selected';


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed bug where the custom select-color is lost during row-recycling/virtual-scrolling.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #1392

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out this branch and run: `nvm use && npm i && npm run start`
2. Go to: http://localhost:4300/ids-data-grid/m3-features.html
3. Click on a row and it has a custom green css color on select
4. Scroll down about 200-300 
5. Scroll back up -> ensure the color is still the custom selection color (not the normal selection color)
6. Compare against: https://main.wc.design.infor.com/ids-data-grid/m3-features.html

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
