### PR TITLE
2494 - Fix legend URL behavior when selectable attribute is true

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### 1.5.0 Fixes
 
+- `[BarChart]` Fixed legend URL behavior when selectable attribute is true. ([#2494](https://github.com/infor-design/enterprise-wc/issues/2494))
 - `[Breadcrumb]` Fixed bug where the current item could be clicked. ([#/2780](https://github.com/infor-design/enterprise/issues//2780))
 - `[ColorPicker]` Fixed bug where custom colors were being overridden. ([#8964](https://github.com/infor-design/enterprise/issues/8964))
 - `[Datagrid]` Fixed bug where datagrid mutates original data passed in by user. ([#2724](https://github.com/infor-design/enterprise-wc/issues/2724))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `[ExpandableArea]` Fix `toggle-btn` type in `ids-expandable-area` for Angular. ([#2730](https://github.com/infor-design/enterprise/issues/2730))
 
+### 1.5.0 Fixes
+
+- `[BarChart]` Fixed legend URL behavior when selectable attribute is true. ([#2494](https://github.com/infor-design/enterprise-wc/issues/2494))
+
 ## 1.5.0
 
 ### 1.5.0 Important Changes
@@ -34,7 +38,6 @@
 
 ### 1.5.0 Fixes
 
-- `[BarChart]` Fixed legend URL behavior when selectable attribute is true. ([#2494](https://github.com/infor-design/enterprise-wc/issues/2494))
 - `[Breadcrumb]` Fixed bug where the current item could be clicked. ([#/2780](https://github.com/infor-design/enterprise/issues//2780))
 - `[ColorPicker]` Fixed bug where custom colors were being overridden. ([#8964](https://github.com/infor-design/enterprise/issues/8964))
 - `[Datagrid]` Fixed bug where datagrid mutates original data passed in by user. ([#2724](https://github.com/infor-design/enterprise-wc/issues/2724))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### 1.5.0 Fixes
 
+- `[BarChart]` Fixed legend URL behavior when selectable attribute is true. ([#2494](https://github.com/infor-design/enterprise-wc/issues/2494))
 - `[Breadcrumb]` Fixed bug where the current item could be clicked. ([#/2780](https://github.com/infor-design/enterprise/issues//2780))
 - `[ColorPicker]` Fixed bug where custom colors were being overridden. ([#8964](https://github.com/infor-design/enterprise/issues/8964))
 - `[Datagrid]` Fixed bug where datagrid mutates original data passed in by user. ([#2724](https://github.com/infor-design/enterprise-wc/issues/2724))

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise Web Components
 
+## 1.5.1
+
+### 1.5.1 Features
+
+- `[ExpandableArea]` Fix `toggle-btn` type in `ids-expandable-area` for Angular. ([#2730](https://github.com/infor-design/enterprise/issues/2730))
+
 ## 1.5.0
 
 ### 1.5.0 Important Changes

--- a/src/components/ids-expandable-area/ids-expandable-area.ts
+++ b/src/components/ids-expandable-area/ids-expandable-area.ts
@@ -49,6 +49,17 @@ export default class IdsExpandableArea extends Base {
 
   connectedCallback(): void {
     super.connectedCallback();
+
+    if (this.type === EXPANDABLE_AREA_TYPES[0]) {
+      // NOTE: For Angular, need to re-run what already happened in IdsExpandableArea#template();
+      // NOTE: since IdsElement.render() is ran in constructor, this.type was not ready in IdsExpandableArea.template()
+      const header = this.shadowRoot?.querySelector('.ids-expandable-area-header');
+      const footer = this.shadowRoot?.querySelector('.ids-expandable-area-footer');
+      header?.setAttribute('data-expander', 'header');
+      header?.setAttribute('aria-expanded', 'false');
+      footer?.remove();
+    }
+
     this.expander = this.shadowRoot?.querySelector('[data-expander]');
     this.expanderDefault = this.shadowRoot?.querySelector('[name="expander-default"]');
     this.expanderExpanded = this.shadowRoot?.querySelector('[name="expander-expanded"]');
@@ -220,10 +231,12 @@ export default class IdsExpandableArea extends Base {
    * @returns {void}
    */
   #attachEventHandlers(): void {
+    this.offEvent('click', this.expander);
     this.onEvent('click', this.expander, () => {
       this.setAttributes();
     });
 
+    this.offEvent('touchstart', this.expander);
     this.onEvent('touchstart', this.expander, (e: any) => {
       if (e.touches && e.touches.length > 0) {
         this.setAttributes();
@@ -232,6 +245,7 @@ export default class IdsExpandableArea extends Base {
       passive: true
     });
 
+    this.offEvent('transitionend', this.pane);
     this.onEvent('transitionend', this.pane, () => {
       const eventOpts = {
         detail: { elem: this }
@@ -271,6 +285,7 @@ export default class IdsExpandableArea extends Base {
       </div>
     `;
 
+    // NOTE: Because IdsElement.render() is ran in constructor, this.type is not ready at this point for Angular
     if (this.type === EXPANDABLE_AREA_TYPES[0]) { // Toggle Button Type
       header = `
         <div class="ids-expandable-area-header" part="header" aria-expanded="false" data-expander="header">

--- a/src/themes/mixins/ids-chart-legend-mixin.scss
+++ b/src/themes/mixins/ids-chart-legend-mixin.scss
@@ -35,6 +35,7 @@
     margin-inline-end: 8px;
     height: 12px;
     width: 12px;
+    pointer-events: none; // prevent URL changes
 
     @for $i from 1 through 21 {
       &.color-#{$i} {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

_Problem_
While setting the `selectable` attribute in a bar (/any other) chart, the legend icon acts as a URL.

Setting up the chart `selectable` attribute to false (or adding  pointer-events : none for the anchor tag in DOM) prevents the chart legend from acting as a URL but does not retain the highlight effect on clicking each of the chart slices.

_Solution_
Added `pointer-events: none;` to `swatch` tag, so all clicks on the `swatch` element will be passed to a parent `chart-legend-item`  element.


**Related github/jira issue (required)**:

Closes #2494

**Steps necessary to review your pull request (required)**:

http://localhost:4300/ids-bar-chart/selectable.html

* Check out this branch and run: `nvm i && nvm use && npm i && npm run start`
* Open http://localhost:4300/ids-bar-chart/selectable.html
* Click to legend labels and label colored icons
* Make sure the URL doesn't change

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.


