### PR TITLE
2740 - Fix maxWidth recursion error in IdsLayoutGrid

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[Datagrid]` Fixed bug editor dropdown can't be re-opened after closing. ([#2589](https://github.com/infor-design/enterprise-wc/issues/2589))
 - `[Dropdown]` Made the `typeahead` setting true by default. ([#2770](https://github.com/infor-design/enterprise-wc/issues/2770))
 - `[Homepage]` Converted home page tests to playwright. ([#1940](https://github.com/infor-design/enterprise-wc/issues/1940))
+- `[LayoutGrid]` Fixed recursion issue in maxWidth setter. ([#2470]https://github.com/infor-design/enterprise-wc/issues/2470)
 - `[Listbuilder]` Fixed buggy builder styles. ([#2701](https://github.com/infor-design/enterprise-wc/issues/2701))
 - `[Listbuilder]` Fixed an issue where clicking the row in the wrong spot would edit the wrong row. ([#2701](https://github.com/infor-design/enterprise-wc/issues/2701))
 - `[Locale]` Fixed translation issue of `small` into Spanish. ([#8962]https://github.com/infor-design/enterprise-wc/issues/8962)

--- a/src/components/ids-layout-grid/demos/example.html
+++ b/src/components/ids-layout-grid/demos/example.html
@@ -498,6 +498,88 @@
         padding="md"
       >
         <ids-layout-grid-cell>
+          <ids-text font-size="12" type="h1">Contained Grid (maxWidth (500px) / margin auto)</ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+
+      <ids-layout-grid
+        id="eight-column-grid-max-width-2"
+        cols="8"
+        padding-x="md"
+        justify-content="center"
+        max-width="500px"
+        margin="auto"
+      >
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="4" fill height="176px">
+          <ids-text font-size="12">4 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="4" fill height="176px">
+          <ids-text font-size="12">4 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="5" fill height="176px">
+          <ids-text font-size="12">5 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="3" fill height="176px">
+          <ids-text font-size="12">3 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="6" fill height="176px">
+          <ids-text font-size="12">6 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="2" fill height="176px">
+          <ids-text font-size="12">2 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="7" fill height="176px">
+          <ids-text font-size="12">7 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="1" fill height="176px">
+          <ids-text font-size="12">1 Col</ids-text>
+        </ids-layout-grid-cell>
+        <ids-layout-grid-cell col-span="8" fill height="176px">
+          <ids-text font-size="12">8 Col</ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+
+      <ids-layout-grid
+        auto-fit="true"
+        padding="md"
+      >
+        <ids-layout-grid-cell>
           <ids-text font-size="12" type="h1">Grid template rows</ids-text>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/src/components/ids-layout-grid/ids-layout-grid.ts
+++ b/src/components/ids-layout-grid/ids-layout-grid.ts
@@ -386,17 +386,22 @@ export default class IdsLayoutGrid extends IdsElement {
    * Set the maxWidth attribute
    * @param {string | null} value The value of the max-width [null, 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '###px']
    */
-  set maxWidth(value: string | null) {
-    if (!value || MAX_WIDTH_SIZES.indexOf(value as any) <= 0) {
-      this.removeAttribute(attributes.MAX_WIDTH);
-
-      // If custom value is set use custom property
-      if (value?.endsWith('px')) {
-        this.style.setProperty('--max-width', value);
-        this.setAttribute(attributes.MAX_WIDTH, value);
-      }
-    } else {
+  set maxWidth(value: string | null | any) {
+    if (MAX_WIDTH_SIZES.indexOf(value as any) >= 0) {
       this.setAttribute(attributes.MAX_WIDTH, value);
+      this.style.removeProperty('--max-width');
+    } else if (/^\d+$/.test(value)) {
+      // If the value is a number without a unit, add 'px'
+      value = `${value}px`;
+      this.style.setProperty('--max-width', value);
+      this.setAttribute(attributes.MAX_WIDTH, value);
+    } else if (value?.endsWith('px')) {
+      // If the value already has a 'px' unit, use it directly
+      this.style.setProperty('--max-width', value);
+      this.setAttribute(attributes.MAX_WIDTH, value);
+    } else {
+      // If the value is invalid or null, remove the attribute and the custom property
+      this.removeAttribute(attributes.MAX_WIDTH);
       this.style.removeProperty('--max-width');
     }
   }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
This PR addresses a recursion issue in the maxWidth setter of the IdsLayoutGrid component that was causing a "Maximum call stack exceeded" error when certain values, particularly those ending with 'px', were set. The fix ensures that the setter does not inadvertently trigger the attribute removal, preventing infinite loops.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
closes #2740 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull and run branch
- got to http://localhost:4300/ids-layout-grid/example.html
- Scroll down to the example labeled "Contained Grid (maxWidth (500px) / margin auto)"
- See properly sized grid
- check the console
- should not see any errors

**Included in this Pull Request**:
~- [ ] Some documentation for the feature.~
~- [ ] A test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
