### PR TITLE
2793 - Add validation indicator to IdsTab

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Switch]` Added a label position setting that allows positioning the label on either the right or left side of the slider. ([#2579](https://github.com/infor-design/enterprise-wc/issues/2579))
 - `[Themes]` Added a setting `IdsGlobal.themePath` that you can use to set the location of the theme files. ([#2125](https://github.com/infor-design/enterprise-wc/issues/2125))
 - `[Themes]` Added latest round of semantic tokens. ([#2471](https://github.com/infor-design/enterprise-wc/issues/2471))
+- `[Tabs]` Added validation error indicator ([#2793](https://github.com/infor-design/enterprise-wc/issues/2793))
 - `[Validation]` Improved the validation message to prevent it from overflowing the field area. ([#2706](https://github.com/infor-design/enterprise-wc/issues/2706))
 
 ### 1.5.0 Fixes

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.6.0
+
+### 1.6.0 Features
+
+- `[Tabs]` Added validation error indicator ([#2793](https://github.com/infor-design/enterprise-wc/issues/2793))
+
 ## 1.5.1
 
 ### 1.5.1 Features
@@ -30,7 +36,6 @@
 - `[Switch]` Added a label position setting that allows positioning the label on either the right or left side of the slider. ([#2579](https://github.com/infor-design/enterprise-wc/issues/2579))
 - `[Themes]` Added a setting `IdsGlobal.themePath` that you can use to set the location of the theme files. ([#2125](https://github.com/infor-design/enterprise-wc/issues/2125))
 - `[Themes]` Added latest round of semantic tokens. ([#2471](https://github.com/infor-design/enterprise-wc/issues/2471))
-- `[Tabs]` Added validation error indicator ([#2793](https://github.com/infor-design/enterprise-wc/issues/2793))
 - `[Validation]` Improved the validation message to prevent it from overflowing the field area. ([#2706](https://github.com/infor-design/enterprise-wc/issues/2706))
 
 ### 1.5.0 Fixes

--- a/src/components/ids-tabs/README.md
+++ b/src/components/ids-tabs/README.md
@@ -109,6 +109,24 @@ Tabs can be configured to display an optional [IdsTriggerButton](../ids-trigger-
 <ids-tab value="one" dismissible>Example One</dismissible>
 ```
 
+### Validation Errors
+
+When a tab contains a field that has a validation error, an error icon will be displayed on the tab. This is useful in scenarios where all tabs must contain valid data before proceeding (e.g when inside a modal). The error icon can also be manually controlled by setting the `has-error` attribute on the tab. The error icon is slotted and can be replaced or styled as needed.
+
+```html
+<ids-tab value="manual-error" has-error>
+    Manually show error icon
+</ids-tab>
+<ids-tab value="custom-error">
+    Custom error icon
+    <ids-icon slot="error" color="warning" icon="alert" size="small"></ids-icon>
+</ids-tab>
+<ids-tab value="hidden-error">
+    No error icon
+    <template slot="error"></template>
+</ids-tab>
+```
+
 ## Settings and Attributes
 
 ### Tab Container Settings (`ids-tabs`)

--- a/src/components/ids-tabs/README.md
+++ b/src/components/ids-tabs/README.md
@@ -122,6 +122,7 @@ Tabs can be configured to display an optional [IdsTriggerButton](../ids-trigger-
 
 - `actionable` {boolean} labels a tab as having a corresponding action, such as "Add", "Reset", "Activate Application Menu", etc.  Tabs that use this setting should also have an `onAction` callback applied, which will be triggered upon selecting the tab.  Tabs that are `actionable` will not cause content in tab panels to be displayed.
 - `disabled` {boolean} allows you to disable a tab among a set of tabs.
+- `has-error` {boolean} display an error indicator on the tab.
 - `selected` {boolean} allows for a tab to display its selected state.  In some cases, tabs with this value set to true will also automatically display their corresponding Tab Panel's content.  Tabs that have an `actionable` attribute applied are not able to be "selected" -- selecting those tabs will focus them.
 - `value` {string | number} the value which when the parent `ids-tabs` also has an equivalent for, selects this tab.
 

--- a/src/components/ids-tabs/demos/index.yaml
+++ b/src/components/ids-tabs/demos/index.yaml
@@ -35,6 +35,9 @@
   - link: vertical.html
     type: Example
     description: Shows vertical tabs
+  - link: validation.html
+    type: Example
+    description: Shows validation indicator in tabs
   - link: side-by-side.html
     type: Side by Side
     description: Showing a tab element side by side working with 4.x

--- a/src/components/ids-tabs/demos/index.yaml
+++ b/src/components/ids-tabs/demos/index.yaml
@@ -36,7 +36,7 @@
     type: Example
     description: Shows vertical tabs
   - link: validation.html
-    type: Example
+    type: Test
     description: Shows validation indicator in tabs
   - link: side-by-side.html
     type: Side by Side

--- a/src/components/ids-tabs/demos/validation.html
+++ b/src/components/ids-tabs/demos/validation.html
@@ -14,7 +14,7 @@
       <ids-tabs>
         <ids-tab value="with-required">Has Required</ids-tab>
         <ids-tab value="other">Other</ids-tab>
-        <ids-tab value="always-error" validation-has-error>Manual Error</ids-tab>
+        <ids-tab value="always-error" has-error>Manual Error</ids-tab>
       </ids-tabs>
       <ids-tab-content value="with-required">
         <ids-layout-grid auto-fit="true" padding="sm">

--- a/src/components/ids-tabs/demos/validation.html
+++ b/src/components/ids-tabs/demos/validation.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <%= htmlWebpackPlugin.options.font %>
+</head>
+<body>
+  <ids-container role="main" padding="8" hidden>
+    <ids-theme-switcher mode="light"></ids-theme-switcher>
+    <ids-layout-grid auto-fit="true" padding="sm">
+      <ids-text font-size="12" type="h1">Tabs</ids-text>
+    </ids-layout-grid>
+    <ids-tabs-context>
+      <ids-tabs>
+        <ids-tab value="with-required">Has Required</ids-tab>
+        <ids-tab value="other">Other</ids-tab>
+        <ids-tab value="always-error" validation-has-error>Manual Error</ids-tab>
+      </ids-tabs>
+      <ids-tab-content value="with-required">
+        <ids-layout-grid auto-fit="true" padding="sm">
+          <ids-input label="Required Field" validate="required"></ids-input>
+          <ids-input label="Another Required Field" validate="required"></ids-input>
+        </ids-layout-grid>
+      </ids-tab-content>
+      <ids-tab-content value="other">
+        <div class="tab-content">
+          <ids-layout-grid auto-fit="true" padding="sm">
+            <ids-text font-size="16" type="p">
+              Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
+            </ids-text>
+          </ids-layout-grid>
+        </div>
+      </ids-tab-content>
+      <ids-tab-content value="always-error">
+        <div class="tab-content">
+          <ids-layout-grid auto-fit="true" padding="sm">
+            <ids-text font-size="16" type="p">
+              This tab always has an error indicator because of the validation-has-error attribute.
+            </ids-text>
+          </ids-layout-grid>
+        </div>
+      </ids-tab-content>
+    </ids-tabs-context>
+  </ids-container>
+</body>
+</html>

--- a/src/components/ids-tabs/demos/validation.html
+++ b/src/components/ids-tabs/demos/validation.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-  <title><%= htmlWebpackPlugin.options.title %></title>
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
   <%= htmlWebpackPlugin.options.font %>
 </head>
+
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
@@ -15,6 +19,10 @@
             <ids-tab value="with-required">Has Required</ids-tab>
             <ids-tab value="other">Other</ids-tab>
             <ids-tab value="always-error" has-error>Manual Error</ids-tab>
+            <ids-tab value="custom-error" has-error>
+              Custom Error
+              <ids-icon slot="error" color="warning" icon="alert" size="small"></ids-icon>
+            </ids-tab>
           </ids-tabs>
           <ids-tab-content value="with-required">
             <ids-layout-grid auto-fit="true" padding="sm">
@@ -23,22 +31,27 @@
             </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="other">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque
+                vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit
+                doloribus unde veritatis rerum quidem!
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="always-error">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  This tab always has an error indicator because of the validation-has-error attribute.
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                This tab always has an error indicator because of the validation-has-error attribute.
+              </ids-text>
+            </ids-layout-grid>
+          </ids-tab-content>
+          <ids-tab-content value="custom-error">
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                This tab has a custom error icon.
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
         </ids-tabs-context>
       </ids-card>
@@ -58,22 +71,20 @@
             </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="other">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque
+                vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit
+                doloribus unde veritatis rerum quidem!
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="always-error">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  This tab always has an error indicator because of the validation-has-error attribute.
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                This tab always has an error indicator because of the validation-has-error attribute.
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="dismissible">
             <ids-text>This tab is dismissible with an error.</ids-text>
@@ -96,22 +107,20 @@
             </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="other">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque
+                vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit
+                doloribus unde veritatis rerum quidem!
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="always-error">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  This tab always has an error indicator because of the validation-has-error attribute.
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                This tab always has an error indicator because of the validation-has-error attribute.
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="dismissible">
             <ids-text>This tab is dismissible with an error.</ids-text>
@@ -134,22 +143,20 @@
             </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="other">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque
+                vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit
+                doloribus unde veritatis rerum quidem!
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="always-error">
-            <div class="tab-content">
-              <ids-layout-grid auto-fit="true" padding="sm">
-                <ids-text font-size="16" type="p">
-                  This tab always has an error indicator because of the validation-has-error attribute.
-                </ids-text>
-              </ids-layout-grid>
-            </div>
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-text font-size="16" type="p">
+                This tab always has an error indicator because of the validation-has-error attribute.
+              </ids-text>
+            </ids-layout-grid>
           </ids-tab-content>
           <ids-tab-content value="dismissible">
             <ids-text>This tab is dismissible with an error.</ids-text>
@@ -160,4 +167,5 @@
 
   </ids-container>
 </body>
+
 </html>

--- a/src/components/ids-tabs/demos/validation.html
+++ b/src/components/ids-tabs/demos/validation.html
@@ -7,40 +7,157 @@
 <body>
   <ids-container role="main" padding="8" hidden>
     <ids-theme-switcher mode="light"></ids-theme-switcher>
-    <ids-layout-grid auto-fit="true" padding="sm">
+    <ids-layout-grid cols="1" padding="sm">
       <ids-text font-size="12" type="h1">Tabs</ids-text>
+      <ids-card no-header="true">
+        <ids-tabs-context id="normal-tabs" slot="card-content">
+          <ids-tabs>
+            <ids-tab value="with-required">Has Required</ids-tab>
+            <ids-tab value="other">Other</ids-tab>
+            <ids-tab value="always-error" has-error>Manual Error</ids-tab>
+          </ids-tabs>
+          <ids-tab-content value="with-required">
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-input label="Required Field" validate="required"></ids-input>
+              <ids-input label="Another Required Field" validate="required"></ids-input>
+            </ids-layout-grid>
+          </ids-tab-content>
+          <ids-tab-content value="other">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+          <ids-tab-content value="always-error">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  This tab always has an error indicator because of the validation-has-error attribute.
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+        </ids-tabs-context>
+      </ids-card>
+
+      <ids-card no-header="true">
+        <ids-tabs-context id="dismissable-normal-tabs" slot="card-content">
+          <ids-tabs>
+            <ids-tab value="with-required">Has Required</ids-tab>
+            <ids-tab value="other">Other</ids-tab>
+            <ids-tab value="always-error" has-error>Manual Error</ids-tab>
+            <ids-tab value="dismissible" has-error dismissible>Dismissible</ids-tab>
+          </ids-tabs>
+          <ids-tab-content value="with-required">
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-input label="Required Field" validate="required"></ids-input>
+              <ids-input label="Another Required Field" validate="required"></ids-input>
+            </ids-layout-grid>
+          </ids-tab-content>
+          <ids-tab-content value="other">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+          <ids-tab-content value="always-error">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  This tab always has an error indicator because of the validation-has-error attribute.
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+          <ids-tab-content value="dismissible">
+            <ids-text>This tab is dismissible with an error.</ids-text>
+          </ids-tab-content>
+        </ids-tabs-context>
+      </ids-card>
+
+      <ids-card no-header="true">
+        <ids-tabs-context id="module-tabs" slot="card-content">
+          <ids-tabs color-variant="module">
+            <ids-tab value="with-required">Has Required</ids-tab>
+            <ids-tab value="other">Other</ids-tab>
+            <ids-tab value="always-error" has-error>Manual Error</ids-tab>
+            <ids-tab value="dismissible" has-error dismissible>Dismissible</ids-tab>
+          </ids-tabs>
+          <ids-tab-content value="with-required">
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-input label="Required Field" validate="required"></ids-input>
+              <ids-input label="Another Required Field" validate="required"></ids-input>
+            </ids-layout-grid>
+          </ids-tab-content>
+          <ids-tab-content value="other">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+          <ids-tab-content value="always-error">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  This tab always has an error indicator because of the validation-has-error attribute.
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+          <ids-tab-content value="dismissible">
+            <ids-text>This tab is dismissible with an error.</ids-text>
+          </ids-tab-content>
+        </ids-tabs-context>
+      </ids-card>
+
+      <ids-card no-header="true">
+        <ids-tabs-context id="count-tabs" slot="card-content">
+          <ids-tabs>
+            <ids-tab value="with-required" count="1">Has Required</ids-tab>
+            <ids-tab value="other" count="2">Other</ids-tab>
+            <ids-tab value="always-error" count="3" has-error>Manual Error</ids-tab>
+            <ids-tab value="dismissible" count="3" has-error dismissible>Dismissible</ids-tab>
+          </ids-tabs>
+          <ids-tab-content value="with-required">
+            <ids-layout-grid auto-fit="true" padding="sm">
+              <ids-input label="Required Field" validate="required"></ids-input>
+              <ids-input label="Another Required Field" validate="required"></ids-input>
+            </ids-layout-grid>
+          </ids-tab-content>
+          <ids-tab-content value="other">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+          <ids-tab-content value="always-error">
+            <div class="tab-content">
+              <ids-layout-grid auto-fit="true" padding="sm">
+                <ids-text font-size="16" type="p">
+                  This tab always has an error indicator because of the validation-has-error attribute.
+                </ids-text>
+              </ids-layout-grid>
+            </div>
+          </ids-tab-content>
+          <ids-tab-content value="dismissible">
+            <ids-text>This tab is dismissible with an error.</ids-text>
+          </ids-tab-content>
+        </ids-tabs-context>
+      </ids-card>
     </ids-layout-grid>
-    <ids-tabs-context>
-      <ids-tabs>
-        <ids-tab value="with-required">Has Required</ids-tab>
-        <ids-tab value="other">Other</ids-tab>
-        <ids-tab value="always-error" has-error>Manual Error</ids-tab>
-      </ids-tabs>
-      <ids-tab-content value="with-required">
-        <ids-layout-grid auto-fit="true" padding="sm">
-          <ids-input label="Required Field" validate="required"></ids-input>
-          <ids-input label="Another Required Field" validate="required"></ids-input>
-        </ids-layout-grid>
-      </ids-tab-content>
-      <ids-tab-content value="other">
-        <div class="tab-content">
-          <ids-layout-grid auto-fit="true" padding="sm">
-            <ids-text font-size="16" type="p">
-              Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed unde laboriosam veniam. Perferendis neque vero mollitia harum delectus, perspiciatis ratione ducimus reprehenderit voluptatibus aspernatur, velit doloribus unde veritatis rerum quidem!
-            </ids-text>
-          </ids-layout-grid>
-        </div>
-      </ids-tab-content>
-      <ids-tab-content value="always-error">
-        <div class="tab-content">
-          <ids-layout-grid auto-fit="true" padding="sm">
-            <ids-text font-size="16" type="p">
-              This tab always has an error indicator because of the validation-has-error attribute.
-            </ids-text>
-          </ids-layout-grid>
-        </div>
-      </ids-tab-content>
-    </ids-tabs-context>
+
   </ids-container>
 </body>
 </html>

--- a/src/components/ids-tabs/demos/validation.ts
+++ b/src/components/ids-tabs/demos/validation.ts
@@ -1,0 +1,3 @@
+import '../../ids-text/ids-text';
+import '../ids-tabs';
+import '../../ids-input/ids-input';

--- a/src/components/ids-tabs/demos/validation.ts
+++ b/src/components/ids-tabs/demos/validation.ts
@@ -1,3 +1,4 @@
 import '../../ids-text/ids-text';
 import '../ids-tabs';
 import '../../ids-input/ids-input';
+import '../../ids-card/ids-card';

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -59,12 +59,6 @@ $ids-tab-vertical-height: 42px;
   display: block;
 }
 
-:host([count]) {
-  ::slotted(ids-trigger-button) {
-    padding-inline-start: var(--ids-space-xs);
-  }
-}
-
 // =================================================
 // Default Variant
 // =================================================
@@ -99,6 +93,8 @@ $ids-tab-vertical-height: 42px;
 .ids-tab {
   display: flex;
   position: relative;
+  align-items: center;
+  gap: var(--ids-space-2xs);
   color: var(--ids-tab-color-text-default);
   box-sizing: border-box;
   height: 100%;

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -92,7 +92,7 @@ $ids-tab-vertical-height: 42px;
   outline: none;
 }
 
-:host(ids-tab:not([validation-has-error])) .ids-tab-error-icon {
+:host(ids-tab:not([has-error])) .ids-tab-error-icon {
   display: none;
 }
 

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -92,6 +92,10 @@ $ids-tab-vertical-height: 42px;
   outline: none;
 }
 
+:host(ids-tab:not([validation-has-error])) .ids-tab-error-icon {
+  display: none;
+}
+
 .ids-tab {
   display: flex;
   position: relative;

--- a/src/components/ids-tabs/ids-tab.scss
+++ b/src/components/ids-tabs/ids-tab.scss
@@ -92,7 +92,7 @@ $ids-tab-vertical-height: 42px;
   outline: none;
 }
 
-:host(ids-tab:not([has-error])) .ids-tab-error-icon {
+:host(ids-tab:not([has-error])) slot[name='error'] {
   display: none;
 }
 

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -9,6 +9,8 @@ import IdsHideFocusMixin from '../../mixins/ids-hide-focus-mixin/ids-hide-focus-
 import IdsElement from '../../core/ids-element';
 
 import '../ids-text/ids-text';
+import '../ids-trigger-field/ids-trigger-button';
+import '../ids-icon/ids-icon';
 
 import styles from './ids-tab.scss';
 import type IdsText from '../ids-text/ids-text';

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -82,7 +82,7 @@ export default class IdsTab extends Base {
    * @returns {string} the template to render
    */
   template(): string {
-    const hasIcon = this.querySelector('ids-icon');
+    const hasIcon = this.querySelector('ids-icon:not([slot="error"])');
     const hasCount = this.hasAttribute(attributes.COUNT);
     const cssClassAttr = buildClassAttrib(
       'ids-tab',
@@ -110,7 +110,9 @@ export default class IdsTab extends Base {
 
     return `<div ${cssClassAttr} tabindex="-1" part="container">
       ${innerContent}
-      <ids-icon icon="error" color="error" size="small" class="ids-tab-error-icon"></ids-icon>
+      <slot name="error">
+        <ids-icon icon="error" color="error" size="small"></ids-icon>
+      </slot>
       <div class="ids-tab-trigger-container">
         <slot name="close"></slot>
       </div>

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -60,7 +60,7 @@ export default class IdsTab extends Base {
       attributes.DISABLED,
       attributes.SELECTED,
       attributes.VALUE,
-      attributes.VALIDATION_HAS_ERROR,
+      attributes.HAS_ERROR,
     ];
   }
 
@@ -307,19 +307,17 @@ export default class IdsTab extends Base {
     });
   }
 
-  set validationHasError(value: boolean | string) {
+  set hasError(value: boolean | string) {
     const val = stringToBool(value);
     if (val) {
-      this.setAttribute(attributes.VALIDATION_HAS_ERROR, val.toString());
-      this.container?.classList.add(attributes.VALIDATION_HAS_ERROR);
+      this.setAttribute(attributes.HAS_ERROR, val.toString());
     } else {
-      this.removeAttribute(attributes.VALIDATION_HAS_ERROR);
-      this.container?.classList.remove(attributes.VALIDATION_HAS_ERROR);
+      this.removeAttribute(attributes.HAS_ERROR);
     }
   }
 
-  get validationHasError(): boolean {
-    return stringToBool(this.getAttribute(attributes.VALIDATION_HAS_ERROR));
+  get hasError(): boolean {
+    return stringToBool(this.getAttribute(attributes.HAS_ERROR));
   }
 
   /** @returns {string} value The number of items represented in the tab (may or may not apply) */

--- a/src/components/ids-tabs/ids-tab.ts
+++ b/src/components/ids-tabs/ids-tab.ts
@@ -59,7 +59,8 @@ export default class IdsTab extends Base {
       attributes.DISMISSIBLE,
       attributes.DISABLED,
       attributes.SELECTED,
-      attributes.VALUE
+      attributes.VALUE,
+      attributes.VALIDATION_HAS_ERROR,
     ];
   }
 
@@ -109,6 +110,7 @@ export default class IdsTab extends Base {
 
     return `<div ${cssClassAttr} tabindex="-1" part="container">
       ${innerContent}
+      <ids-icon icon="error" color="error" size="small" class="ids-tab-error-icon"></ids-icon>
       <div class="ids-tab-trigger-container">
         <slot name="close"></slot>
       </div>
@@ -303,6 +305,21 @@ export default class IdsTab extends Base {
       bubbles: true,
       detail: { value: `${value}` }
     });
+  }
+
+  set validationHasError(value: boolean | string) {
+    const val = stringToBool(value);
+    if (val) {
+      this.setAttribute(attributes.VALIDATION_HAS_ERROR, val.toString());
+      this.container?.classList.add(attributes.VALIDATION_HAS_ERROR);
+    } else {
+      this.removeAttribute(attributes.VALIDATION_HAS_ERROR);
+      this.container?.classList.remove(attributes.VALIDATION_HAS_ERROR);
+    }
+  }
+
+  get validationHasError(): boolean {
+    return stringToBool(this.getAttribute(attributes.VALIDATION_HAS_ERROR));
   }
 
   /** @returns {string} value The number of items represented in the tab (may or may not apply) */

--- a/src/components/ids-tabs/ids-tabs-context.ts
+++ b/src/components/ids-tabs/ids-tabs-context.ts
@@ -13,7 +13,7 @@ import styles from './ids-tabs-context.scss';
 import type IdsTabContent from './ids-tab-content';
 import type IdsTabs from './ids-tabs';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
-import type { IdsValidateEvent, IdsValidatedElement } from '../../mixins/ids-validation-mixin/ids-validation-mixin';
+import { isIdsValidatedElement, type IdsValidateEvent } from '../../mixins/ids-validation-mixin/ids-validation-mixin';
 
 const Base = IdsOrientationMixin(
   IdsEventsMixin(
@@ -64,9 +64,8 @@ export default class IdsTabsContext extends Base {
       if (!tab) {
         return;
       }
-      const validatedElements = content.querySelectorAll<IdsValidatedElement>('[validate]');
-      const valid = [...validatedElements].every((el) => el.isValid);
-      tab.hasError = !valid;
+      const validatedElements = [...content.querySelectorAll('[validate]')].filter(isIdsValidatedElement);
+      tab.hasError = validatedElements.some((el) => !el.isValid);
     });
 
     this.#afterConnectedCallback();

--- a/src/components/ids-tabs/ids-tabs-context.ts
+++ b/src/components/ids-tabs/ids-tabs-context.ts
@@ -12,8 +12,8 @@ import styles from './ids-tabs-context.scss';
 
 import type IdsTabContent from './ids-tab-content';
 import type IdsTabs from './ids-tabs';
-import type IdsTab from './ids-tab';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
+import type { IdsValidateEvent, IdsValidatedElement } from '../../mixins/ids-validation-mixin/ids-validation-mixin';
 
 const Base = IdsOrientationMixin(
   IdsEventsMixin(
@@ -55,18 +55,18 @@ export default class IdsTabsContext extends Base {
       this.#changeContentPane(this.value, this.value);
     });
 
-    this.onEvent('validate', this, () => {
-      this.querySelectorAll<IdsTabContent>('ids-tab-content').forEach((content) => {
-        // TODO: Figure out how to extract the type from the mixin
-        type ValidationMixinElement = HTMLElement & { isValid: boolean };
-
-        const tab = this.tabList?.querySelector<IdsTab>(`ids-tab[value="${content.value}"]`);
-        if (tab) {
-          const validated = content.querySelectorAll<ValidationMixinElement>('[validate]');
-          const valid = [...validated].every((el) => el.isValid);
-          tab.validationHasError = !valid;
-        }
-      });
+    this.onEvent('validate', this, (e: IdsValidateEvent) => {
+      const content = e.detail.elem?.closest<IdsTabContent>('ids-tab-content');
+      if (!content) {
+        return;
+      }
+      const tab = this.tabList?.tabs.find(({ value }) => value === content.value);
+      if (!tab) {
+        return;
+      }
+      const validatedElements = content.querySelectorAll<IdsValidatedElement>('[validate]');
+      const valid = [...validatedElements].every((el) => el.isValid);
+      tab.hasError = !valid;
     });
 
     this.#afterConnectedCallback();

--- a/src/components/ids-tabs/ids-tabs-context.ts
+++ b/src/components/ids-tabs/ids-tabs-context.ts
@@ -12,6 +12,7 @@ import styles from './ids-tabs-context.scss';
 
 import type IdsTabContent from './ids-tab-content';
 import type IdsTabs from './ids-tabs';
+import type IdsTab from './ids-tab';
 import { stringToBool } from '../../utils/ids-string-utils/ids-string-utils';
 
 const Base = IdsOrientationMixin(
@@ -52,6 +53,20 @@ export default class IdsTabsContext extends Base {
     // Set active pane when content is inserted dynamically
     this.onEvent('slotchange', this.container, () => {
       this.#changeContentPane(this.value, this.value);
+    });
+
+    this.onEvent('validate', this, () => {
+      this.querySelectorAll<IdsTabContent>('ids-tab-content').forEach((content) => {
+        // TODO: Figure out how to extract the type from the mixin
+        type ValidationMixinElement = HTMLElement & { isValid: boolean };
+
+        const tab = this.tabList?.querySelector<IdsTab>(`ids-tab[value="${content.value}"]`);
+        if (tab) {
+          const validated = content.querySelectorAll<ValidationMixinElement>('[validate]');
+          const valid = [...validated].every((el) => el.isValid);
+          tab.validationHasError = !valid;
+        }
+      });
     });
 
     this.#afterConnectedCallback();

--- a/src/components/ids-tabs/ids-tabs.ts
+++ b/src/components/ids-tabs/ids-tabs.ts
@@ -175,6 +175,10 @@ export default class IdsTabs extends Base {
     return [...this.querySelectorAll<IdsTab>('ids-tab')].pop();
   }
 
+  get tabs(): IdsTab[] {
+    return [...this.querySelectorAll<IdsTab>('ids-tab')];
+  }
+
   /**
    * @readonly
    * @returns {any} [IdsTab | null] The last possible tab with a usable value in the list

--- a/src/core/ids-attributes.ts
+++ b/src/core/ids-attributes.ts
@@ -216,6 +216,7 @@ export const attributes = {
   GROUPED: 'grouped',
   GROW: 'grow',
   HANDLE: 'handle',
+  HAS_ERROR: 'has-error',
   HEADER_MENU_ID: 'header-menu-id',
   HEIGHT: 'height',
   HEX: 'hex',

--- a/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
+++ b/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
@@ -51,6 +51,17 @@ export type IdsValidateEvent = CustomEvent<{
  */
 export type IdsValidatedElement = InstanceType<ReturnType<typeof IdsValidationMixin>>;
 
+/**
+ * Check whether an element has the {@link IdsValidationMixin} applied.
+ * @param {Element} element The element to check.
+ * @returns {boolean} `true` if the element has the mixin.
+ */
+export function isIdsValidatedElement(element: Element): element is IdsValidatedElement {
+  // Note: Could introduce a Symbol or similar instead.
+  return typeof (element as IdsValidatedElement)?.checkValidation === 'function'
+  && typeof (element as IdsValidatedElement)?.validate === 'string';
+}
+
 type Constraints = IdsConstructor<EventsMixinInterface>;
 
 /**

--- a/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
+++ b/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
@@ -206,7 +206,6 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
     const checkRules = (input: any) => {
       this.isTypeNotValid = {};
       let isValid = true;
-      const wasValid = this.isValid;
       const useRules = this.useRules.get(input);
       useRules?.forEach((thisRule: any) => {
         if (thisRule.rule !== undefined && !thisRule.rule?.check(input, this.rules) && this.isTypeNotValid) {
@@ -222,9 +221,7 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
         }
       });
       this.isTypeNotValid = null;
-      if (isValid !== wasValid) { // Only trigger if the state has changed, for performance.
-        this.#triggerValidateEvent(isValid);
-      }
+      this.#triggerValidateEvent(isValid);
     };
 
     if ((this as IdsInputInterface).input) {

--- a/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
+++ b/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
@@ -184,6 +184,7 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
     const checkRules = (input: any) => {
       this.isTypeNotValid = {};
       let isValid = true;
+      const wasValid = this.isValid;
       const useRules = this.useRules.get(input);
       useRules?.forEach((thisRule: any) => {
         if (thisRule.rule !== undefined && !thisRule.rule?.check(input, this.rules) && this.isTypeNotValid) {
@@ -199,7 +200,9 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
         }
       });
       this.isTypeNotValid = null;
-      this.triggerEvent('validate', this, { detail: { elem: this, value: (this as IdsInputInterface).value, isValid } });
+      if (isValid !== wasValid) { // Only trigger if the state has changed, for performance.
+        this.#triggerValidateEvent(isValid);
+      }
     };
 
     if ((this as IdsInputInterface).input) {
@@ -561,6 +564,17 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
     if ((this as IdsInputInterface).input) {
       destroy((this as IdsInputInterface).input);
     }
+  }
+
+  #triggerValidateEvent(isValid: boolean) {
+    this.triggerEvent('validate', this, {
+      detail: {
+        elem: this,
+        value: (this as IdsInputInterface).value,
+        isValid,
+      },
+      bubbles: true,
+    });
   }
 
   /**

--- a/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
+++ b/src/mixins/ids-validation-mixin/ids-validation-mixin.ts
@@ -40,6 +40,17 @@ export type IdsValidationRule = {
   check: (input: any) => boolean;
 };
 
+export type IdsValidateEvent = CustomEvent<{
+  elem: IdsValidatedElement;
+  value?: unknown;
+  isValid: boolean;
+}>;
+
+/**
+ * Represents an instance that has the {@link IdsValidationMixin} applied.
+ */
+export type IdsValidatedElement = InstanceType<ReturnType<typeof IdsValidationMixin>>;
+
 type Constraints = IdsConstructor<EventsMixinInterface>;
 
 /**
@@ -572,7 +583,7 @@ const IdsValidationMixin = <T extends Constraints>(superclass: T) => class exten
         elem: this,
         value: (this as IdsInputInterface).value,
         isValid,
-      },
+      } satisfies IdsValidateEvent['detail'],
       bubbles: true,
     });
   }

--- a/tests/ids-tabs/ids-tabs.spec.ts
+++ b/tests/ids-tabs/ids-tabs.spec.ts
@@ -205,7 +205,7 @@ test.describe('IdsTabs tests', () => {
 
     test('should not be visible by default', async ({ page }) => {
       const tab = await page.locator('ids-tab[value="with-required"]');
-      await expect(tab).not.toHaveAttribute('validation-has-error', /.*/);
+      await expect(tab).not.toHaveAttribute('has-error', /.*/);
       await expect(tab.locator('ids-icon[icon="error"]')).not.toBeVisible();
     });
 
@@ -217,7 +217,7 @@ test.describe('IdsTabs tests', () => {
       await firstInput.evaluate((el: IdsInput) => { el.value = 'hello'; });
       await firstInput.evaluate((el: IdsInput) => { el.value = ''; });
 
-      await expect(tab).toHaveAttribute('validation-has-error', 'true');
+      await expect(tab).toHaveAttribute('has-error', 'true');
       await expect(tab.locator('ids-icon[icon="error"]')).toBeVisible();
     });
   });

--- a/tests/ids-tabs/ids-tabs.spec.ts
+++ b/tests/ids-tabs/ids-tabs.spec.ts
@@ -6,6 +6,7 @@ import { test } from '../base-fixture';
 import IdsTabs from '../../src/components/ids-tabs/ids-tabs';
 import IdsTab from '../../src/components/ids-tabs/ids-tab';
 import IdsTabContent from '../../src/components/ids-tabs/ids-tab-content';
+import IdsInput from '../../src/components/ids-input/ids-input';
 
 test.describe('IdsTabs tests', () => {
   const url = '/ids-tabs/example.html';
@@ -194,6 +195,30 @@ test.describe('IdsTabs tests', () => {
       const tab = await page.locator('ids-tab').first();
       await page.getByLabel('Contracts').click();
       await expect(tab).toHaveAttribute('selected');
+    });
+  });
+
+  test.describe('validation indicator', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/ids-tabs/validation.html');
+    });
+
+    test('should not be visible by default', async ({ page }) => {
+      const tab = await page.locator('ids-tab[value="with-required"]');
+      await expect(tab).not.toHaveAttribute('validation-has-error', /.*/);
+      await expect(tab.locator('ids-icon[icon="error"]')).not.toBeVisible();
+    });
+
+    test('should be visible when there is a validation error', async ({ page }) => {
+      const tab = page.locator('ids-tab[value="with-required"]');
+      const tabContent = page.locator('ids-tab-content[value="with-required"]');
+      const firstInput = tabContent.locator('ids-input').first();
+
+      await firstInput.evaluate((el: IdsInput) => { el.value = 'hello'; });
+      await firstInput.evaluate((el: IdsInput) => { el.value = ''; });
+
+      await expect(tab).toHaveAttribute('validation-has-error', 'true');
+      await expect(tab.locator('ids-icon[icon="error"]')).toBeVisible();
     });
   });
 });

--- a/tests/ids-tabs/ids-tabs.spec.ts
+++ b/tests/ids-tabs/ids-tabs.spec.ts
@@ -204,21 +204,29 @@ test.describe('IdsTabs tests', () => {
     });
 
     test('should not be visible by default', async ({ page }) => {
-      const tab = await page.locator('ids-tab[value="with-required"]');
-      await expect(tab).not.toHaveAttribute('has-error', /.*/);
-      await expect(tab.locator('ids-icon[icon="error"]')).not.toBeVisible();
+      const contexts = await page.locator('ids-tabs-context').all();
+      for (const context of contexts) {
+        const tab = context.locator('ids-tab[value="with-required"]');
+        await expect(tab).not.toHaveAttribute('has-error', /.*/);
+        await expect(tab.locator('ids-icon[icon="error"]')).not.toBeVisible();
+      }
     });
 
-    test('should be visible when there is a validation error', async ({ page }) => {
-      const tab = page.locator('ids-tab[value="with-required"]');
-      const tabContent = page.locator('ids-tab-content[value="with-required"]');
-      const firstInput = tabContent.locator('ids-input').first();
+    test('should only be visible when there is a validation error', async ({ page }) => {
+      const contexts = await page.locator('ids-tabs-context').all();
+      for (const context of contexts) {
+        const tab = context.locator('ids-tab[value="with-required"]');
+        const content = context.locator('ids-tab-content[value="with-required"]');
+        const input = content.locator('ids-input').first();
+        const icon = tab.locator('ids-icon[icon="error"]');
 
-      await firstInput.evaluate((el: IdsInput) => { el.value = 'hello'; });
-      await firstInput.evaluate((el: IdsInput) => { el.value = ''; });
+        await input.evaluate((el: IdsInput) => { el.value = 'hello'; });
+        await input.evaluate((el: IdsInput) => { el.value = ''; });
+        await expect(icon).toBeVisible();
 
-      await expect(tab).toHaveAttribute('has-error', 'true');
-      await expect(tab.locator('ids-icon[icon="error"]')).toBeVisible();
+        await input.evaluate((el: IdsInput) => { el.value = 'hello'; });
+        await expect(icon).not.toBeVisible();
+      }
     });
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Adds an error indicator to IdsTab when its' IdsTabContent contains an invalid input. 

**Related github/jira issue (required)**: Fixes #2793

**Summary:**
- Adds an `error` slot to IdsTab for customization (custom icon, tooltips, legacy IDS compat etc)
- Adds a `has-error` attribute to IdsTab which can be used to display the slotted `error`.
- Show the error in the tab title when there is a validation error inside the tab content.
- The IdsValidateMixin's `validate` event now bubbles, and has stronger typings.

**Related fixes:**
- Adds missing imports in IdsTab (icon & dismiss button)
- Fix vertical alignment of dismiss button

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/b65be87d-fa6b-46e0-9728-799416dd2905">


**Steps necessary to review your pull request (required)**:

- Check out the branch
- `npm start`
- Go to http://localhost:4300/ids-tabs/validation.html
- Go to every test/sample page that contains either form validation or tabs, and make sure they still work.

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A test for the bug or feature.
- [x] A note to the change log.
