### PR TITLE
2686 - ids-dropdown listbox fix display of 0-value

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Fix Clear Row / Eraser button so that changes persist throughout pagination. ([#2615](https://github.com/infor-design/enterprise-wc/issues/2615))
 - `[Dropdown|ListBox]` Fix `ids-dropdown` so that it doesn't lose track of it's value when `ids-list-box-option` is dynamically set in Angular. ([#2612](https://github.com/infor-design/enterprise-wc/issues/2612))
 - `[Dropdown]` Fixed IdsDropdown default value.  There was a bug where the value property was not working properly with dynamic data. ([#2727](https://github.com/infor-design/enterprise-wc/issues/2727))
+- `[Dropdown]` Fixed a bug where 0-indexed values were not being properly displayed in `ids-dropdown`. ([#2686](https://github.com/infor-design/enterprise-wc/issues/2686))
 - `[Datagrid]` Fix Clear Row / Eraser button so that changes persist throughout pagination. ([#2615]https://github.com/infor-design/enterprise-wc/issues/2615)
 - `[Datagrid]` Added async/await to beforecelledit. ([#2726]https://github.com/infor-design/enterprise-wc/issues/2726)
 - `[NotificationBanner]` Added a notification service which can be used to manage notification banners on a page. ([#2160]https://github.com/infor-design/enterprise-wc/issues/2160)

--- a/src/components/ids-dropdown/ids-dropdown.ts
+++ b/src/components/ids-dropdown/ids-dropdown.ts
@@ -323,7 +323,7 @@ export default class IdsDropdown extends Base {
    * @param {string} value The value/id to use
    */
   set value(value: string | null) {
-    value = (Array.isArray(value) ? value[0] : value) || '';
+    value = (Array.isArray(value) ? value[0] : value) || String(value ?? '');
     const labels = this.labels;
     const label = String(value);
     if (labels.includes(label)) {

--- a/src/components/ids-multiselect/ids-multiselect.ts
+++ b/src/components/ids-multiselect/ids-multiselect.ts
@@ -171,6 +171,7 @@ class IdsMultiselect extends IdsDropdown {
    */
   set value(value: any) {
     let matched = true;
+    value = !Array.isArray(value) ? [String(value)] : value;
     if (!Array.isArray(value) || value.length > this.max) {
       return;
     }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed a bug where 0-indexed values were not being properly displayed in `ids-dropdown`.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes #2686 
Related examples: https://github.com/infor-design/enterprise-wc-examples/pull/98

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out this branch and run: `nvm i && nvm use && npm i && npm run start`
2. Ensure no regressions here: http://localhost:4300/ids-dropdown/example.html
3. Ensure no regressions here: http://localhost:4300/ids-multiselect/example.html
4. In another terminal window, and run `npm run publish:link`
5. Then check out this branch in `enterprise-wc-examples`: https://github.com/infor-design/enterprise-wc-examples/pull/90
6. Then run: `npm i && npm link ids-enterprise-wc`
7. Then run: `rm -fr .angular/cache && nvm i && nvm use && npm run build && npm run start`
8. Then see `IDS Dropdown 0-indexed` examples here: http://localhost:4200/ids-reactive-forms/example
9. Keep clicking the `Update Values` button and ensure new dropdown cycles through each option without ever skipping the first 0-indexed value.
10. Also ensure the `IDS Multiselect` field  cycles through each option properly.


**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure checks on the PR -->
