### PR TITLE
2747 - Fix opened menus on navigation

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Datagrid]` Fix Clear Row / Eraser button so that changes persist throughout pagination. ([#2615](https://github.com/infor-design/enterprise-wc/issues/2615))
 - `[LoadingIndicator]` Added a setting `contained` which confines the loading indicator within it's nearest parent. ([#2256](https://github.com/infor-design/enterprise-wc/issues/2256))
 - `[NotificationBanner]` Added a notification service which can be used to manage notification banners on a page. ([#2160](https://github.com/infor-design/enterprise-wc/issues/2160))
+- `[Popup]` Fixed a bug where in Angular the click events cause menus to open when navigating. ([#2747](https://github.com/infor-design/enterprise-wc/issues/2747))
 - `[SegmentedControl]` Added the IdsSegmentedControl component. ([#2180]https://github.com/infor-design/enterprise-wc/issues/2180)
 - `[Switch]` Added a label position setting that allows positioning the label on either the right or left side of the slider. ([#2579](https://github.com/infor-design/enterprise-wc/issues/2579))
 - `[Themes]` Added a setting `IdsGlobal.themePath` that you can use to set the location of the theme files. ([#2125](https://github.com/infor-design/enterprise-wc/issues/2125))

--- a/src/mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin.ts
+++ b/src/mixins/ids-popup-interactions-mixin/ids-popup-interactions-mixin.ts
@@ -212,12 +212,14 @@ const IdsPopupInteractionsMixin = <T extends Constraints>(superclass: T) => clas
         }
 
         // Open/Close the menu when the trigger element is clicked
-        this.offEvent('click.trigger');
-        this.onEvent('click.trigger', targetElem, (e: Event) => {
-          if (typeof this.onTriggerClick === 'function') {
-            return this.onTriggerClick(e);
-          }
-          return true;
+        requestAnimationFrame(() => {
+          this.offEvent('click.trigger');
+          this.onEvent('click.trigger', targetElem, (e: Event) => {
+            if (typeof this.onTriggerClick === 'function') {
+              return this.onTriggerClick(e);
+            }
+            return true;
+          });
         });
 
         break;


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

In a very specific app scenario, navigating the page causes click events to be established too early. Makes menus appear open when they should not be.

**Related github/jira issue (required)**:
Fixes #2747 

** Example Project**
[stackblitz-starters-mhnb1p.zip](https://github.com/user-attachments/files/16893127/stackblitz-starters-mhnb1p.zip)

**Steps necessary to review your pull request (required)**:
- pull the branch and run `npm run build:dist`
- unzip the attached project and put it in a folder
- cd to that folder and run `npm i`
- then take the files from the folder in build/dist/development and copy them over node_modules/ids-enterprise-wc in the zipped project
- then run the zipped project by opening that folder in a terminal and running `npm run start`
- in the sample app open the app menu and select a menu item and repeat this step
- no menus should be open from navigating the menu (but the menu button will still work when clicked)

**Included in this Pull Request**:
- [x] A note to the change log.
