### PR TITLE
2589 - IdsDataGrid fix dropdown reopen

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 1.4.3 Fixes
 
 - `[Datagrid]` Fixed bug where the custom select-color is lost during row-recycling/virtual-scrolling. ([#1392](https://github.com/infor-design/enterprise-wc/issues/1392))
+- `[Datagrid]` Fixed bug editor dropdown can't be re-opened after closing. ([#2589](https://github.com/infor-design/enterprise-wc/issues/2589))
 - `[Homepage]` Converted home page tests to playwright. ([#1940](https://github.com/infor-design/enterprise-wc/issues/1940))
 - `[Listbuilder]` Fixed buggy builder styles. ([#2701]https://github.com/infor-design/enterprise-wc/issues/2701)
 - `[Listbuilder]` Fixed an issue where clicking the row in the wrong spot would edit the wrong row. ([#2701]https://github.com/infor-design/enterprise-wc/issues/2701)

--- a/src/components/ids-data-grid/ids-data-grid-cell.ts
+++ b/src/components/ids-data-grid/ids-data-grid-cell.ts
@@ -320,6 +320,8 @@ export default class IdsDataGridCell extends IdsElement {
           this.endCellEdit();
         });
       });
+    } else if (editorType === 'dropdown') {
+      this.editor.input?.onEvent('close', this.editor.input, () => this.endCellEdit());
     } else {
       this.editor.input?.onEvent('focusout', this.editor.input, () => {
         this.endCellEdit();
@@ -344,6 +346,7 @@ export default class IdsDataGridCell extends IdsElement {
 
     const editorType = (this.editor?.type as string);
     input?.offEvent('focusout', input);
+    input?.offEvent('close', input);
 
     if (['input', 'tree'].includes(editorType) && input?.setDirtyTracker) {
       input?.setDirtyTracker(input?.value as any);

--- a/src/components/ids-data-grid/ids-data-grid-editors.ts
+++ b/src/components/ids-data-grid/ids-data-grid-editors.ts
@@ -339,7 +339,7 @@ export class DropdownEditor implements IdsDataGridEditor {
   /* Save selected dropdown value */
   save() {
     return {
-      value: this.#value,
+      value: this.input?.value,
       dirtyCheckValue: this.input?.input?.value
     };
   }

--- a/tests/ids-data-grid/ids-data-grid-editing.spec.ts
+++ b/tests/ids-data-grid/ids-data-grid-editing.spec.ts
@@ -628,11 +628,10 @@ test.describe('IdsDataGrid editing tests', () => {
       const editableCell = dataGrid.container?.querySelector<IdsDataGridCell>('ids-data-grid-cell.is-dropdown.is-editable');
       editableCell?.startCellEdit();
       editableCell?.querySelector<IdsDropdown>('ids-dropdown')?.setAttribute('value', 'eur');
-      editableCell?.endCellEdit();
       return editableCell?.value;
     });
 
-    expect(results).toBe('EUR');
+    expect(results).toBe('eur');
   });
 
   test('supports updating data set and refreshing row', async ({ page }) => {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed bug where dropdown wouldn't reopen after it was clicked to close.

**Related github/jira issue (required)**:
Closes #2589 

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-data-grid/editable-inline.html
3. Click dropdown to open
4. Click same dropdown to close
5. Check that you're able to reopen that dropdown

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.

