### PR TITLE
2494 - Fixed legend URL behavior when selectable attribute is true

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `[ExpandableArea]` Fix `toggle-btn` type in `ids-expandable-area` for Angular. ([#2730](https://github.com/infor-design/enterprise/issues/2730))
 
+### 1.5.1 Fixes
+
+- `[BarChart]` Fixed legend URL behavior when selectable attribute is true. ([#2494](https://github.com/infor-design/enterprise-wc/issues/2494))
+
 ## 1.5.0
 
 ### 1.5.0 Important Changes

--- a/src/themes/mixins/ids-chart-legend-mixin.scss
+++ b/src/themes/mixins/ids-chart-legend-mixin.scss
@@ -35,6 +35,7 @@
     margin-inline-end: 8px;
     height: 12px;
     width: 12px;
+    pointer-events: none; // prevent URL changes
 
     @for $i from 1 through 21 {
       &.color-#{$i} {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**

_Problem_
While setting the `selectable` attribute in a bar (/any other) chart, the legend icon acts as a URL.

Setting up the chart `selectable` attribute to false (or adding  pointer-events : none for the anchor tag in DOM) prevents the chart legend from acting as a URL but does not retain the highlight effect on clicking each of the chart slices.

_Solution_
Added `pointer-events: none;` to `swatch` tag, so all clicks on the `swatch` element will be passed to a parent `chart-legend-item`  element.


**Related github/jira issue (required)**:

Closes #2494

**Steps necessary to review your pull request (required)**:

http://localhost:4300/ids-bar-chart/selectable.html

* Check out this branch and run: `nvm i && nvm use && npm i && npm run start`
* Open http://localhost:4300/ids-bar-chart/selectable.html
* Click to legend labels and label colored icons
* Make sure the URL doesn't change

**Included in this Pull Request**:
- [ ] Some documentation for the feature.
- [ ] A test for the bug or feature.
- [x] A note to the change log.


