### PR TITLE
2256 - IdsLoadingIndicator set to contained area

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Card]` Adds `draggable` attribute to ids-card which allows card to be used in drag and drop scenarios. ([#2423](https://github.com/infor-design/enterprise-wc/issues/2423))
 - `[Datagrid]` Fix Clear Row / Eraser button so that changes persist throughout pagination. ([#2615]https://github.com/infor-design/enterprise-wc/issues/2615)
+- `[LoadingIndicator]` Added a setting `contained` which confines the loading indicator within it's nearest parent. ([#2256]https://github.com/infor-design/enterprise-wc/issues/2256)
 - `[NotificationBanner]` Added a notification service which can be used to manage notification banners on a page. ([#2160]https://github.com/infor-design/enterprise-wc/issues/2160)
 - `[Themes]` Added a setting `IdsGlobal.themePath` that you can use to set the location of the theme files. ([#2125]https://github.com/infor-design/enterprise-wc/issues/2125)
 

--- a/src/assets/css/ids-layout-grid/example-inbox.css
+++ b/src/assets/css/ids-layout-grid/example-inbox.css
@@ -1,3 +1,7 @@
 ids-toolbar {
   border-bottom: 1px solid var(--ids-color-gray-40);
 }
+
+ids-list-view::part(list-view) {
+  overflow: hidden;
+}

--- a/src/components/ids-list-view/ids-list-view.ts
+++ b/src/components/ids-list-view/ids-list-view.ts
@@ -495,7 +495,7 @@ export default class IdsListView extends Base {
   templateStatic(): string {
     const selectable = this.selectable ? ` ${this.selectableClass()}` : '';
     return `
-      <div class="ids-list-view${selectable}">
+      <div class="ids-list-view${selectable}" part="list-view">
         <div class="ids-list-view-body" role="listbox" aria-label="${this.label}" part="contents">
           ${this.sortable ? `<ids-swappable selection=${this.selectable}>` : ''}
             ${this.templateListItems()}

--- a/src/components/ids-loading-indicator/README.md
+++ b/src/components/ids-loading-indicator/README.md
@@ -54,6 +54,12 @@ affixed to the top of view it is currently in:
 <ids-loading-indicator progress="10" sticky></ids-loading-indicator>
 ```
 
+The `contained` setting is a boolean attribute that controls whether the IdsLoadingIndicator is confined within its parent element. When this setting is enabled, the loading indicator will remain within the boundaries of its nearest parent element, preventing it from overflowing or overlapping other content.
+
+```html
+<ids-loading-indicator contained></ids-loading-indicator>
+```
+
 ## Settings and Attributes
 
 - `progress` {number | undefined} Represents the percentage completed for the indicator; if not specified, the indicator is set into indeterminate mode (e.g. no specific progress with an animation)

--- a/src/components/ids-loading-indicator/demos/index.yaml
+++ b/src/components/ids-loading-indicator/demos/index.yaml
@@ -14,6 +14,9 @@
   - link: full-page.html
     type: Example
     description: Shows loading indicator in a full page
+  - link: list-view-loading.html
+    type: Example of loading indicator in a list view
+    description: Shows loading indicator in a list view
   - link: side-by-side.html
     type: Side by Side
     description: Showing a loading indicators side by side with a 4.x busy indicator

--- a/src/components/ids-loading-indicator/demos/list-view-loading.html
+++ b/src/components/ids-loading-indicator/demos/list-view-loading.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <%= htmlWebpackPlugin.options.font %>
+  </head>
+  <body>
+    <ids-container role="main" padding="0" hidden>
+      <ids-toolbar id="toolbar-container">
+        <ids-toolbar-section type="button">
+          <ids-button id="menu-button" icon="menu" role="button">
+            <span class="audible">Menu Button</span>
+          </ids-button>
+        </ids-toolbar-section>
+        <ids-toolbar-section type="title">
+          <ids-text font-size="20">Notification Center</ids-text>
+        </ids-toolbar-section>
+        <ids-toolbar-section align="end">
+          <ids-search-field
+            collapsible
+            id="header-search"
+            clearable
+            label-state="collapsed"
+            no-margins
+          >
+            <ids-trigger-button slot="trigger-start" icon="search"></ids-trigger-button>
+          </ids-search-field>
+        </ids-toolbar-section>
+      </ids-toolbar>
+      <ids-layout-grid
+        id="container-grid"
+        class="container-enabled"
+        cols="12"
+        justify-content="start"
+      >
+        <ids-layout-grid-cell id="listview-cell" col-span="12" col-span-md="4" col-span-lg="3" height="calc(100vh - 64px)">
+          <ids-list-view
+            id="demo-lv-selectable-single"
+            selectable="single"
+            item-height="76"
+          >
+            <template>
+              <ids-text font-size="16" type="h2">${productName}</ids-text>
+              <ids-text font-size="12" type="span">Count: ${units}</ids-text>
+              <ids-text font-size="12" type="span">Price: $ ${unitPrice}</ids-text>
+            </template>
+            <ids-loading-indicator align="center" overlay contained></ids-loading-indicator>
+          </ids-list-view>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell id="hidden-cell-md" col-span="12" col-span-md="8" col-span-lg="9" hide="md">
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+    </ids-container>
+  </body>
+</html>

--- a/src/components/ids-loading-indicator/demos/list-view-loading.ts
+++ b/src/components/ids-loading-indicator/demos/list-view-loading.ts
@@ -1,0 +1,43 @@
+// Supporting components
+import '../../ids-list-view/ids-list-view';
+import '../../ids-hidden/ids-hidden';
+import '../../ids-toolbar/ids-toolbar';
+import '../ids-loading-indicator';
+import '../../ids-modal/ids-overlay';
+import productsJSON from '../../../assets/data/products-100.json';
+import css from '../../../assets/css/ids-layout-grid/example-inbox.css';
+
+const cssLink = `<link href="${css}" rel="stylesheet">`;
+const head = document.querySelector('head');
+if (head) {
+  head.insertAdjacentHTML('afterbegin', cssLink);
+}
+
+// Example for populating the List View
+const listView: any = document.querySelector('#demo-lv-selectable-single');
+
+if (listView) {
+  // Do an ajax request and apply the data to the list
+  const url: any = productsJSON;
+
+  const setData = async () => {
+    const res = await fetch(url);
+    const data = await res.json();
+    listView.data = data;
+  };
+
+  listView.addEventListener('selected', (e: any) => {
+    console.info('selected event called', e.detail);
+  });
+  listView.addEventListener('deselected', (e: any) => {
+    console.info('deselected event called', e.detail);
+  });
+  listView.addEventListener('click', (e: any) => {
+    console.info('clicked event called', e.detail);
+  });
+  listView.addEventListener('activated', (e: any) => {
+    console.info('activated event called', e.detail);
+  });
+
+  await setData();
+}

--- a/src/components/ids-loading-indicator/ids-loading-indicator-attributes.ts
+++ b/src/components/ids-loading-indicator/ids-loading-indicator-attributes.ts
@@ -76,7 +76,7 @@ const getInnerIndicatorHtml = ({
         <circle cx="50" cy="50" r="45" stroke-width="${inline ? 8 : inner}" class="circle" part="circle" />
         <circle cx="50" cy="50" r="45" stroke-width="${inline ? 18 : outer}" class="progress" part="progress" />
       </svg>
-      ${!percentageVisible ? '' : getPercentageTextHtml({ progress })}<ids-overlay opacity="0.7" background-color="page"></ids-overlay>`
+      ${!percentageVisible ? '' : getPercentageTextHtml({ progress })}<ids-overlay ${type === 'contained' ? 'class="contained"' : ''} exportparts="overlay: innerOverlay" opacity="0.7" background-color="page"></ids-overlay>`
       );
     }
   }

--- a/src/components/ids-loading-indicator/ids-loading-indicator.scss
+++ b/src/components/ids-loading-indicator/ids-loading-indicator.scss
@@ -25,6 +25,15 @@
   margin-block-start: -25px;
 }
 
+:host(ids-loading-indicator[align='center'][contained]:not([sticky]):not([inline])) {
+  position: absolute;
+  margin: 0;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+}
+
 // Paused/Stopped
 :host(ids-loading-indicator[stopped]:not([linear]):not([sticky]):not([inline])) {
   display: none;

--- a/src/components/ids-loading-indicator/ids-loading-indicator.scss
+++ b/src/components/ids-loading-indicator/ids-loading-indicator.scss
@@ -28,8 +28,8 @@
 :host(ids-loading-indicator[align='center'][contained]:not([sticky]):not([inline])) {
   position: absolute;
   margin: 0;
-  left: 0;
-  top: 0;
+  inset-block-start: 0;
+  inset-inline-start: 0;
   height: 100%;
   width: 100%;
 }

--- a/src/components/ids-loading-indicator/ids-loading-indicator.ts
+++ b/src/components/ids-loading-indicator/ids-loading-indicator.ts
@@ -46,6 +46,7 @@ export default class IdsLoadingIndicator extends Base {
   static get attributes(): Array<string> {
     return [
       attributes.ALIGN,
+      attributes.CONTAINED,
       attributes.GENERATIVE_AI,
       attributes.INLINE,
       attributes.LINEAR,
@@ -75,6 +76,10 @@ export default class IdsLoadingIndicator extends Base {
 
     if (this.hasAttribute(attributes.GENERATIVE_AI)) {
       type = 'generative-ai';
+    }
+
+    if (this.hasAttribute(attributes.CONTAINED)) {
+      type = 'contained';
     }
 
     return getInnerIndicatorHtml({
@@ -174,6 +179,22 @@ export default class IdsLoadingIndicator extends Base {
    */
   get sticky() {
     return this.hasAttribute(attributes.STICKY);
+  }
+
+  /**
+   * Flags the indicator as being an contained indicator relative to nearest parent
+   * @param {string | boolean} value true if the indicator should be contained
+   */
+  set contained(value: string | boolean) {
+    this.#onUpdateTypeFlag(attributes.CONTAINED, stringToBool(value));
+  }
+
+  /**
+   * @returns {boolean} Flags the indicator as being a
+   * contained indicator relative to nearest parent
+   */
+  get contained() {
+    return this.hasAttribute(attributes.CONTAINED);
   }
 
   /**

--- a/src/components/ids-modal/ids-overlay.scss
+++ b/src/components/ids-modal/ids-overlay.scss
@@ -28,3 +28,7 @@
     pointer-events: auto;
   }
 }
+
+:host(.contained)::part(overlay) {
+  position: absolute;
+}

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -116,6 +116,7 @@ export const attributes = {
   COMPONENT_NAME: 'component-name',
   CONDITION: 'condition',
   CONFIRM: 'confirm',
+  CONTAINED: 'contained',
   CONTAINER_TARGET: 'container-target',
   CONTENT_ALIGN: 'content-align',
   COPYRIGHT_YEAR: 'copyright-year',

--- a/tests/ids-list-view/snapshots/list-view-shadow.snap
+++ b/tests/ids-list-view/snapshots/list-view-shadow.snap
@@ -1,7 +1,7 @@
 
       <div class="ids-list-view-search" part="search"><slot name="search"></slot></div>
       
-      <div class="ids-list-view" style="height: 100%;">
+      <div class="ids-list-view" part="list-view" style="height: 100%;">
         <div class="ids-list-view-body" role="listbox" aria-label="Ids list view" part="contents" aria-activedescendant="id-1">
           
             <div><ids-list-view-item row-index="0" index="0" aria-posinset="1" id="id-1" aria-setsize="77" tabindex="0" role="option">

--- a/tests/ids-loading-indicator/ids-loading-indicator.spec.ts
+++ b/tests/ids-loading-indicator/ids-loading-indicator.spec.ts
@@ -117,6 +117,15 @@ test.describe('IdsLoadingIndicator tests', () => {
       await expect(await locator.getAttribute('linear')).toEqual('true');
     });
 
+    test('should set contained by attribute', async ({ page }) => {
+      const locator = await page.locator('ids-loading-indicator').first();
+      const handle = await page.$('ids-loading-indicator');
+      await handle?.evaluate((el: IdsLoadingIndicator) => {
+        el.setAttribute('contained', 'true');
+      });
+      await expect(await locator.getAttribute('contained')).toEqual('true');
+    });
+
     test('calls type getter reliably based on flags set', async ({ page }) => {
       const locator = await page.locator('ids-loading-indicator').first();
       const handle = await page.$('ids-loading-indicator');

--- a/tests/ids-loading-indicator/snapshots/loading-indicator-shadow.snap
+++ b/tests/ids-loading-indicator/snapshots/loading-indicator-shadow.snap
@@ -2,4 +2,4 @@
         <circle cx="50" cy="50" r="45" stroke-width="3" class="circle" part="circle"></circle>
         <circle cx="50" cy="50" r="45" stroke-width="6" class="progress" part="progress"></circle>
       </svg>
-      <ids-overlay opacity="0.7" background-color="page"></ids-overlay>
+      <ids-overlay exportparts="overlay: innerOverlay" opacity="0.7" background-color="page"></ids-overlay>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
This PR introduces a new setting, `contained`, to the IdsLoadingIndicator component. The contained setting enables the loading indicator to be confined within its parent element, preventing it from overflowing or extending beyond the intended boundaries.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
closes #2256 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull and run branch
- go to http://localhost:4300/ids-loading-indicator/list-view-loading.html
- See example of contained loading indicator.

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
