### PR TITLE
4575 - Rename datavis-color to color-datavis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "html-loader": "^5.1.0",
         "html-webpack-plugin": "^5.6.0",
         "htmlhint": "^1.1.4",
-        "ids-foundation": "1.1.0",
+        "ids-foundation": "1.1.1",
         "loglevel": "^1.9.2",
         "mini-css-extract-plugin": "^2.9.1",
         "nyc": "^17.0.0",
@@ -8828,9 +8828,9 @@
       }
     },
     "node_modules/ids-foundation": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ids-foundation/-/ids-foundation-1.1.0.tgz",
-      "integrity": "sha512-B69no7fJFPnw5FBY9h4H/zpC2mP9G1XG0IPB4RSDFUTNKTw9n90nCYNzqOEQDayRb3XX8vUNDEMH3508xublfA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ids-foundation/-/ids-foundation-1.1.1.tgz",
+      "integrity": "sha512-+F/lAaYQckKcYffcHMAzOc3qwHmqBuWpBAp5M0fb4Lgv8c9xvPtNs0R6MVlbKobJbBCYm3Uaq8m9W9xj+lxzOA==",
       "dev": true
     },
     "node_modules/ignore": {
@@ -23277,9 +23277,9 @@
       "requires": {}
     },
     "ids-foundation": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ids-foundation/-/ids-foundation-1.1.0.tgz",
-      "integrity": "sha512-B69no7fJFPnw5FBY9h4H/zpC2mP9G1XG0IPB4RSDFUTNKTw9n90nCYNzqOEQDayRb3XX8vUNDEMH3508xublfA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ids-foundation/-/ids-foundation-1.1.1.tgz",
+      "integrity": "sha512-+F/lAaYQckKcYffcHMAzOc3qwHmqBuWpBAp5M0fb4Lgv8c9xvPtNs0R6MVlbKobJbBCYm3Uaq8m9W9xj+lxzOA==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "html-loader": "^5.1.0",
     "html-webpack-plugin": "^5.6.0",
     "htmlhint": "^1.1.4",
-    "ids-foundation": "1.1.0",
+    "ids-foundation": "1.1.1",
     "loglevel": "^1.9.2",
     "mini-css-extract-plugin": "^2.9.1",
     "nyc": "^17.0.0",

--- a/src/assets/data/themeData/ids-theme-default-core.json
+++ b/src/assets/data/themeData/ids-theme-default-core.json
@@ -10485,11 +10485,11 @@
     {
       "id": "id-1725374355204-3583",
       "tokenName": "--ids-chart-color-accent-01",
-      "tokenValue": "var(--ids-dataviz-color-sequential-01)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-01)",
       "children": [
         {
           "id": "id-1725374355204-3580",
-          "tokenName": "--ids-dataviz-color-sequential-01",
+          "tokenName": "--ids-color-dataviz-sequential-01",
           "tokenValue": "var(--ids-color-blue-80)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10508,7 +10508,7 @@
             }
           ],
           "colorValue": "#0054b1",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-01)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-01)"
         }
       ],
       "type": "Component",
@@ -10519,11 +10519,11 @@
     {
       "id": "id-1725374355204-3587",
       "tokenName": "--ids-chart-color-accent-02",
-      "tokenValue": "var(--ids-dataviz-color-sequential-02)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-02)",
       "children": [
         {
           "id": "id-1725374355204-3584",
-          "tokenName": "--ids-dataviz-color-sequential-02",
+          "tokenName": "--ids-color-dataviz-sequential-02",
           "tokenValue": "var(--ids-color-teal-60)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10542,7 +10542,7 @@
             }
           ],
           "colorValue": "#40bdbe",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-02)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-02)"
         }
       ],
       "type": "Component",
@@ -10553,11 +10553,11 @@
     {
       "id": "id-1725374355204-3591",
       "tokenName": "--ids-chart-color-accent-03",
-      "tokenValue": "var(--ids-dataviz-color-sequential-03)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-03)",
       "children": [
         {
           "id": "id-1725374355204-3588",
-          "tokenName": "--ids-dataviz-color-sequential-03",
+          "tokenName": "--ids-color-dataviz-sequential-03",
           "tokenValue": "var(--ids-color-purple-60)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10576,7 +10576,7 @@
             }
           ],
           "colorValue": "#7928e1",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-03)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-03)"
         }
       ],
       "type": "Component",
@@ -10587,11 +10587,11 @@
     {
       "id": "id-1725374355204-3595",
       "tokenName": "--ids-chart-color-accent-04",
-      "tokenValue": "var(--ids-dataviz-color-sequential-04)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-04)",
       "children": [
         {
           "id": "id-1725374355204-3592",
-          "tokenName": "--ids-dataviz-color-sequential-04",
+          "tokenName": "--ids-color-dataviz-sequential-04",
           "tokenValue": "var(--ids-color-neutral-40)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10610,7 +10610,7 @@
             }
           ],
           "colorValue": "#bbbbbf",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-04)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-04)"
         }
       ],
       "type": "Component",
@@ -10621,11 +10621,11 @@
     {
       "id": "id-1725374355204-3599",
       "tokenName": "--ids-chart-color-accent-05",
-      "tokenValue": "var(--ids-dataviz-color-sequential-05)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-05)",
       "children": [
         {
           "id": "id-1725374355204-3596",
-          "tokenName": "--ids-dataviz-color-sequential-05",
+          "tokenName": "--ids-color-dataviz-sequential-05",
           "tokenValue": "var(--ids-color-orange-30)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10644,7 +10644,7 @@
             }
           ],
           "colorValue": "#fcc888",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-05)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-05)"
         }
       ],
       "type": "Component",
@@ -10655,11 +10655,11 @@
     {
       "id": "id-1725374355204-3603",
       "tokenName": "--ids-chart-color-accent-06",
-      "tokenValue": "var(--ids-dataviz-color-sequential-06)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-06)",
       "children": [
         {
           "id": "id-1725374355204-3600",
-          "tokenName": "--ids-dataviz-color-sequential-06",
+          "tokenName": "--ids-color-dataviz-sequential-06",
           "tokenValue": "var(--ids-color-orange-70)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10678,7 +10678,7 @@
             }
           ],
           "colorValue": "#df6f00",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-06)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-06)"
         }
       ],
       "type": "Component",
@@ -10689,11 +10689,11 @@
     {
       "id": "id-1725374355204-3607",
       "tokenName": "--ids-chart-color-accent-07",
-      "tokenValue": "var(--ids-dataviz-color-sequential-07)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-07)",
       "children": [
         {
           "id": "id-1725374355204-3604",
-          "tokenName": "--ids-dataviz-color-sequential-07",
+          "tokenName": "--ids-color-dataviz-sequential-07",
           "tokenValue": "var(--ids-color-green-80)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10712,7 +10712,7 @@
             }
           ],
           "colorValue": "#1f9254",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-07)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-07)"
         }
       ],
       "type": "Component",
@@ -10723,11 +10723,11 @@
     {
       "id": "id-1725374355204-3611",
       "tokenName": "--ids-chart-color-accent-08",
-      "tokenValue": "var(--ids-dataviz-color-sequential-08)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-08)",
       "children": [
         {
           "id": "id-1725374355204-3608",
-          "tokenName": "--ids-dataviz-color-sequential-08",
+          "tokenName": "--ids-color-dataviz-sequential-08",
           "tokenValue": "var(--ids-color-blue-30)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10746,7 +10746,7 @@
             }
           ],
           "colorValue": "#8abff7",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-08)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-08)"
         }
       ],
       "type": "Component",
@@ -10757,11 +10757,11 @@
     {
       "id": "id-1725374355204-3615",
       "tokenName": "--ids-chart-color-accent-09",
-      "tokenValue": "var(--ids-dataviz-color-sequential-09)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-09)",
       "children": [
         {
           "id": "id-1725374355204-3612",
-          "tokenName": "--ids-dataviz-color-sequential-09",
+          "tokenName": "--ids-color-dataviz-sequential-09",
           "tokenValue": "var(--ids-color-red-80)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10780,7 +10780,7 @@
             }
           ],
           "colorValue": "#a30d11",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-09)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-09)"
         }
       ],
       "type": "Component",
@@ -10791,11 +10791,11 @@
     {
       "id": "id-1725374355204-3619",
       "tokenName": "--ids-chart-color-accent-10",
-      "tokenValue": "var(--ids-dataviz-color-sequential-10)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-10)",
       "children": [
         {
           "id": "id-1725374355204-3616",
-          "tokenName": "--ids-dataviz-color-sequential-10",
+          "tokenName": "--ids-color-dataviz-sequential-10",
           "tokenValue": "var(--ids-color-neutral-20)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10814,7 +10814,7 @@
             }
           ],
           "colorValue": "#e0e0e1",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-10)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-10)"
         }
       ],
       "type": "Component",
@@ -10825,11 +10825,11 @@
     {
       "id": "id-1725374355204-3623",
       "tokenName": "--ids-chart-color-accent-11",
-      "tokenValue": "var(--ids-dataviz-color-sequential-11)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-11)",
       "children": [
         {
           "id": "id-1725374355204-3620",
-          "tokenName": "--ids-dataviz-color-sequential-11",
+          "tokenName": "--ids-color-dataviz-sequential-11",
           "tokenValue": "var(--ids-color-teal-60)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10848,7 +10848,7 @@
             }
           ],
           "colorValue": "#40bdbe",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-11)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-11)"
         }
       ],
       "type": "Component",
@@ -10859,11 +10859,11 @@
     {
       "id": "id-1725374355204-3627",
       "tokenName": "--ids-chart-color-accent-12",
-      "tokenValue": "var(--ids-dataviz-color-sequential-12)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-12)",
       "children": [
         {
           "id": "id-1725374355204-3624",
-          "tokenName": "--ids-dataviz-color-sequential-12",
+          "tokenName": "--ids-color-dataviz-sequential-12",
           "tokenValue": "var(--ids-color-orange-90)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10882,7 +10882,7 @@
             }
           ],
           "colorValue": "#bb5500",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-12)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-12)"
         }
       ],
       "type": "Component",
@@ -10893,11 +10893,11 @@
     {
       "id": "id-1725374355204-3631",
       "tokenName": "--ids-chart-color-accent-13",
-      "tokenValue": "var(--ids-dataviz-color-sequential-13)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-13)",
       "children": [
         {
           "id": "id-1725374355204-3628",
-          "tokenName": "--ids-dataviz-color-sequential-13",
+          "tokenName": "--ids-color-dataviz-sequential-13",
           "tokenValue": "var(--ids-color-purple-30)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10916,7 +10916,7 @@
             }
           ],
           "colorValue": "#c2a1f1",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-13)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-13)"
         }
       ],
       "type": "Component",
@@ -10927,11 +10927,11 @@
     {
       "id": "id-1725374355204-3635",
       "tokenName": "--ids-chart-color-accent-14",
-      "tokenValue": "var(--ids-dataviz-color-sequential-14)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-14)",
       "children": [
         {
           "id": "id-1725374355204-3632",
-          "tokenName": "--ids-dataviz-color-sequential-14",
+          "tokenName": "--ids-color-dataviz-sequential-14",
           "tokenValue": "var(--ids-color-blue-60)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10950,7 +10950,7 @@
             }
           ],
           "colorValue": "#0072ed",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-14)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-14)"
         }
       ],
       "type": "Component",
@@ -10961,11 +10961,11 @@
     {
       "id": "id-1725374355204-3639",
       "tokenName": "--ids-chart-color-accent-15",
-      "tokenValue": "var(--ids-dataviz-color-sequential-15)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-15)",
       "children": [
         {
           "id": "id-1725374355204-3636",
-          "tokenName": "--ids-dataviz-color-sequential-15",
+          "tokenName": "--ids-color-dataviz-sequential-15",
           "tokenValue": "var(--ids-color-red-30)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -10984,7 +10984,7 @@
             }
           ],
           "colorValue": "#ee9496",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-15)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-15)"
         }
       ],
       "type": "Component",
@@ -10995,11 +10995,11 @@
     {
       "id": "id-1725374355204-3643",
       "tokenName": "--ids-chart-color-accent-16",
-      "tokenValue": "var(--ids-dataviz-color-sequential-16)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-16)",
       "children": [
         {
           "id": "id-1725374355204-3640",
-          "tokenName": "--ids-dataviz-color-sequential-16",
+          "tokenName": "--ids-color-dataviz-sequential-16",
           "tokenValue": "var(--ids-color-purple-80)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -11018,7 +11018,7 @@
             }
           ],
           "colorValue": "#591da8",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-16)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-16)"
         }
       ],
       "type": "Component",
@@ -11029,11 +11029,11 @@
     {
       "id": "id-1725374355204-3647",
       "tokenName": "--ids-chart-color-accent-17",
-      "tokenValue": "var(--ids-dataviz-color-sequential-17)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-17)",
       "children": [
         {
           "id": "id-1725374355204-3644",
-          "tokenName": "--ids-dataviz-color-sequential-17",
+          "tokenName": "--ids-color-dataviz-sequential-17",
           "tokenValue": "var(--ids-color-green-30)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -11052,7 +11052,7 @@
             }
           ],
           "colorValue": "#a1e4bf",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-17)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-17)"
         }
       ],
       "type": "Component",
@@ -11063,11 +11063,11 @@
     {
       "id": "id-1725374355204-3651",
       "tokenName": "--ids-chart-color-accent-18",
-      "tokenValue": "var(--ids-dataviz-color-sequential-18)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-18)",
       "children": [
         {
           "id": "id-1725374355204-3648",
-          "tokenName": "--ids-dataviz-color-sequential-18",
+          "tokenName": "--ids-color-dataviz-sequential-18",
           "tokenValue": "var(--ids-color-teal-80)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -11086,7 +11086,7 @@
             }
           ],
           "colorValue": "#2f8d8e",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-18)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-18)"
         }
       ],
       "type": "Component",
@@ -11097,11 +11097,11 @@
     {
       "id": "id-1725374355204-3655",
       "tokenName": "--ids-chart-color-accent-19",
-      "tokenValue": "var(--ids-dataviz-color-sequential-19)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-19)",
       "children": [
         {
           "id": "id-1725374355204-3652",
-          "tokenName": "--ids-dataviz-color-sequential-19",
+          "tokenName": "--ids-color-dataviz-sequential-19",
           "tokenValue": "var(--ids-color-neutral-60)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -11120,7 +11120,7 @@
             }
           ],
           "colorValue": "#6f6f76",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-19)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-19)"
         }
       ],
       "type": "Component",
@@ -11131,11 +11131,11 @@
     {
       "id": "id-1725374355204-3659",
       "tokenName": "--ids-chart-color-accent-20",
-      "tokenValue": "var(--ids-dataviz-color-sequential-20)",
+      "tokenValue": "var(--ids-color-dataviz-sequential-20)",
       "children": [
         {
           "id": "id-1725374355204-3656",
-          "tokenName": "--ids-dataviz-color-sequential-20",
+          "tokenName": "--ids-color-dataviz-sequential-20",
           "tokenValue": "var(--ids-color-red-40)",
           "type": "Semantic",
           "source": "semanticLightTokens",
@@ -11154,7 +11154,7 @@
             }
           ],
           "colorValue": "#e66467",
-          "tokenNameCSS": "var(--ids-dataviz-color-sequential-20)"
+          "tokenNameCSS": "var(--ids-color-dataviz-sequential-20)"
         }
       ],
       "type": "Component",

--- a/src/components/ids-axis-chart/ids-axis-chart.ts
+++ b/src/components/ids-axis-chart/ids-axis-chart.ts
@@ -937,7 +937,7 @@ export default class IdsAxisChart extends Base implements ChartSelectionHandler 
         const transform = this.rotateNameLabels !== 0
           ? ` transform="rotate(${this.rotateNameLabels}, ${left}, ${top})"` : '';
         const value = this.#formatXLabel((this.data as any)[0]?.data[index]?.name);
-        labelHtml += `<text x="${left}" y="${top}" aria-hidden="true"${transform}>${value}</text>`;
+        labelHtml += `<text x="${left}" y="${top}"${transform}>${value}</text>`;
         top += gap;
       }
     } else {
@@ -951,10 +951,10 @@ export default class IdsAxisChart extends Base implements ChartSelectionHandler 
         if (this.alignXLabels === 'middle') {
           const x = left + (this.sectionWidths[index].width / 2);
           transform = this.rotateNameLabels !== 0 ? ` transform="rotate(${this.rotateNameLabels}, ${x}, ${top})" transform-origin="8px 8px"` : '';
-          labelHtml += `<text x="${x}" y="${top}" alignment-baseline="middle" text-anchor="middle" aria-hidden="true"${transform}>${value}</text>`;
+          labelHtml += `<text x="${x}" y="${top}" alignment-baseline="middle" text-anchor="middle"${transform}>${value}</text>`;
         } else {
           transform = this.rotateNameLabels !== 0 ? ` transform="rotate(${this.rotateNameLabels}, ${left}, ${top})" text-anchor="end"` : '';
-          labelHtml += `<text x="${left}" y="${top}" aria-hidden="true"${transform}>${value}</text>`;
+          labelHtml += `<text x="${left}" y="${top}"${transform}>${value}</text>`;
         }
         left += this.alignXLabels === 'middle' ? this.sectionWidths[index].width : gap;
       }
@@ -978,7 +978,7 @@ export default class IdsAxisChart extends Base implements ChartSelectionHandler 
       if (this.axisLabelTop) top += this.axisLabelMargin;
 
       this.markerData.scaleValues?.slice().forEach((value: any) => {
-        lineHtml += `<text x="${left}" y="${top}" aria-hidden="true">${this.formatYLabel(value)}</text>`;
+        lineHtml += `<text x="${left}" y="${top}">${this.formatYLabel(value)}</text>`;
         left += this.#valuesLineGap();
       });
     } else {
@@ -988,7 +988,7 @@ export default class IdsAxisChart extends Base implements ChartSelectionHandler 
       top = this.margins.top + textSize;
 
       this.markerData.scaleValues?.slice().reverse().forEach((value: any) => {
-        lineHtml += `<text x="${left}" y="${top}" aria-hidden="true">${this.formatYLabel(value)}</text>`;
+        lineHtml += `<text x="${left}" y="${top}">${this.formatYLabel(value)}</text>`;
         top += this.#valuesLineGap();
       });
     }

--- a/src/components/ids-bar-chart/ids-bar-chart.ts
+++ b/src/components/ids-bar-chart/ids-bar-chart.ts
@@ -344,7 +344,7 @@ export default class IdsBarChart extends IdsAxisChart {
 
         barHTML += `<g role="listitem">
           <text class="audible" x="${left}" y="${this.markerData.gridBottom}">${label} ${point.value}</text>
-          <rect class="bar color-${groupIndex + 1}" aria-hidden="true" group-index="${groupIndex}" index="${index}" width="${barWidth}" height="${height}" x="${left}" y="${top}"${pattern}>
+          <rect class="bar color-${groupIndex + 1}" group-index="${groupIndex}" index="${index}" width="${barWidth}" height="${height}" x="${left}" y="${top}"${pattern}>
             <animate attributeName="height" from="0" to="${height}" ${this.animated ? this.cubicBezier : this.cubicBezier.replace('0.8s', '0.01s')}></animate>
             <animate attributeName="y" from="${bottom}" to="${top}" ${this.animated ? this.cubicBezier : this.cubicBezier.replace('0.8s', '0.01s')}></animate>
           </rect></g>`;
@@ -401,7 +401,7 @@ export default class IdsBarChart extends IdsAxisChart {
 
         barHTML += `<g role="listitem">
           <text class="audible" x="${x}" y="${this.markerData.gridBottom}">${label} ${point.value}</text>
-          <rect class="bar color-${groupIndex + 1}" aria-hidden="true" group-index="${groupIndex}" index="${index}" width="${width}" height="${barHeight}" x="${x}" y="${top}"${pattern}>
+          <rect class="bar color-${groupIndex + 1}" group-index="${groupIndex}" index="${index}" width="${width}" height="${barHeight}" x="${x}" y="${top}"${pattern}>
             <animate attributeName="x" from="${startEdge}" to="${x}" ${this.animated ? this.cubicBezier : this.cubicBezier.replace('0.8s', '0.01s')}></animate>
             <animate attributeName="width" from="0" to="${width}" ${this.animated ? this.cubicBezier : this.cubicBezier.replace('0.8s', '0.01s')}></animate>
           </rect></g>`;

--- a/src/themes/default/ids-theme-default-core.scss
+++ b/src/themes/default/ids-theme-default-core.scss
@@ -473,26 +473,26 @@
   --ids-chart-legend-color-text: var(--ids-color-text-label);
 
   // Charts - Color Progression
-  --ids-chart-color-accent-01: var(--ids-dataviz-color-sequential-01);
-  --ids-chart-color-accent-02: var(--ids-dataviz-color-sequential-02);
-  --ids-chart-color-accent-03: var(--ids-dataviz-color-sequential-03);
-  --ids-chart-color-accent-04: var(--ids-dataviz-color-sequential-04);
-  --ids-chart-color-accent-05: var(--ids-dataviz-color-sequential-05);
-  --ids-chart-color-accent-06: var(--ids-dataviz-color-sequential-06);
-  --ids-chart-color-accent-07: var(--ids-dataviz-color-sequential-07);
-  --ids-chart-color-accent-08: var(--ids-dataviz-color-sequential-08);
-  --ids-chart-color-accent-09: var(--ids-dataviz-color-sequential-09);
-  --ids-chart-color-accent-10: var(--ids-dataviz-color-sequential-10);
-  --ids-chart-color-accent-11: var(--ids-dataviz-color-sequential-11);
-  --ids-chart-color-accent-12: var(--ids-dataviz-color-sequential-12);
-  --ids-chart-color-accent-13: var(--ids-dataviz-color-sequential-13);
-  --ids-chart-color-accent-14: var(--ids-dataviz-color-sequential-14);
-  --ids-chart-color-accent-15: var(--ids-dataviz-color-sequential-15);
-  --ids-chart-color-accent-16: var(--ids-dataviz-color-sequential-16);
-  --ids-chart-color-accent-17: var(--ids-dataviz-color-sequential-17);
-  --ids-chart-color-accent-18: var(--ids-dataviz-color-sequential-18);
-  --ids-chart-color-accent-19: var(--ids-dataviz-color-sequential-19);
-  --ids-chart-color-accent-20: var(--ids-dataviz-color-sequential-20);
+  --ids-chart-color-accent-01: var(--ids-color-dataviz-sequential-01);
+  --ids-chart-color-accent-02: var(--ids-color-dataviz-sequential-02);
+  --ids-chart-color-accent-03: var(--ids-color-dataviz-sequential-03);
+  --ids-chart-color-accent-04: var(--ids-color-dataviz-sequential-04);
+  --ids-chart-color-accent-05: var(--ids-color-dataviz-sequential-05);
+  --ids-chart-color-accent-06: var(--ids-color-dataviz-sequential-06);
+  --ids-chart-color-accent-07: var(--ids-color-dataviz-sequential-07);
+  --ids-chart-color-accent-08: var(--ids-color-dataviz-sequential-08);
+  --ids-chart-color-accent-09: var(--ids-color-dataviz-sequential-09);
+  --ids-chart-color-accent-10: var(--ids-color-dataviz-sequential-10);
+  --ids-chart-color-accent-11: var(--ids-color-dataviz-sequential-11);
+  --ids-chart-color-accent-12: var(--ids-color-dataviz-sequential-12);
+  --ids-chart-color-accent-13: var(--ids-color-dataviz-sequential-13);
+  --ids-chart-color-accent-14: var(--ids-color-dataviz-sequential-14);
+  --ids-chart-color-accent-15: var(--ids-color-dataviz-sequential-15);
+  --ids-chart-color-accent-16: var(--ids-color-dataviz-sequential-16);
+  --ids-chart-color-accent-17: var(--ids-color-dataviz-sequential-17);
+  --ids-chart-color-accent-18: var(--ids-color-dataviz-sequential-18);
+  --ids-chart-color-accent-19: var(--ids-color-dataviz-sequential-19);
+  --ids-chart-color-accent-20: var(--ids-color-dataviz-sequential-20);
 
   // Checkbox
   --ids-checkbox-color-border-default: var(--ids-color-border-default);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

Adds a new ids-foundation package with one renamed set of tokens.

**Related github/jira issue (required)**:
Closes https://inforwiki.atlassian.net/browse/IDS-4575
Closes https://inforwiki.atlassian.net/browse/IDS-4461

**Steps necessary to review your pull request (required)**:
- test http://localhost:4300/ids-bar-chart/grouped.html -> should look the same and still show the colors
- test http://localhost:4300/ids-area-chart/example.html -> should look the same and still show the colors
- test http://localhost:4300/ids-line-chart/example.html -> should look the same and still show the colors
- NOTE: New tokens added here https://github.com/infor-design/ids-foundation/tree/main/tokens/dtcg will later use this in future updates for now its extra data
- go to http://localhost:4300/ids-personalize/token-table.html and search for datavis in the "Token Value" and should say color-datavis now not datavis-color

**Included in this Pull Request**:
- [x] Some documentation for the feature.
- [x] A note to the change log.
