### PR TITLE
2724 - IdsDataGrid deep clone dataset

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Button]` Fixed a bug in the lifecycle where inner classes where not refreshed in some frameworks.([#2627]https://github.com/infor-design/enterprise-wc/issues/2627)
 - `[Button]` Fixed an issue where Button layout looks off in smaller viewport. ([#2652](https://github.com/infor-design/enterprise-wc/issues/2652))
 - `[Checkbox]` Fixed an issue where native events were triggered multiple times in single selection. ([#2385](https://github.com/infor-design/enterprise-wc/issues/2385))
+- `[Datagrid]` Fixed bug where datagrid mutates original data passed in by user. ([#2724](https://github.com/infor-design/enterprise-wc/issues/2724))
 - `[Datagrid]` If no options the datagrid will still show the value, defaulting the options that may load later. ([#2386](https://github.com/infor-design/enterprise-wc/issues/2386))
 - `[Dropdown]` Converted dropdown tests to playwright. ([#1846](https://github.com/infor-design/enterprise-wc/issues/1846))
 - `[Dropdown]` Fixed an issue where disabling typeahead allowed typing in the input. ([#2662](https://github.com/infor-design/enterprise-wc/issues/2662))

--- a/src/components/ids-data-grid/demos/tree-grid.ts
+++ b/src/components/ids-data-grid/demos/tree-grid.ts
@@ -3,6 +3,7 @@ import '../ids-data-grid';
 import type { IdsDataGridColumn } from '../ids-data-grid-column';
 import buildingsJSON from '../../../assets/data/tree-buildings.json';
 
+let dataset: Record<string, any>[] = [];
 // Example for populating the DataGrid
 const dataGrid = document.querySelector<IdsDataGrid>('#tree-grid')!;
 
@@ -88,17 +89,41 @@ if (dataGrid) {
     const setData = async () => {
       const res = await fetch(url);
       const data = await res.json();
-      dataGrid.data = data;
+
+      console.info(`Initial Load`);
+      dataset = data.slice(0, 120);
+      console.info('-------- local dataset ---------');
+      console.info(dataset);
+
+      dataGrid.data = dataset;
+      console.info('-------- dataGrid.data ---------');
+      console.info(dataGrid.data);
     };
 
     await setData();
 
+    dataGrid.addEventListener('selectionchanged', (e: Event) => {
+      console.info(`Selection Changed`, (<CustomEvent>e).detail);
+      console.info('-------- local dataset ---------');
+      console.info(dataset);
+      console.info('-------- dataGrid.data ---------');
+      console.info(dataGrid.data);
+    });
+
     dataGrid.addEventListener('rowexpanded', (e: Event) => {
       console.info(`Row Expanded`, (<CustomEvent>e).detail);
+      console.info('-------- local dataset ---------');
+      console.info(dataset);
+      console.info('-------- dataGrid.data ---------');
+      console.info(dataGrid.data);
     });
 
     dataGrid.addEventListener('rowcollapsed', (e: Event) => {
       console.info(`Row Collapsed`, (<CustomEvent>e).detail);
+      console.info('-------- local dataset ---------');
+      console.info(dataset);
+      console.info('-------- dataGrid.data ---------');
+      console.info(dataGrid.data);
     });
   }());
 }

--- a/src/core/ids-data-source.ts
+++ b/src/core/ids-data-source.ts
@@ -133,10 +133,10 @@ class IdsDataSource {
    * Sets the data array on the data source object
    * @param {Array | null} value The array to attach
    */
-  set data(value) {
-    if (!this.groupable) this.#currentData = this.#flattenData(deepClone(value));
-    if (this.groupable) this.#currentData = this.#groupData(deepClone(value));
-    this.#originalData = value;
+  set data(value: Array<Record<string, any>> | null) {
+    const copy = deepClone(value) ?? [];
+    this.#currentData = this.groupable ? this.#groupData(copy) : this.#flattenData(copy);
+    this.#originalData = copy.slice(0);
     this.#total = this.#currentData?.length || 0;
   }
 


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixes bug where datagrid actions mutate original dataset passed in

**Related github/jira issue (required)**:
Closes #2724 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/tree-grid.html
3. Open dev console and note state of `local dataset` vs data from `dataGrid.data`
4. Expand/Select various rows on the datagrid
5. Ensure that the `local dataset` was not changed (ex. rowExpanded, rowSelected props keep original values)

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.
