### PR TITLE
8964 - IdsColorPicker fix color picker custom colors

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 1.4.3 Fixes
 
+- `[ColorPicker]` Fixed bug where custom colors were being overidden. ([#8964](https://github.com/infor-design/enterprise/issues/8964))
 - `[Datagrid]` Fixed bug where the custom select-color is lost during row-recycling/virtual-scrolling. ([#1392](https://github.com/infor-design/enterprise-wc/issues/1392))
 - `[Datagrid]` Fixed bug editor dropdown can't be re-opened after closing. ([#2589](https://github.com/infor-design/enterprise-wc/issues/2589))
 - `[Homepage]` Converted home page tests to playwright. ([#1940](https://github.com/infor-design/enterprise-wc/issues/1940))

--- a/src/components/ids-color-picker/demos/example.html
+++ b/src/components/ids-color-picker/demos/example.html
@@ -21,6 +21,11 @@
           <ids-color hex="#FFCAD4"></ids-color>
           <ids-color hex="#F4ACB7"></ids-color>
           <ids-color hex="#9D8189"></ids-color>
+          <ids-color hex="#fbe7e8"></ids-color>
+          <ids-color hex="#f5c3c4"></ids-color>
+          <ids-color hex="#ee9496"></ids-color>
+          <ids-color hex="#e66467"></ids-color>
+          <ids-color hex="#df3539"></ids-color>
         </ids-color-picker>
 
         <ids-color-picker label="Suppress Labels" value="#3B1470" suppress-labels></ids-color-picker>

--- a/src/components/ids-color-picker/ids-color-picker.ts
+++ b/src/components/ids-color-picker/ids-color-picker.ts
@@ -41,7 +41,7 @@ const Base = IdsClearableMixin(
 export default class IdsColorPicker extends Base {
   isFormComponent = true;
 
-  useDefaultSwatches = true;
+  useDefaultSwatches = false;
 
   initialized = false;
 

--- a/tests/ids-color-picker/ids-color-picker.spec.ts
+++ b/tests/ids-color-picker/ids-color-picker.spec.ts
@@ -190,6 +190,15 @@ test.describe('IdsColorPicker tests', () => {
       await page.keyboard.press('Enter');
       expect(await colorPicker.evaluate((colorpicker: IdsColorPicker) => colorpicker.value)).toEqual('#fbe7e8');
     });
+
+    test.only('should allow custom colors to be slotted', async ({ page }) => {
+      const customColor = await page.evaluate(() => {
+        const customColorPicker = document.querySelector('[label="Custom Colors"]');
+        const customColorElem = customColorPicker?.querySelector('ids-color[hex="#D8E2DC"]');
+        return customColorElem;
+      });
+      expect(customColor).toBeDefined();
+    });
   });
 
   test.describe('When Popup is Closed', () => {

--- a/tests/ids-color-picker/ids-color-picker.spec.ts
+++ b/tests/ids-color-picker/ids-color-picker.spec.ts
@@ -191,7 +191,7 @@ test.describe('IdsColorPicker tests', () => {
       expect(await colorPicker.evaluate((colorpicker: IdsColorPicker) => colorpicker.value)).toEqual('#fbe7e8');
     });
 
-    test.only('should allow custom colors to be slotted', async ({ page }) => {
+    test('should allow custom colors to be slotted', async ({ page }) => {
       const customColor = await page.evaluate(() => {
         const customColorPicker = document.querySelector('[label="Custom Colors"]');
         const customColorElem = customColorPicker?.querySelector('ids-color[hex="#D8E2DC"]');


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fix bug where color picker custom colors were being overridden by default swatches

**Related github/jira issue (required)**:
Closes [#89](https://github.com/infor-design/enterprise/issues/8964)

**Steps necessary to review your pull request (required)**:
1. Checkout branch
2. Go to http://localhost:4300/ids-color-picker/example.html
3. Check "Custom Colors" example
4. Check that custom colors are shown in popup

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
